### PR TITLE
Wait for a server's READY line on evidence, not luck

### DIFF
--- a/gates/_common.sh
+++ b/gates/_common.sh
@@ -2768,6 +2768,59 @@ run_bounded() {
     run_with_watchdog "${DN2CPP_RUN_WATCHDOG_SECS:-600}" "$@"
 }
 
+# wait_ready_line NAME PID OUT ERR [SECONDS] — echo the first COMPLETE line the
+# background server PID writes to OUT, or print the evidence and return 1.
+# A pid that already exited fails at once: waiting the deadline out for a dead
+# process reports only "the file is empty", which is what made this unreadable.
+# The deadline governs only the slow case, and a slow case costs one xargs -P
+# worker slot for its length — so it is set well past a loaded runner's start,
+# far below run_bounded's own budget.
+wait_ready_line() {
+    local name="$1" pid="$2" out="$3" err="$4" secs="${5:-60}"
+    local t0=$SECONDS line="" waited=0 dead=0
+    while :; do
+        # `read` succeeds only on a NEWLINE-terminated line. `[ -s "$out" ]` also
+        # accepts a half-written "READY 5324", and the caller then parses a port
+        # that is not there yet.
+        if { IFS= read -r line < "$out"; } 2>/dev/null && [ -n "$line" ]; then
+            waited=$((SECONDS - t0))
+            # stdout is this function's return channel, so the warning takes stderr;
+            # run-all-gates.sh folds stderr into the gate log its grep reads.
+            [ "$waited" -lt $((secs / 2)) ] \
+                || gate_warn "the $name took ${waited}s of its ${secs}s budget to print READY — a start this slow is one load spike from failing the gate" >&2
+            printf '%s\n' "${line%$'\r'}"
+            return 0
+        fi
+        # Liveness AFTER the read: a server that prints READY and exits is ready.
+        # kill -0 can read a zombie or a recycled pid as alive; both only cost the
+        # full deadline, neither manufactures a failure.
+        if ! kill -0 "$pid" 2>/dev/null; then
+            if { IFS= read -r line < "$out"; } 2>/dev/null && [ -n "$line" ]; then
+                printf '%s\n' "${line%$'\r'}"
+                return 0
+            fi
+            dead=1; break
+        fi
+        waited=$((SECONDS - t0))
+        [ "$waited" -lt "$secs" ] || break
+        sleep 0.1
+    done
+    waited=$((SECONDS - t0))
+    local state="still running"
+    [ "$dead" = 0 ] || state="already gone — it exited before printing READY"
+    {
+        printf 'FAIL: the %s never printed a READY line (waited %ss of %ss; pid %s %s)\n' \
+            "$name" "$waited" "$secs" "$pid" "$state"
+        # $(cat) rather than cat: a server killed mid-line leaves no trailing
+        # newline, and the next heading would then run onto its own evidence.
+        if [ -s "$out" ]; then printf -- '--- %s ---\n%s\n' "$out" "$(cat "$out")"
+        else printf -- '--- %s: EMPTY ---\n' "$out"; fi
+        if [ -s "$err" ]; then printf -- '--- %s ---\n%s\n' "$err" "$(cat "$err")"
+        else printf -- '--- %s: EMPTY ---\n' "$err"; fi
+    } >&2
+    return 1
+}
+
 # xcodebuild_pipe_budget [HELD] — bytes the kernel grants a FRESH pipe while HELD
 # pipes (default 10) are already open. Prints one integer, or 0 if it cannot
 # measure. The grant is graded out of a machine-wide budget (16384 down to 512

--- a/gates/build-and-run-grpc-unary.sh
+++ b/gates/build-and-run-grpc-unary.sh
@@ -165,14 +165,7 @@ dotnet "$srv" > "$srvdir/ready.out" 2>"$srvdir/server.err" &
 srvpid=$!
 disown "$srvpid" 2>/dev/null || true
 trap 'kill "$srvpid" 2>/dev/null; rm -rf "$srvdir"' EXIT
-ready=""
-for _ in $(seq 1 100); do
-    [ -s "$srvdir/ready.out" ] && { ready="$(head -1 "$srvdir/ready.out")"; break; }
-    sleep 0.1
-done
-[ -n "$ready" ] || {
-    echo "FAIL: the gRPC oracle server never printed READY" >&2
-    cat "$srvdir/server.err" >&2; exit 1; }
+ready=$(wait_ready_line "gRPC oracle server" "$srvpid" "$srvdir/ready.out" "$srvdir/server.err") || exit 1
 read -r tag port <<<"$ready"
 [ "$tag" = "READY" ] && [ -n "${port:-}" ] || {
     echo "FAIL: could not parse the oracle's READY line: $ready" >&2; exit 1; }

--- a/gates/build-and-run-http2-unary.sh
+++ b/gates/build-and-run-http2-unary.sh
@@ -131,14 +131,7 @@ dotnet "$srv" > "$h2cdir/ready.out" 2>"$h2cdir/server.err" &
 h2cpid=$!
 disown "$h2cpid" 2>/dev/null || true
 trap 'kill "$h2cpid" "$tlspid" 2>/dev/null; rm -rf "$h2cdir" "$tlsdir"' EXIT
