### PR TITLE
fix: ask the token, not WhenAny, on a canceled h2 read

### DIFF
--- a/internal/DnHttp/src/DnHttp/Http2StreamBackend.cs
+++ b/internal/DnHttp/src/DnHttp/Http2StreamBackend.cs
@@ -648,7 +648,12 @@ internal static class Http2StreamBackend
                 }
             }
             if (!await work.ConfigureAwait(false))
+            {
+                // Same ordering hazard as the read: the abort releases the worker, so the
+                // token is asked before the drain failure is reported as an ended call.
+                cancellationToken.ThrowIfCancellationRequested();
                 throw Ended();
+            }
         }
 
         public override void Flush()
@@ -752,7 +757,14 @@ internal static class Http2StreamBackend
                         throw new TaskCanceledException("The read was canceled.", null, cancellationToken);
                 }
             }
-            return Interpret(await work.ConfigureAwait(false));
+            int n = await work.ConfigureAwait(false);
+            // A fired token's abort and a transport failure both come back as n<0, and the
+            // abort can complete the read before the arm above observes the cancel — so the
+            // token, not that race, is what tells them apart: real HttpClient answers a
+            // fired token with an OperationCanceledException, never an IOException.
+            if (n < 0)
+                cancellationToken.ThrowIfCancellationRequested();
+            return Interpret(n);
         }
 
         public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)


### PR DESCRIPTION
## What broke

windows-smoke run [31254512065](https://github.com/takuma-komatsu/dn2cpp/actions/runs/31254512065) failed on one gate — `grpc-unary`, section 9 (mid-stream deadline):

```
FAIL: native output is missing the mid-stream deadline shape (one tick, then abort)
[sdeadline] got=1 status=Unavailable        # expected: got=1 status=DeadlineExceeded
```

`got=1` is right — the abort landed. Only the status is wrong. The same tree was green on the four PR runs before it, so this is timing, not a deterministic regression.

## Why

`Http2ResponseStream.ReadAsync`'s cancel registration calls `_call.Abort()` and only then sets the `TaskCompletionSource` the `WhenAny` arm watches. The abort is immediate: `dn2cpp_http2_call_abort` sets `aborted` and notifies, `dn2cpp_http2_call_read` wakes and answers `-1`. So the work task can complete before `WhenAny` observes the cancel, `Interpret(-1)` throws an `IOException`, and grpc-dotnet reads a transport-shaped exception as `Unavailable` rather than `DeadlineExceeded`.

The window is narrow — the cancel thread has one statement left to run, the read needs a worker rescheduled — which is why it only opened on a shared-vCPU Windows runner. `CancelAfter` spawning a dedicated `std::thread` per timer widens it further.

The server cannot produce this status: `Countdown` throws `Unavailable` only on the `FailAfterTwo && i == 2` arm, which is section 6's `[sfail]`. Section 9 passes `FailAfterTwo` false. And nothing intercepts grpc's deadline path, so the exception type is the only lever.

## The fix

Stop resting correctness on which task `WhenAny` observes first; ask the token when the read reports failure. This is the shape `SendAsync` already uses — its comment states the invariant: *a cancel and a transport failure arrive alike; the token is what tells them apart*.

Sound because `dn2cpp_cts_cancel` marks the source canceled **before** it walks the registration chain, so by the time an abort can complete a read the token is already decisive. `DrainAsync` carried the same hazard and its doc comment names the read as its twin, so both move together. `SendAsync` is unchanged.

## Verification

Full suite on Windows against real MSVC, `SKIP_GODOT=1 DN2CPP_GATE_CACHE=0`, 104 gates:

- **`grpc-unary` green** — the gate that went red
- `http2-unary`'s `[cancel] caller=OperationCanceledException` green — the direct assertion on the changed path
- 5 skips, all declared opt-outs (Emscripten ×3, godot-dotnet, Xcode)

Three gates stayed red on this machine for reasons independent of this change, each checked rather than assumed:

| gate | cause |
|---|---|
| `http-get`, `reflect-types` | no real Python 3 installed (PATH has the Microsoft Store stub) |
| `http2-unary` `[drop]` | conservative-GC finalizer reachability — **reproduced identically on the unmodified tree**; green on CI |

Not the merge gate: `./gates/pre-merge.sh` still has to run on a fully provisioned machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
