### PR TITLE
gates: default the Windows host compiler to cl

### DIFF
--- a/gates/_common.sh
+++ b/gates/_common.sh
@@ -63,6 +63,15 @@ detect_os() {
 }
 DN2CPP_OS=${DN2CPP_OS:-$(detect_os)}
 
+# Windows's host toolchain is MSVC, so name it rather than making every caller
+# do it: unset, cmake dies on its own "No CMAKE_CXX_COMPILER could be found"
+# instead of reaching ensure_msvc_env's vcvarsall import. Anything else on
+# Windows — clang++, clang-cl — is still spelled out here explicitly.
+if [ "$DN2CPP_OS" = windows ]; then
+    : "${CMAKE_CXX_COMPILER:=cl}"
+    export CMAKE_CXX_COMPILER
+fi
+
 # LIB_EXT (extension, no dot) / LIB_PREFIX ("lib", empty on Windows) /
 # LIB_PATH_ENV (loader's run-time shared-library search-path env var).
 case "$DN2CPP_OS" in


### PR DESCRIPTION
## The paper cut

On Windows with no compiler on the bare PATH, a gate run dies before it reaches anything this repository wrote:

```
-- The CXX compiler identification is unknown
CMake Error at CMakeLists.txt:22 (project):
  No CMAKE_CXX_COMPILER could be found.
```

`ensure_msvc_env` exists precisely to fix that — it locates the install through vswhere and imports `vcvarsall x64` so a plain Git Bash gets `cl.exe` non-interactively. But it is gated on `is_msvc_compiler`, which reads `CMAKE_CXX_COMPILER`, so it never runs unless the caller already named the compiler. Every Windows invocation had to carry `CMAKE_CXX_COMPILER=cl` — `windows-smoke.yml` does, and a human running `./gates/pre-merge.sh` does not.

## The change

Default it beside `DN2CPP_OS`, ahead of the `ensure_msvc_env` call that reads it. Windows's host toolchain here is MSVC; naming it should not be every caller's job. `clang++` or `clang-cl` on Windows stays available, spelled out explicitly.

## Why this does not leak MSVC into a cross build

Checked rather than assumed — `CMAKE_CXX_COMPILER` is not just a cmake argument, it also flips `is_msvc_compiler`, which selects MSVC-vs-GNU flag syntax (`libpath_flag`'s `/LIBPATH:` vs `-L`):

- `cmake_configure` / `_cmake_app_builddir` already withhold `-DCMAKE_CXX_COMPILER` when `WASM`/`IOS_DEV`/`IOS_SIM`/`ANDROID` is set.
- Every `is_msvc_compiler` outside `_common.sh` — `pinvoke-native`, `pinvoke-wasm`, `uco-shared`, `godot-dotnet-sample` — selects a **host** library recipe. `pinvoke-wasm`'s is for the host oracle library real .NET loads beside the wasm archive, so cl is the right answer there too.
- `libpath_flag`'s only caller outside `_common.sh` is `pinvoke-native`, host side.

## Verification

Full suite on Windows, `CMAKE_CXX_COMPILER` **unset**, `SKIP_GODOT=1 DN2CPP_GATE_CACHE=0`, 104 gates — identical to a run with `=cl` spelled out:

- `pinvoke-native` and `uco-shared` green (the `is_msvc_compiler` consumers)
- 5 skips, all declared opt-outs (Emscripten ×3, godot-dotnet, Xcode)
- 3 red, all environmental and all red before this change: `http-get` and `reflect-types` (no real Python 3 on this machine — PATH carries the Microsoft Store stub), `http2-unary`'s `[drop]` (conservative-GC finalizer reachability; green on CI)

This removes a first-step stumble; it does not make `./gates/pre-merge.sh` pass on Windows. Under `DN2CPP_REQUIRE_ALL=1` the iOS lane (Xcode, macOS-only) and the CRI lane (proprietary package) remain structurally unrunnable there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
