### PR TITLE
Box a primitive constrained. receiver for Equals

### DIFF
--- a/gates/build-and-run-boxing-primitives.sh
+++ b/gates/build-and-run-boxing-primitives.sh
@@ -33,6 +33,19 @@
 #     answering `is IConvertible` and the set that can dispatch one are one set. Its
 #     IComparable half is also the only coverage of dn2cpp_object_compare's Decimal
 #     and date/time ordering arms.
+#   * BoxedNegativeItfSubset — the NEGATIVE half of that itable test, and not a
+#     boxing test either: `is IEnumerable` / IList / IDictionary / ICollection /
+#     IEnumerable<char> over boxed float/double/int/enum/DateTime/decimal, each
+#     of which must answer False, against string and int[] as the True controls.
+#     The positive matrix above cannot see a type test that OVER-admits, and the
+#     arm one lets run reads the box payload as a type pointer.
+#   * ConstrainedObjectEqualsSubset — the RECEIVER side of that hazard, over a
+#     generic wrapper: `constrained. !T; callvirt object::Equals(object)` boxes
+#     only the ARGUMENT, so a receiver left unboxed at the call site is its own
+#     bits read as a type-info (0.003f as a Dn2CppTypeInfo* — a SIGSEGV, seen in
+#     a real game's settings comparison). Every T kind that reaches the prefix:
+#     the primitives, enum, an overriding struct, decimal/DateTime, string and
+#     object — the last four being the arms that already boxed.
 #
 # The culture pin is the driver's first two statements, NOT an InvariantGlobalization
 # property — that one pins only the oracle and drops ICU (stated at the

