### PR TITLE
Make the Linux CI lane green

### DIFF
--- a/.github/workflows/linux-smoke.yml
+++ b/.github/workflows/linux-smoke.yml
@@ -5,29 +5,28 @@
 # a fully provisioned machine, and it CANNOT be run here. Not "has not been
 # wired up yet" — cannot, and the reasons are structural:
 #
-#   - The desktop/iOS/Android/Web editor-export lane (six gates) runs a
-#     scons-built dn2cpp FORK of the Godot editor. gates/setup-godot-fork.sh has
-#     one arm per OS whose engine it can build — macOS and Windows — and no
-#     Linux arm; gates/_godot_fork.sh says so in the skip's own text: "running
-#     that script will NOT close this skip".
-#   - The three CRI ADX LE gates need the proprietary CriWare.CriAtomLE NuGet
-#     package and the adjacent private cri_adx_le_for_csharp sample repository.
-#     No script in this repository fetches them, and none can: the licence is
-#     the obstacle, not the automation.
-#   - The four godot-dotnet gates need a MONO editor + glue at a pinned commit,
+#   - The desktop/iOS/Android/Web editor-export lane runs a scons-built dn2cpp
+#     FORK of the Godot editor. gates/setup-godot-fork.sh has one arm per OS
+#     whose engine it can build — macOS and Windows — and no Linux arm;
+#     gates/_godot_fork.sh says so in the skip's own text: "running that script
+#     will NOT close this skip".
+#   - The CRI ADX LE gates need the proprietary CriWare.CriAtomLE NuGet package
+#     and the adjacent private cri_adx_le_for_csharp sample repository. No
+#     script in this repository fetches them, and none can: the licence is the
+#     obstacle, not the automation.
+#   - The godot-dotnet gates need a MONO editor + glue at a pinned commit,
 #     produced either by a macOS scons build or by a hand-supplied prebuilt.
 #   - The iOS gates need Xcode, a simulator, and an export template repaired by
 #     a local scons build (godot#118161).
 #
 # DN2CPP_REQUIRE_ALL=1 turns every one of those skips into a failure — which is
 # the whole point of the mode — so a hosted runner can never be green under it.
-# The last Linux measurement (2026-07-15) was 133/145 gates with twelve skips,
-# every one of them cross-toolchain. Running REQUIRE_ALL here
-# would produce a permanently red check that says nothing about the code, and
-# NOT running it while calling this file "CI" would be worse: it would let a
-# green badge stand in for a gate nobody ran. So this workflow does neither. It
-# runs the part of the suite a hosted runner can honestly run, and says in its
-# name, here, and in AGENTS.md that passing it is not permission to merge.
+# Running REQUIRE_ALL here would produce a permanently red check that says
+# nothing about the code, and NOT running it while calling this file "CI" would
+# be worse: it would let a green badge stand in for a gate nobody ran. So this
+# workflow does neither. It runs the part of the suite a hosted runner can
+# honestly run, and says in its name, here, and in AGENTS.md that passing it is
+# not permission to merge.
 #
 # What it does buy, which nothing else in the repository does: it is the only
 # automatic check that the tree still builds and transpiles on LINUX. Every
@@ -49,6 +48,11 @@ env:
   DOTNET_NOLOGO: "1"
   DOTNET_CLI_TELEMETRY_OPTOUT: "1"
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "1"
+  # cmake resolves /usr/bin/c++ — g++ — unless told otherwise, so the clang the
+  # steps below install goes unused and this lane measures a compiler nothing
+  # else here builds with. Tier-1 is clang; keep the axis this buys to the OS.
+  CC: clang
+  CXX: clang++
   # The engine is a manual prerequisite everywhere else (nothing in gates/
   # downloads it). Here it is pinned to the same version gates/_common.sh
   # verifies, and fetched from the public godot-builds release.
@@ -123,7 +127,7 @@ jobs:
       - name: Dump extension_api.json
         run: godot --headless --dump-extension-api
 