-ready=""
-for _ in $(seq 1 100); do
-    [ -s "$h2cdir/ready.out" ] && { ready="$(head -1 "$h2cdir/ready.out")"; break; }
-    sleep 0.1
-done
-[ -n "$ready" ] || {
-    echo "FAIL: the h2 oracle server never printed READY" >&2
-    cat "$h2cdir/server.err" >&2; exit 1; }
+ready=$(wait_ready_line "h2 oracle server" "$h2cpid" "$h2cdir/ready.out" "$h2cdir/server.err") || exit 1
 read -r tag h2cport h1port <<<"$ready"
 [ "$tag" = "READY" ] && [ -n "${h2cport:-}" ] && [ -n "${h1port:-}" ] || {
     echo "FAIL: could not parse the oracle's READY line (expected 2 ports): $ready" >&2; exit 1; }
@@ -343,14 +336,7 @@ dotnet "$srv" --cert "$tlsdir/srv.pem" --key "$tlsdir/srv.key" \
     > "$tlsdir/ready.out" 2>"$tlsdir/server.err" &
 tlspid=$!
 disown "$tlspid" 2>/dev/null || true
-tlsready=""
-for _ in $(seq 1 100); do
-    [ -s "$tlsdir/ready.out" ] && { tlsready="$(head -1 "$tlsdir/ready.out")"; break; }
-    sleep 0.1
-done
-[ -n "$tlsready" ] || {
-    echo "FAIL: the TLS oracle server never printed READY" >&2
-    cat "$tlsdir/server.err" >&2; exit 1; }
+tlsready=$(wait_ready_line "TLS oracle server" "$tlspid" "$tlsdir/ready.out" "$tlsdir/server.err") || exit 1
 read -r tag _ _ tlsport <<<"$tlsready"
 [ "$tag" = "READY" ] && [ -n "${tlsport:-}" ] || {
     echo "FAIL: could not parse the TLS oracle's READY line (expected 3 ports): $tlsready" >&2; exit 1; }


### PR DESCRIPTION
## What broke

The macOS suite failed `http2-unary` intermittently ([run 31460072328](https://github.com/takuma-komatsu/dn2cpp/actions/runs/31460072328)). The gate log ended at two lines:

```
== 5/5 Live TLS+ALPN: a real h2-over-TLS handshake (self-contained) ==
FAIL: the TLS oracle server never printed READY
```

The gate already `cat`s the server's stderr on that path, so the silence after it means **stderr was empty** — nothing separates a server that crashed from one that was merely slow. That, not the deadline, is the defect: the failure arrived with no cause attached.

Only section 5's server loads a certificate (RSA-2048 PEM → PKCS#12 round-trip → `UseHttps`, the macOS ephemeral-key workaround), and it starts while `xargs -P nCPU` has the runner's 3 cores saturated and http-get's own TLS server up.

## Where the 10s came from

Nothing chose it. It first appears in `11de2cb2`, where the comment explains only "poll instead of a fixed sleep" and says nothing about the bound; four later gates copied the literal, including the two touched here. Across the whole history of `gates/`, `seq 1 100` is added 18 times and removed twice — and both removals widen it (`f17a388a`, http-get, 100→300, no reason recorded, part of a night spent on this same failure on a hosted macOS runner).

The two bounds this tree does justify: `run_bounded` names the cost of a long deadline (one `xargs -P` worker slot held for its length, against a 600s budget), and `build-and-run-cri-android.sh` names how to pick one (`bounded well past` the measured time). 60s follows from both, and this time the reason is written at the site.

## The change

One helper in `gates/_common.sh` replaces three copies of the loop (`http2-unary` ×2, `grpc-unary` ×1):

- returns **only a newline-terminated line** — `[ -s ]` also accepts a half-written `READY 5324`, which the caller then parses as a missing port
- **a dead pid fails immediately**, deadline or not
- on failure prints elapsed time, deadline, whether the pid is still running, and both streams — naming an empty one as empty
- a start past half the budget calls `gate_warn`, so a wait drifting toward its deadline is visible before it fails one

`build-and-run-http-get.sh`'s four waits are probe-shaped (a real python request) and are left alone; folding them in would blur this against http-get's own two failures.

## Verification

- helper unit-tested across 7 paths: immediate READY, dead process, deadline exceeded, partial line, slow-but-in-time, CRLF, prints-then-exits
- fault-injected in the real gate (section 5 pointed at a missing cert): fails in **0s of 60s** with `already gone`, `ready.out: EMPTY`, and the server's full `FileNotFoundException` stack; exit 1
- warning path fired end to end: reaches `_warnings.txt` and the summary's ⚠ block, gate green, suite exit 0
- `SKIP_GODOT=1 ./gates/run-all-gates.sh` → **105/105, 0 skipped, 0 cached**; `doc-claims` green

## What this does not settle

It does not identify the cause. The evidence to date cannot separate "slow" from "wedged"; making that separable is the point. If a rerun fails at 60s with `still running`, the macOS PKCS#12 load in `samples/dotnet/Http2TestServer/Program.cs` becomes the suspect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)