--- a/samples/dotnet/BoxingPrimitives/BoxedNegativeItfSubset.cs
+++ b/samples/dotnet/BoxingPrimitives/BoxedNegativeItfSubset.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+// The NEGATIVE half of the boxed-built-in interface test: an interface a boxed
+// primitive does NOT implement must answer False. The positive matrix next door
+// only proves that an admitted pair dispatches; a test that over-admits is
+// invisible there, and the arm it lets run reads the box payload as a type
+// pointer.
+namespace BoxedNegativeItfSubset;
+
+internal static class Program
+{
+    internal static void Run()
+    {
+        object of = 0.003f;
+        Console.WriteLine("float is IEnumerable: " + (of is IEnumerable));
+        Console.WriteLine("float is IComparable: " + (of is IComparable));
+        Console.WriteLine("float CompareTo: " + ((IComparable)of).CompareTo(0.004f));
+
+        object od = 0.003;
+        Console.WriteLine("double is IEnumerable: " + (od is IEnumerable));
+        object oi = 42;
+        Console.WriteLine("int is IEnumerable: " + (oi is IEnumerable));
+        Console.WriteLine("int is IEnumerable<char>: " + (oi is IEnumerable<char>));
+        Console.WriteLine("int is IList: " + (oi is IList));
+        Console.WriteLine("int is IDictionary: " + (oi is IDictionary));
+        Console.WriteLine("int is ICollection: " + (oi is ICollection));
+
+        // Boxed enum and the date family, whose type-infos carry a real map.
+        object oe = DayOfWeek.Monday;
+        Console.WriteLine("enum is IEnumerable: " + (oe is IEnumerable));
+        object odt = new DateTime(2020, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+        Console.WriteLine("DateTime is IEnumerable: " + (odt is IEnumerable));
+        object om = 3.5m;
+        Console.WriteLine("decimal is IEnumerable: " + (om is IEnumerable));
+
+        // Controls: the two boxed shapes that DO answer True.
+        object os = "x";
+        Console.WriteLine("string is IEnumerable: " + (os is IEnumerable));
+        Console.WriteLine("string is IEnumerable<char>: " + (os is IEnumerable<char>));
+        object oa = new int[] { 1, 2 };
+        Console.WriteLine("int[] is IEnumerable: " + (oa is IEnumerable));
+
+        // The shape the crash took: a True answer runs the foreach arm.
+        Console.WriteLine("float enumerated: " + Enumerate(of));
+        Console.WriteLine("string enumerated: " + Enumerate(os));
+    }
+
+    private static string Enumerate(object v)
+    {
+        if (v is not IEnumerable e)
+        {
+            return "not-enumerable";
+        }
+
+        int n = 0;
+        foreach (object _ in e)
+        {
+            n++;
+        }
+
+        return "count=" + n;
+    }
+}

--- a/samples/dotnet/BoxingPrimitives/ConstrainedObjectEqualsSubset.cs
+++ b/samples/dotnet/BoxingPrimitives/ConstrainedObjectEqualsSubset.cs
@@ -1,0 +1,79 @@
+using System;
+
+// `constrained. !T; callvirt object::Equals(object)` — the Object-rooted overload,
+// whose argument is already a boxed reference. The receiver is NOT: it arrives as a
+// managed pointer to the raw value, and dn2cpp_object_equals reads its first word as
+// a type-info, so a primitive receiver that is not boxed at the call site has its own
+// bits dereferenced as a Dn2CppTypeInfo* (0.003f => 0x3B449BA6) and the process dies.
+// Every T shape that can reach the prefix is here, because the fault is per-kind:
+// struct and reference receivers were already covered and are the controls.
+namespace ConstrainedObjectEqualsSubset;
+
+internal enum Hue : byte { Red = 1, Green = 2 }
+
+internal struct Coord
+{
+    public int X;
+    public int Y;
+    public Coord(int x, int y) { X = x; Y = y; }
+    public override bool Equals(object o) => o is Coord c && c.X == X && c.Y == Y;
+    public override int GetHashCode() => X * 31 + Y;
+}
+
+internal sealed class Box<T>
+{
+    public T Value;
+    public Box(T v) { Value = v; }
+
+    // The field spelling (ldflda + constrained.) — the shape a settings wrapper
+    // comparing its own stored value reaches.
+    public bool EqField(Box<T> o) => Value.Equals((object)o.Value);
+
+    // The same prefix over a local (ldloca).
+    public bool EqLocal(T v)
+    {
+        T local = Value;
+        return local.Equals((object)v);
+    }
+
+    // A boxed argument of a foreign runtime type, and null: both must answer False
+    // rather than fault.
+    public bool EqForeign(object o) => Value.Equals(o);
+}
+
+internal static class Program
+{
+    private static void One<T>(string tag, T a, T b)
+    {
+        var x = new Box<T>(a);
+        Console.WriteLine("coe " + tag
+            + " same=" + x.EqField(new Box<T>(a))
+            + " diff=" + x.EqField(new Box<T>(b))
+            + " local=" + x.EqLocal(a)
+            + " localDiff=" + x.EqLocal(b)
+            + " null=" + x.EqForeign(null)
+            + " foreign=" + x.EqForeign("nope"));
+    }
+
+    internal static void Run()
+    {
+        One("float", 0.003f, 0.004f);
+        One("double", 0.003d, 0.004d);
+        One("int", 7, 8);
+        One("uint", 7u, 8u);
+        One("long", 7L, 8L);
+        One("ulong", 7UL, 8UL);
+        One("short", (short)7, (short)8);
+        One("byte", (byte)7, (byte)8);
+        One("sbyte", (sbyte)-7, (sbyte)8);
+        One("char", 'a', 'b');
+        One("bool", true, false);
+        One("nint", (IntPtr)7, (IntPtr)8);
+        One("enum", Hue.Red, Hue.Green);
+        One("struct", new Coord(1, 2), new Coord(3, 4));
+        One("decimal", 1.5m, 2.5m);
+        One("datetime", new DateTime(2020, 1, 2), new DateTime(2021, 3, 4));
+        One("string", "hi", "there");
+        One("object", new object(), new object());
+    }
+}

--- a/samples/dotnet/BoxingPrimitives/Program.cs
+++ b/samples/dotnet/BoxingPrimitives/Program.cs
@@ -26,6 +26,14 @@ namespace BoxingPrimitives
     //     back, asserted against the type TEST that admits the same pairs. It also
     //     pins dn2cpp_object_compare's Decimal / date-time ordering arms, which
     //     nothing else in the suite reaches.
+    //   * BoxedNegativeItfSubset is the NEGATIVE half of that itable test: an
+    //     interface a boxed primitive does not implement must answer False. The
+    //     positive matrix cannot see a test that over-admits, and the arm such a
+    //     test lets run reads the box payload as a type pointer.
+    //   * ConstrainedObjectEqualsSubset is the RECEIVER side of the same hazard:
+    //     `constrained. !T; callvirt object::Equals(object)` hands the helper a
+    //     managed pointer to the raw value, so a receiver left unboxed there is its
+    //     own bits read as a type-info. Every T kind that reaches the prefix.
     //   * MouthAgreementSubset is a MOUTH-AGREEMENT test over three surfaces
     //     that are not boxing at heart: a boxed enum's cut ISpanFormattable.TryFormat
     //     against its IFormattable text, the self-instantiated IComparable<T>/
@@ -49,6 +57,8 @@ namespace BoxingPrimitives
             PrimitiveCompareHashSubset.Program.Run();
             BoxedBuiltinItfDispatchSubset.Program.Run();
             MouthAgreementSubset.Program.Run();
+            BoxedNegativeItfSubset.Program.Run();
+            ConstrainedObjectEqualsSubset.Program.Run();
         }
     }
 }

