### PR TITLE
gates: take the prebuilt godot-dotnet arm on macOS

### DIFF
--- a/gates/setup-godot-dotnet.sh
+++ b/gates/setup-godot-dotnet.sh
@@ -208,10 +208,12 @@ resolve_prebuilt() {
             echo "       directly with DN2CPP_GODOT_PREBUILT=<editor binary>." >&2
             return 1
         fi
-        # GodotSharp/ sits beside the REAL binary, so resolve the link first —
-        # a PATH entry is very often a symlink into an install elsewhere.
-        editor="$(readlink -f "$editor" 2>/dev/null || printf '%s\n' "$editor")"
     fi
+    # GodotSharp/ sits beside the REAL binary, so resolve the link before anything
+    # reads the dirname — a named editor is very often a symlink into an install
+    # elsewhere, whether it came off PATH or out of DN2CPP_GODOT_PREBUILT. Left
+    # unresolved, a correct mono install is refused as "not a mono install".
+    editor="$(readlink -f "$editor" 2>/dev/null || printf '%s\n' "$editor")"
     [ -x "$editor" ] || { echo "error: prebuilt editor not executable: $editor" >&2; return 1; }
     prebuilt_pin_ok "$editor" || return 1
     printf '%s\n' "$editor"

--- a/gates/setup-godot-dotnet.sh
+++ b/gates/setup-godot-dotnet.sh
@@ -46,9 +46,10 @@
 #
 #   - DN2CPP_GODOT_PREBUILT=<editor binary> — take the editor, the glue, the
 #     GodotSharp assemblies and the nupkgs from an official install. Honoured on
-#     EVERY OS. The engine's own rule ("GodotSharp/ sits beside the executable",
-#     modules/mono/godotsharp_dirs.cpp) is what makes naming the *binary* — not
-#     a root directory — the right handle: everything else hangs off its dirname.
+#     EVERY OS. The engine's own rule (modules/mono/godotsharp_dirs.cpp) is what
+#     makes naming the *binary* — not a root directory — the right handle:
+#     GodotSharp/ hangs off its dirname, and off Contents/Resources instead when
+#     that dirname is a .app's Contents/MacOS.
 #   - unset, on Windows: auto-detect from $GODOT (else `godot` on PATH). scons
 #     is not an option here — platform/windows/detect.py forces d3d12=yes and
 #     exit 255s without the Mesa build deps — so a failed detect is a hard error
@@ -307,7 +308,17 @@ if [ -n "$PREBUILT" ]; then
     # the pinned tree (verified above), its GodotSharp was generated from that
     # tree's glue, and it ships the very nupkgs build_assemblies.py packs.
     prebuilt_dir="$(cd "$(dirname "$PREBUILT")" && pwd)"
+    # macOS ships the official mono editor as a .app, and there GodotSharp/ sits
+    # in Contents/Resources rather than beside the executable — the engine's own
+    # MACOS_ENABLED branch in godotsharp_dirs.cpp. Without this the prebuilt arm
+    # cannot be taken on macOS at all.
     prebuilt_sharp="$prebuilt_dir/GodotSharp"
+    case "$prebuilt_dir" in
+        */Contents/MacOS)
+            [ -d "$prebuilt_sharp" ] \
+                || prebuilt_sharp="${prebuilt_dir%/MacOS}/Resources/GodotSharp"
+            ;;
+    esac
 
     echo "== 1/6 Mono-enabled editor build =="
     echo "skip: official pinned build supplies it: $PREBUILT"
@@ -318,7 +329,7 @@ if [ -n "$PREBUILT" ]; then
 
     echo "== 3/6 Building managed assemblies + local nuget feed =="
     [ -f "$prebuilt_sharp/Api/Release/GodotSharp.dll" ] || {
-        echo "error: no GodotSharp/Api/Release/GodotSharp.dll beside $PREBUILT" >&2
+        echo "error: no Api/Release/GodotSharp.dll under $prebuilt_sharp" >&2
         echo "       That directory is where the engine itself looks for it, so this is" >&2
         echo "       not a mono install — use the *_mono_* download, not the plain one." >&2
         exit 1


### PR DESCRIPTION
`gates/setup-godot-dotnet.sh` の prebuilt アーム(公式インストールから steps 1-3 を取る経路)が
macOS で構造的に通らなかった。ヘッダーは "Honoured on EVERY OS" と書いているが、macOS だけは
どう指定しても step 3 で落ちる。

## 1. `.app` の中の GodotSharp を解決する

prebuilt アームは GodotSharp/ をエディタバイナリの隣でしか探していなかった。エンジンが
そこを読むのは macOS 以外で、macOS の公式 mono エディタは `.app` であり、
`godotsharp_dirs.cpp` の `MACOS_ENABLED` 分岐は `Contents/Resources` を読む。

結果、macOS はこのアームを一度も取れなかった — もう一方の分岐が数十分の scons ビルドである、
唯一のホストで。エンジン自身と同じ規則に合わせた。

## 2. 名指しされたエディタのリンクも解決する

リンク解決が PATH 自動検出アーム(Windows 専用)の中だけにあり、`DN2CPP_GODOT_PREBUILT` を
明示した経路は呼び出し側の綴りをそのまま使っていた。別の場所へのシンボリックリンクを渡すと
dirname が GodotSharp のない場所を指し、**正しい mono インストールが
`not a mono install — use the *_mono_* download` と誤診断されて exit 1 する。**

この変数が実パスを要求するとはどこにも書かれておらず、もう一方のアームが解決する理由は
そのアーム固有のものでもない — エンジンはどちらでも実バイナリの隣を読む。

## 検証

ゲートに覆われていないセットアップ補助スクリプトなので手動で確認した。

- 修正前のコードにリンクを渡し、上記の誤診断を**再現**した
- 修正後、同じリンクで `Contents/Resources/GodotSharp/Tools/nupkgs` を正しく拾い、
  `editor_bin` が実体を指すことを確認
- 実パス直指定の既存経路が壊れていないことを確認
- キャッシュを使う `godot-dotnet-handshake` ゲートが緑
- このキャッシュに依存する 4 ゲート(handshake / gdtask / sample / trim)を含め、
  Release・Debug 両スイートが 119/122 passed・0 failed(skip は CRI 3 件のみ)

## 残る穴(この PR では扱わない)

homebrew cask の `godot-mono` は**シンボリックリンクではなくラッパースクリプト**で `.app` 内の
バイナリを exec するため、`readlink -f` では辿れない。パス解決では原理的に閉じられないので
対象外とした。修正後はラッパーの置き場所を正しく名指しした診断になる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)