### PR TITLE
transpiler: Span<T>.Clear writes T{}, not (T)0

### DIFF
--- a/samples/dotnet/SpanOps/SpanInstanceSubset.cs
+++ b/samples/dotnet/SpanOps/SpanInstanceSubset.cs
@@ -61,5 +61,26 @@ class Program
         ((Span<int>)empty).Clear();                              // no-op
         int[] ecopy = ((ReadOnlySpan<int>)empty).ToArray();
         Console.WriteLine(ecopy.Length);                         // 0
+
+        // --- Span.Clear over a STRUCT element (whole + a Slice view) ---
+        // A struct has no cast from 0, so the zero written per element must be
+        // the value-initialized T{}, not a scalar conversion.
+        Pair[] ps = { new Pair(1, 2), new Pair(3, 4), new Pair(5, 6) };
+        ((Span<Pair>)ps).Slice(1, 1).Clear();
+        Console.WriteLine($"{ps[0].A},{ps[0].B};{ps[1].A},{ps[1].B};{ps[2].A},{ps[2].B}"); // 1,2;0,0;5,6
+        ((Span<Pair>)ps).Clear();
+        Console.WriteLine($"{ps[0].A},{ps[2].B}");               // 0,0
+    }
+}
+
+internal struct Pair
+{
+    internal long A;
+    internal long B;
+
+    internal Pair(long a, long b)
+    {
+        A = a;
+        B = b;
     }
 }

--- a/src/Dn2Cpp.Transpiler/MethodCompiler.Arithmetic.cs
+++ b/src/Dn2Cpp.Transpiler/MethodCompiler.Arithmetic.cs
@@ -1372,7 +1372,7 @@ internal sealed partial class MethodCompiler
             case "Clear":
             {
                 string sp = SpanPtr(Pop(), spanCt);
-                Emit($"for ({i} = 0; {i} < {sp}->f__length; {i}++) (({elemSt}*){sp}->f__reference)[{i}] = ({elemSt})0;");
+                Emit($"for ({i} = 0; {i} < {sp}->f__length; {i}++) (({elemSt}*){sp}->f__reference)[{i}] = {CppTypes.ZeroInitExpr(elemSt)};");
                 return true;
             }
             case "Fill":


### PR DESCRIPTION
Fixes #11.

## What

`TryEmitSpanInstanceBulk` の `Clear` 腕は要素のゼロ値を `(T)0`(ストレージ型への C スタイルキャスト)で書いており、要素型が構造体のとき生成 C++ が `no matching conversion for C-style cast from 'int'` でコンパイルに失敗していた。ゼロ値の綴りを既存ヘルパー `CppTypes.ZeroInitExpr`(ポインタ → `nullptr`、スカラー → `0`、構造体 → `T{}`)に置き換える — `initobj` が使っているものと同じ。

## Coverage

`samples/dotnet/SpanOps/SpanInstanceSubset.cs` に構造体要素の `Clear` セクションを追加(全体 + Slice ビュー、未タッチ要素の残存確認)。修正前のトランスパイラでこのセクションは Issue と同一のコンパイルエラーを 2 箇所で再現することを確認済み(red-before-green)。

## Verification

- `gates/build-and-run-span-ops.sh` green(新セクションの出力が verbatim・contiguous、旧出力は unchanged prefix)
- Release スイート: 119/122 passed、0 failed、skip は CRI 3 件のみ(このマシンの既知の未導入分)
- Debug スイート(shared-generics バックストップ全コーパス): 119 ran、0 failed、skip 同上
- `gates/verify-culture-invariance.sh` exit 0
- `gates/selfhost-emit.sh`: 自己ホスト fixpoint byte-for-byte 再現

🤖 Generated with [Claude Code](https://claude.com/claude-code)