-      # Normal mode on purpose. DN2CPP_REQUIRE_ALL=1 would fail on the twelve
+      # Normal mode on purpose. DN2CPP_REQUIRE_ALL=1 would fail on the
       # cross-toolchain gates this runner cannot satisfy — see the header.
       - name: Run the non-Godot suite
         run: SKIP_GODOT=1 ./gates/run-all-gates.sh

--- a/gates/build-and-run-http2-unary.sh
+++ b/gates/build-and-run-http2-unary.sh
@@ -209,10 +209,10 @@ grep -qF '[contentread] body-lagged-headers=False' "$out/native.out" || {
 # PooledConnectionIdleTimeout — the failure mode being an intercept that drops the
 # handler instance — reuses the connection in BOTH lines.
 grep -qF '[pool] default-reuse=True' "$out/native.out" || {
-    echo "FAIL: a default-configured handler did not reuse a 2 s-idle connection" >&2
+    echo "FAIL: a default-configured handler did not reuse a 5 s-idle connection" >&2
     cat "$out/native.out" >&2; exit 1; }
 grep -qF '[pool] expiring-reuse=False' "$out/native.out" || {
-    echo "FAIL: PooledConnectionIdleTimeout=1s did not stop the reuse of a 2 s-idle connection" >&2
+    echo "FAIL: PooledConnectionIdleTimeout=1s did not stop the reuse of a 5 s-idle connection" >&2
     cat "$out/native.out" >&2; exit 1; }
 # Both halves observed at the SERVER. Four concurrent h2 requests rode ONE
 # connection — multiplexing, impossible while every call has its own multi — and

--- a/gates/build-and-run-pinvoke-native.sh
+++ b/gates/build-and-run-pinvoke-native.sh
@@ -18,14 +18,17 @@
 # fast path where real .NET raises TypeLoadException (measured).
 #
 # Also the system-libc section (PInvokeLibcSubset, folded in from its own gate):
-# [DllImport] into always-linked libc/libSystem with blittable primitives /
-# pointers only. Each pinvokeimpl method lowers to a direct native call into an
-# extern "C" entry point declared once by the emitter (aliased via an asm label so
-# it never collides with the libc prototype the runtime header already includes).
-# Covers int/long integer returns (abs/llabs), double ABI (sqrt/pow/floor/ceil),
-# implicit vs explicit EntryPoint, a pointer argument with a pointer-sized return
-# (strlen), and a void* (pointer) return aliasing its destination (memset) plus a
-# pointer == pointer compare. That section used to assert a hard-coded expected
+# [DllImport] into always-linked libc/libSystem with blittable primitives,
+# pointers and an ASCII string. Each pinvokeimpl method lowers to a direct native
+# call into an extern "C" entry point declared once by the emitter (aliased via an
+# asm label so it never collides with the libc prototype the runtime header already
+# includes).
+# Covers int/long integer returns (abs/llabs), a double return (atof/strtod — NOT
+# sqrt/pow/floor/ceil, which glibc keeps in libm, not libc.so.6; the double ARGUMENT
+# crossing is PInvokeCustomLibSubset's), implicit vs explicit EntryPoint, a
+# pointer argument with a pointer-sized return (strlen), a byref out-param pointer
+# (strtod's end), and a void* (pointer) return aliasing its destination (memset) plus
+# a pointer == pointer compare. That section used to assert a hard-coded expected
 # string; folded here it is exact-diffed against real .NET instead. Its own
 # DllImportResolver redirects `libc` onto ucrtbase.dll on Windows, where the
 # platform C library carries those symbols under a name no default probe reaches —

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -368,8 +368,17 @@ endfunction()
 # they always have — they are not ours to fix.
 function(_dn2cpp_stack_frame_limit target)
     if(DN2CPP_MAX_STACK_FRAME AND NOT MSVC)
+        # GCC's option name keeps its trailing '=', clang takes the group name
+        # without one. Spelling it clang's way on GCC does not merely lose the
+        # ceiling: cc1plus rejects the -Werror= itself and every TU fails. A clang
+        # host never sees it, so the whole Linux lane is what breaks.
+        if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+            set(_werror_frame "-Werror=frame-larger-than=")
+        else()
+            set(_werror_frame "-Werror=frame-larger-than")
+        endif()
         target_compile_options(${target} PRIVATE
-            "-Wframe-larger-than=${DN2CPP_MAX_STACK_FRAME}" -Werror=frame-larger-than)
+            "-Wframe-larger-than=${DN2CPP_MAX_STACK_FRAME}" "${_werror_frame}")
     endif()
 endfunction()
 

