### PR TITLE
Scrub the finalizer thread's stack after ring drains

### DIFF
--- a/runtime/core/dn2cpp_gc.cpp
+++ b/runtime/core/dn2cpp_gc.cpp
@@ -1372,7 +1372,12 @@ bool dn2cpp_suppress_set_take(Dn2CppObject* obj)
 // against net10.0: an InvalidOperationException thrown from a finalizer body
 // aborts with no further finalizers run) — match that instead of swallowing it,
 // so any other queued finalizer is correctly left un-run rather than papered over.
-void dn2cpp_run_finalizer_body(Dn2CppObject* obj)
+//
+// NOINLINE so this frame DIES on return: inlined, its object slots join the
+// consumer's long-lived loop frame, which is scanned live on every collection
+// and out of the idle scrub's reach — pinning a dropped entry's object past
+// the second unreachability its re-registration waits for.
+DN2CPP_NOINLINE void dn2cpp_run_finalizer_body(Dn2CppObject* obj)
 {
     // The one place every queued entry passes through, so the one place a
     // suppress that arrived after the enqueue can still cancel the body.
@@ -1486,6 +1491,12 @@ void dn2cpp_finalizer_thread_main()
         // g_finalizer_tail below publishes this clear to a reusing producer.
         slot.store(nullptr, std::memory_order_relaxed);
         dn2cpp_run_finalizer_body(obj);
+        // Ring drains must arm the idle scrub exactly like spill drains: this
+        // body's dead frames (and the enqueue callback's, from any collection it
+        // ran) hold object pointers, and a thread that sleeps over them pins
+        // those blocks for as long as it keeps sleeping — including an object a
+        // dropped-entry's re-registration needs collectable a second time.
+        ranSinceIdle = true;
         tail++;
         g_finalizer_tail.store(tail, std::memory_order_release);
     }


### PR DESCRIPTION
The dedicated finalizer thread scrubs its dead stack band once per idle transition, but the flag that arms that scrub was set only by **spill** drains — and the spill only fills when the ring overflows. On the common path the thread went to sleep having drained the ring and never scrubbed, parked over dead frames still naming every object it had just finalized. A sleeping thread's stack is scanned on every collection, so those objects stayed pinned for as long as the thread stayed idle.

Harmless for a finalizer that already ran. Not harmless for an entry the consumer **drops**, whose object must become unreachable a second time before its re-registration can fire: that second death never arrives. `dn2cpp_run_finalizer_body` also gets `DN2CPP_NOINLINE`, because inlined its object slots join the consumer's long-lived loop frame, which is scanned live and out of any scrub's reach.

Split out of #21, which builds the drop-and-re-arm path this hygiene is a precondition for. #21 is stacked on this branch.

## Verification

- `DN2CPP_GATE_CACHE=0 ./gates/build-and-run-finalizers.sh` — green.
- The full `SKIP_GODOT=1` suite runs on the stacked #21 tree, which contains this commit unchanged (see #21's verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SRaS9sNir7ZM6G2NrnUgF8