--- a/src/Dn2Cpp.Transpiler/MethodCompiler.Call.cs
+++ b/src/Dn2Cpp.Transpiler/MethodCompiler.Call.cs
@@ -3710,7 +3710,7 @@ internal sealed partial class MethodCompiler
             // reference path, which neither boxes the value nor emits the interface's ti_/struct.
             // Devirtualize to a typed value compare (the EqualityComparer<T>.Default.Equals form)
             // instead. Distinguish the typed Equals (the value is on the stack) from
-            // Object::Equals(object) (a boxed reference arg), which is left to the normal path.
+            // Object::Equals(object) (a boxed reference arg), which the arm below claims.
             case "Equals" when ((c.Kind == TypeKind.Primitive && !c.IsObject && !c.IsString)
                                 || c is { Kind: TypeKind.Class, Class.IsEnum: true })
                 && _stack.Count >= 2 && _stack[^1].Kind != StackKind.Ref:
@@ -3720,6 +3720,20 @@ internal sealed partial class MethodCompiler
                 string ct = CppTypes.Of(c);
                 var x = new StackEntry(ConstrainedReceiverValue(c, receiver.Expr), CppTypes.KindOf(c), ct);
                 Push(StackKind.I4, "int32_t", EqualityEqualsExpr(c, x, arg));
+                return true;
+            }
+            // Object::Equals(object) on a primitive or enum receiver — only the ARGUMENT
+            // is boxed by the IL, so box the receiver too rather than handing
+            // dn2cpp_object_equals a managed pointer whose pointee it would read as an
+            // object header (the struct twin below, for the same reason).
+            case "Equals" when ((c.Kind == TypeKind.Primitive && !c.IsObject && !c.IsString)
+                                || c is { Kind: TypeKind.Class, Class.IsEnum: true })
+                && ConstrainedCalleeSig(handle).ParameterTypes is [{ IsObject: true }]:
+            {
+                var other = Pop();
+                var receiver = Pop(); // managed pointer to the constrained value
+                string boxed = BoxedConstrainedReceiver(c, receiver);
+                Push(StackKind.I4, "int32_t", $"dn2cpp_object_equals({boxed}, {Cast(other, "Dn2CppObject*")})");
                 return true;
             }
             // IComparable<T>.CompareTo(T) on a primitive or string key (the LINQ


### PR DESCRIPTION
A `constrained. !T` prefix on `Object::Equals(object)` boxes only the
ARGUMENT, so a primitive or enum receiver reached
`dn2cpp_object_equals` as a managed pointer to the field. That helper
reads both operands as object headers, so the value's own bits were
dereferenced as a `Dn2CppTypeInfo*`.

Found in a real Thrive run: opening the options menu crashed with
`EXC_BAD_ACCESS` at `0x3b449ba6` — the single-precision bit pattern of
the setting's value (~0.003f) — inside `SettingValue<float>.Equals`.
Minimal repro (real .NET prints True, dn2cpp SIGSEGVs):

```csharp
public class Box<T> {
    public T Value;
    public bool Eq(Box<T> o) => Value.Equals((object)o.Value);
}
```

The struct receiver already had this guard, with a comment saying why;
primitives and enums did not. The new arm is its twin and selects on the
callee signature being `Equals(object)`, which makes it visibly
exclusive with the typed `IEquatable<T>.Equals(T)` arm above it.

Also folded in: a `BoxingPrimitives` section pinning that `isinst` on a
boxed primitive answers negatively for interfaces it does not implement
(`float is IEnumerable` etc). That was the first hypothesis for this
crash; it turned out to be correct behaviour already, and the section
keeps it that way.

Verification: the new gate section is red before the fix (the native
binary SIGSEGVs mid-output) and green after; `selfhost-emit.sh` reaches
its fixpoint at 128 TU; the full suite is 122/122 with no skips and no
cached results. `pre-merge.sh` has not been run.