--- a/runtime/core/platform/posix/dn2cpp_system_native.cpp
+++ b/runtime/core/platform/posix/dn2cpp_system_native.cpp
@@ -17,6 +17,7 @@
 //   - Error: PAL codes 0x1XXXX (E2BIG=0x10001, …); unknown → ENONSTANDARD
 //   - Passwd: sequential {ptr,ptr,u32,u32,ptr,ptr,ptr} (48 bytes on LP64)
 //   - Signals: PAL-stable values (SIGKILL=9, SIGSTOP=19) converted to host here
+//   - SysConfName: PAL values (_SC_CLK_TCK=1, _SC_PAGESIZE=2) likewise converted
 //   - AccessMode: PAL values (F_OK=0, X_OK=1, W_OK=2, R_OK=4) equal the host's
 //     on every platform built here — asserted at the site, passed through raw
 // Only the members a reachable closure needs are implemented; a new gap shows
@@ -42,6 +43,7 @@
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <sys/types.h>
+#include <sys/utsname.h>
 #include <unistd.h>
 
 #if defined(__APPLE__)
@@ -51,6 +53,7 @@
 #include <sys/attr.h>
 #include <sys/mount.h>
 #include <sys/param.h>
+#include <sys/sysctl.h> // KERN_BOOTTIME — Darwin has no CLOCK_BOOTTIME
 
 // The autorelease-pool ABI clang emits for @autoreleasepool. Stable exported
 // libobjc surface since 10.7, but not declared in the public objc/ headers, so
@@ -1528,6 +1531,92 @@ int32_t SystemNative_GetPwUidR(uint32_t uid, Dn2CppPalPasswd* pwd, char* buf, in
     {
     }
     return dn2cpp_pal_convert_passwd(error, &nativePwd, result, pwd);
+}
+
+// ================ sysconf / boot time / OS release =========================
+// pal_io.c SystemNative_SysConf, pal_time.c SystemNative_GetBootTimeTicks and
+// pal_runtimeinformation.c SystemNative_GetUnixRelease (tag v10.0.9), same style
+// as the sections above.
+//
+// All three are reached only by a transpile of the LINUX flavor of the BCL:
+// Process.TicksToTimeSpan and Process.BootTime are Process.Linux.cs, and
+// Environment.OSVersion reads GetUnixRelease in Environment.OSVersion.Unix.cs
+// where the OSX flavor answers from libproc instead. So the reach path that
+// names them is the one macOS never takes, and their regression mode on this
+// host is a link error on a Linux CI run — this file's standard loud outcome.
+
+// Managed Interop.Sys.SysConfName (Interop.SysConf.cs, mirrored by pal_io.h) —
+// PAL-stable values that are NOT the host's _SC_* numbers: those are 2 and 30 on
+// glibc, 3 and 29 on Darwin. Passing the managed value through would read some
+// other limit and answer plausibly, not fail.
+#define DN2CPP_PAL_SC_CLK_TCK 1
+#define DN2CPP_PAL_SC_PAGESIZE 2
+
+// pal_io.h SystemNative_SysConf: the limit on success, -1 with errno otherwise.
+// An unmodeled name is EINVAL rather than a pass-through, mirroring the PAL's
+// `default:` arm. Reach path: Process.TicksToTimeSpan converting /proc jiffies,
+// which throws Win32Exception on a non-positive answer.
+int64_t SystemNative_SysConf(int32_t name)
+{
+    switch (name)
+    {
+        case DN2CPP_PAL_SC_CLK_TCK: return (int64_t)::sysconf(_SC_CLK_TCK);
+        case DN2CPP_PAL_SC_PAGESIZE: return (int64_t)::sysconf(_SC_PAGESIZE);
+        default:
+            errno = EINVAL;
+            return -1;
+    }
+}
+
+// pal_time.h SystemNative_GetBootTimeTicks: the boot INSTANT as .NET ticks
+// (100 ns units since 0001-01-01 UTC) — not a duration and not a Unix timestamp,
+// because Process.BootTime feeds it straight to `new DateTime(ticks)`. The
+// declaration is SetLastError=false, so a failure has no channel but the value;
+// -1 (what the real PAL returns on a platform without the clock) surfaces there
+// as an ArgumentOutOfRangeException instead of a wrong StartTime.
+int64_t SystemNative_GetBootTimeTicks(void)
+{
+    const int64_t unixEpochTicks = 621355968000000000LL;
+#if defined(__APPLE__)
+    // KERN_BOOTTIME is already the boot instant in wall-clock terms, so unlike
+    // the Linux arm there is nothing to subtract.
+    int mib[2] = { CTL_KERN, KERN_BOOTTIME };
+    struct timeval boot;
+    size_t len = sizeof(boot);
+    if (::sysctl(mib, 2, &boot, &len, nullptr, 0) != 0 || len != sizeof(boot))
+        return -1;
+    return unixEpochTicks + (int64_t)boot.tv_sec * 10000000 + (int64_t)boot.tv_usec * 10;
+#else
+    // now-since-boot subtracted from now-since-epoch. CLOCK_BOOTTIME rather than
+    // CLOCK_MONOTONIC because the elapsed side must include time spent suspended,
+    // or a laptop's boot time drifts later every resume.
+    struct timespec ts;
+    if (::clock_gettime(CLOCK_BOOTTIME, &ts) != 0)
+        return -1;
+    int64_t sinceBootTicks = (int64_t)ts.tv_sec * 10000000 + (int64_t)(ts.tv_nsec / 100);
+    if (::clock_gettime(CLOCK_REALTIME_COARSE, &ts) != 0)
+        return -1;
+    int64_t sinceEpochTicks = (int64_t)ts.tv_sec * 10000000 + (int64_t)(ts.tv_nsec / 100);
+    return unixEpochTicks + sinceEpochTicks - sinceBootTicks;
+#endif
+}
+
+// pal_runtimeinformation.h SystemNative_GetUnixRelease: uname(2)'s `release`
+// field, or null on failure. Ownership passes to the caller — the managed
+// declaration marshals it with Utf8StringMarshaller, whose Free reaches
+// NativeMemory.Free, the same convention SystemNative_SearchPath above
+// documents. So the allocation must be malloc-compatible: handing back
+// utsname's own storage would have the caller free a stack address.
+//
+// The PAL's TARGET_ANDROID arm (which answers the Android API level instead) is
+// deliberately absent: dn2cpp transpiles a DESKTOP-flavor CoreLib on that target
+// too, and GetOperatingSystem parses what it is given as a kernel release.
+char* SystemNative_GetUnixRelease(void)
+{
+    struct utsname name;
+    if (::uname(&name) == -1)
+        return nullptr;
+    return ::strdup(name.release);
 }
 
 // ===================== low-level monitor ===================================

--- a/runtime/godot/dn2cpp_godot.cpp
+++ b/runtime/godot/dn2cpp_godot.cpp
@@ -7,6 +7,7 @@
 
 #include <vector>
 #include <array>
+#include <string>
 #include <atomic>
 #include <mutex>
 

--- a/samples/dotnet/Http2Unary/Program.cs
+++ b/samples/dotnet/Http2Unary/Program.cs
@@ -242,10 +242,18 @@ namespace Http2Unary
             return bodyMs - headersMs > 750;
         }
 
+        private const int PoolIdleTimeoutSeconds = 1;
+
+        // The idle gap both arms wait out. Real .NET evicts an over-idle connection only on
+        // the pool manager's scavenge tick (period max(idle timeout / 4, 1 s)), so the gap
+        // must clear the timeout PLUS one tick — 2 s here — by a margin of further ticks: at
+        // 2 s exactly the oracle's verdict is that timer's phase, i.e. a coin flip.
+        private const int PoolIdleGapMs = 5000;
+
         // (h) CONNECTION-POOL SETTINGS. The observable that a lifetime knob really reached
         // the transport is the SERVER's own connection id: a handler that will not reuse a
-        // connection idle for more than a second must open a new one across a two-second
-        // gap, and a default-configured one (a minute) must not. Two separate HttpClients
+        // connection idle for more than a second must open a new one across the gap above,
+        // and a default-configured one (a minute) must not. Two separate HttpClients
         // rather than one reconfigured handler, because a SocketsHttpHandler refuses these
         // setters after its first request. The structural knobs (MaxConnectionsPerServer,
         // EnableMultipleHttp2Connections) have their own sections, (j) and (k).
@@ -256,7 +264,7 @@ namespace Http2Unary
 
             var expiring = new SocketsHttpHandler
             {
-                PooledConnectionIdleTimeout = TimeSpan.FromSeconds(1),
+                PooledConnectionIdleTimeout = TimeSpan.FromSeconds(PoolIdleTimeoutSeconds),
             };
             using (var client = new HttpClient(expiring))
                 Console.WriteLine("[pool] expiring-reuse=" + SameConnAcrossIdle(client, h2cBase));
@@ -265,7 +273,7 @@ namespace Http2Unary
         private static bool SameConnAcrossIdle(HttpClient client, string h2cBase)
         {
             string first = GetText(client, h2cBase + "/connid");
-            Thread.Sleep(2000);
+            Thread.Sleep(PoolIdleGapMs);
             string second = GetText(client, h2cBase + "/connid");
             return first.Length > 0 && first == second;
         }

--- a/samples/dotnet/PInvokeNative/PInvokeLibcSubset.cs
+++ b/samples/dotnet/PInvokeNative/PInvokeLibcSubset.cs
@@ -4,8 +4,8 @@ using System.Runtime.InteropServices;
 
 namespace PInvokeLibcSubset;
 
-// Blittable primitives and pointers into the always-linked libc, so no link flag is
-// emitted — unlike every other section in this bucket.
+// Blittable primitives, pointers and an ASCII string into the always-linked libc, so no
+// link flag is emitted — unlike every other section in this bucket.
 internal static unsafe class Program
 {
     // Implicit entry point: the method name is the symbol.
@@ -16,17 +16,17 @@ internal static unsafe class Program
     [DllImport("libc", EntryPoint = "llabs")]
     private static extern long LongAbs(long n);
 
+    // The double return rides libc's own converters, NOT sqrt/pow/floor/ceil: glibc keeps the
+    // math symbols in libm, so a "libc" import of one is an EntryPointNotFoundException on
+    // Linux — macOS's libSystem and the UCRT fold math in and hide that. The double ARGUMENT
+    // crossing is PInvokeCustomLibSubset's (dn2cpptest_scale).
     [DllImport("libc")]
-    private static extern double sqrt(double x);
+    private static extern double atof(string s);
 
-    [DllImport("libc")]
-    private static extern double pow(double b, double e);
-
-    [DllImport("libc")]
-    private static extern double floor(double x);
-
-    [DllImport("libc")]
-    private static extern double ceil(double x);
+    // Explicit EntryPoint over the same double return, plus the end pointer strtod writes
+    // back through a byref out-param.
+    [DllImport("libc", EntryPoint = "strtod")]
+    private static extern double StrToD(byte* s, out IntPtr end);
 
     // A native-pointer-sized return.
     [DllImport("libc", EntryPoint = "strlen")]
@@ -52,10 +52,16 @@ internal static unsafe class Program
 
         Console.WriteLine(abs(-7));               // 7
         Console.WriteLine(LongAbs(-1234567890123L)); // 1234567890123
-        Console.WriteLine(sqrt(2.0));             // 1.4142135623730951
-        Console.WriteLine(pow(2.0, 10.0));        // 1024
-        Console.WriteLine(floor(3.7));            // 3
-        Console.WriteLine(ceil(3.2));             // 4
+        Console.WriteLine(atof("14142135623730951e-16")); // 1.4142135623730951
+
+        // "5e-1x": strtod stops at the 'x' and reports where through its end pointer. Both
+        // parsed spellings carry an exponent and no decimal point on purpose — the radix
+        // character is LC_NUMERIC's, and the diff spans two processes.
+        byte* num = stackalloc byte[6];
+        num[0] = 53; num[1] = 101; num[2] = 45; num[3] = 49; num[4] = 120; num[5] = 0;
+        IntPtr end;
+        Console.WriteLine(StrToD(num, out end));  // 0.5
+        Console.WriteLine((int)((byte*)end - num)); // 4
 
         // "Hello\0" in a stack buffer.
         byte* s = stackalloc byte[6];


### PR DESCRIPTION
The linux-smoke lane had never been green — every run died in the runtime build. Four commits, each closing one defect the Tier-1 macOS host structurally cannot see:

- **`ci: make the Linux lane build`** — GCC spells `-Werror=frame-larger-than` with a trailing `=` where clang's group name has none, so cc1plus rejected the `-Werror` itself and every runtime TU failed. cmake also resolved `/usr/bin/c++` (g++) while the workflow installed clang and never named it; `CC`/`CXX` now pin the lane to clang so it measures the OS, not a second compiler. And `dn2cpp_godot.cpp` used `std::string` with no `<string>` — libc++ brings it in transitively, libstdc++ does not. The header's dated gate measurement is dropped rather than updated.
- **`pal: the SystemNative entries a Linux CoreLib reaches`** — a transpile of the Linux-flavor CoreLib names `SystemNative_SysConf`, `SystemNative_GetBootTimeTicks` and `SystemNative_GetUnixRelease`, which this runtime never had; a macOS transpile never asks for them. SysConf converts the managed SysConfName rather than passing it through (the PAL's 1/2 are glibc's 2/30 and Darwin's 3/29 — a pass-through reads some other limit and answers plausibly). Checked against dotnet/runtime v10.0.9.
- **`gates: import a double from libc, not from libm`** — glibc keeps `sqrt`/`pow`/`floor`/`ceil` in libm, so a `"libc"` import of one is an `EntryPointNotFoundException` on Linux; macOS's libSystem and the UCRT fold math in and hide that. The double-return coverage now rides `atof`/`strtod` (in libc on all three), and strtod's end pointer adds a byref out-param the section did not cover.
- **`gates: wait out the pool's scavenge tick`** — the idle-reuse arm slept exactly as long as real .NET's eviction upper bound (`PooledConnectionIdleTimeout` is read only on the scavenge tick, period `max(timeout/4, 1 s)`, strict `>`), so the ORACLE's verdict was that timer's phase: the gate passed and failed on the same commit.

Verified: linux-smoke green on this head (console + SKIP_GODOT suite, 98 ran / 5 cross-toolchain skips, 1601 s), and `./gates/pre-merge.sh` green locally — culture + Release + Debug, 122 gates each, every gate ran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LHbVGsuRfUwoFZ8hYwVAta