### PR TITLE
Complete incremental GC write-barrier coverage

### DIFF
--- a/runtime/core/dn2cpp_casts.cpp
+++ b/runtime/core/dn2cpp_casts.cpp
@@ -1331,7 +1331,7 @@ Dn2CppObject* dn2cpp_box(const Dn2CppTypeInfo* ti, const void* value, size_t siz
 {
     auto* obj = static_cast<Dn2CppObject*>(dn2cpp_alloc(sizeof(Dn2CppObject) + size));
     obj->type = ti;
-    std::memcpy(obj + 1, value, size);
+    dn2cpp_gc_memmove_refs(obj + 1, value, size); // the payload may carry managed refs
     return obj;
 }
 
@@ -1378,7 +1378,9 @@ Dn2CppObject* dn2cpp_delegate_combine(Dn2CppObject* a, Dn2CppObject* b)
     copy->type = bd->type;
     copy->target = bd->target;
     copy->method = bd->method;
-    copy->prev = dn2cpp_delegate_combine(a, bd->prev);
+    // The recursion allocates, so an incremental cycle may blacken `copy`
+    // before this store; barrier it or the combined chain is lost.
+    dn2cpp_gc_store_ref(&copy->prev, dn2cpp_delegate_combine(a, bd->prev));
     return copy;
 }
 

--- a/runtime/core/dn2cpp_exceptions.cpp
+++ b/runtime/core/dn2cpp_exceptions.cpp
@@ -127,7 +127,7 @@ void dn2cpp_exc_inflight_push(Dn2CppObject* obj)
     auto* node = static_cast<Dn2CppInflightExcNode*>(dn2cpp_alloc(sizeof(Dn2CppInflightExcNode)));
     node->obj = obj;
     std::lock_guard<std::mutex> lk(g_inflight_exc_mtx);
-    node->next = g_inflight_excs;
+    dn2cpp_gc_store_ref(&node->next, g_inflight_excs);
     g_inflight_excs = node;
     if (++g_inflight_exc_count > kInflightExcCap)
     {

--- a/runtime/core/dn2cpp_exceptions.cpp
+++ b/runtime/core/dn2cpp_exceptions.cpp
@@ -148,6 +148,7 @@ void dn2cpp_exc_inflight_pop(Dn2CppObject* obj)
         {
             Dn2CppInflightExcNode* dead = *pp;
             *pp = dead->next;
+            dn2cpp_gc_write_barrier_if_heap(pp); // pp may name the static head
             dead->next = nullptr;
             g_inflight_exc_count--;
             return;
@@ -1135,7 +1136,9 @@ Dn2CppStackFrame* dn2cpp_stackframe_new(Dn2CppString* fileName, int32_t line, in
 static Dn2CppStackFrame* dn2cpp_stackframe_of_text(const char* text, size_t len)
 {
     Dn2CppStackFrame* f = dn2cpp_stackframe_new(nullptr, 0, 0);
-    f->methodDesc = dn2cpp_string_from_utf8(text, static_cast<int32_t>(len));
+    // The string alloc may blacken the fresh frame; barrier the store.
+    dn2cpp_gc_store_ref(&f->methodDesc,
+        dn2cpp_string_from_utf8(text, static_cast<int32_t>(len)));
     return f;
 }
 
@@ -1241,7 +1244,9 @@ Dn2CppStackTrace* dn2cpp_stacktrace_new(const Dn2CppTypeInfo* frameArrTi, int32_
         // ss->frames[] is push order (outermost first); mirror the stamp
         // loop's reversal so entry 0 is the innermost un-skipped frame.
         const char* name = ss->frames[stored - 1 - skipStored - i];
-        frames->data[i] = dn2cpp_stackframe_of_text(name, std::strlen(name));
+        // The frame alloc may blacken `frames` mid-loop; barrier each store.
+        dn2cpp_gc_store_ref(&frames->data[i],
+            reinterpret_cast<Dn2CppObject*>(dn2cpp_stackframe_of_text(name, std::strlen(name))));
     }
     return dn2cpp_stacktrace_wrap(frames, overflowed - skipOverflow);
 }
@@ -1278,7 +1283,9 @@ Dn2CppStackTrace* dn2cpp_stacktrace_of_exception(const Dn2CppTypeInfo* frameArrT
         for (int32_t i = 0; i < n; i++)
         {
             const auto* name = static_cast<const char*>(trace->entries[skipEntries + i]);
-            frames->data[i] = dn2cpp_stackframe_of_text(name, std::strlen(name));
+            // See above: barrier each store of an allocating fill loop.
+            dn2cpp_gc_store_ref(&frames->data[i],
+                reinterpret_cast<Dn2CppObject*>(dn2cpp_stackframe_of_text(name, std::strlen(name))));
         }
         return dn2cpp_stacktrace_wrap(frames, trace->dropped - skipDropped);
     }
@@ -1301,7 +1308,9 @@ Dn2CppStackTrace* dn2cpp_stacktrace_of_exception(const Dn2CppTypeInfo* frameArrT
     for (int32_t i = 0; i < n; i++)
     {
         const std::string& line = lines[start + static_cast<size_t>(i)];
-        frames->data[i] = dn2cpp_stackframe_of_text(line.c_str(), line.size());
+        // See above: barrier each store of an allocating fill loop.
+        dn2cpp_gc_store_ref(&frames->data[i],
+            reinterpret_cast<Dn2CppObject*>(dn2cpp_stackframe_of_text(line.c_str(), line.size())));
     }
     return dn2cpp_stacktrace_wrap(frames, 0);
 }

--- a/runtime/core/dn2cpp_gc.cpp
+++ b/runtime/core/dn2cpp_gc.cpp
@@ -747,7 +747,7 @@ static void dn2cpp_cctor_unlink(Dn2CppCctorRun* node, Dn2CppCctorFailure* failur
     {
         // Failure: record, and leave the flag at 0 so no fast path ever reads this
         // type as initialized. A thread parked in the wait below re-tests the record.
-        failure->next = g_cctor_failed;
+        dn2cpp_gc_store_ref(&failure->next, g_cctor_failed);
         g_cctor_failed = failure;
     }
     else

--- a/runtime/core/dn2cpp_gc.cpp
+++ b/runtime/core/dn2cpp_gc.cpp
@@ -2203,6 +2203,9 @@ Dn2CppDependentHandle dn2cpp_dependenthandle_alloc(Dn2CppObject* target, Dn2CppO
     auto* cell = static_cast<Dn2CppDependentCell*>(dn2cpp_alloc(sizeof(Dn2CppDependentCell)));
     cell->targetWeak = dn2cpp_gchandle_internal_alloc(target, 0); // 0 = Weak (short link)
     cell->dependent = dependent;
+    // The internal alloc above can run an incremental step that blackens the
+    // fresh cell before these stores; one barrier covers both fields.
+    dn2cpp_gc_write_barrier(cell);
     return Dn2CppDependentHandle{cell};
 }
 
@@ -2361,7 +2364,12 @@ Dn2CppGCHandle dn2cpp_gchandle_alloc(Dn2CppObject* target, void* dataAddr, int32
     if (cell == nullptr) // uncollectable + zero-filled (see dn2cpp_alloc_pinned)
         cell = static_cast<Dn2CppGCHandleCell*>(dn2cpp_alloc_pinned(sizeof(Dn2CppGCHandleCell)));
     if (handleType <= 1) // Weak or WeakTrackResurrection: no strong ref in the cell
+    {
+        // The stored value is the collectable weak cell's address; the pooled
+        // uncollectable cell is old, so the store must dirty it.
         cell->weakCell = dn2cpp_gchandle_internal_alloc(target, handleType);
+        dn2cpp_gc_write_barrier(&cell->weakCell);
+    }
     else // Normal or Pinned: a strong pointer + (Pinned) the pinned data address
     {
         dn2cpp_gc_store_ref(&cell->target, target);

--- a/runtime/core/dn2cpp_interp.cpp
+++ b/runtime/core/dn2cpp_interp.cpp
@@ -1883,10 +1883,11 @@ Dn2CppInterpImage* dn2cpp_patch_load(const void* blobPtr, size_t len)
     // flagged type's .cctor is the first entry of its own MethodTable run.
     if (img->typeCount > 0)
     {
-        img->cctorStarted = static_cast<uint8_t*>(dn2cpp_alloc_atomic(img->typeCount));
+        dn2cpp_gc_store_ref(&img->cctorStarted,
+            static_cast<uint8_t*>(dn2cpp_alloc_atomic(img->typeCount)));
         std::memset(img->cctorStarted, 0, img->typeCount);
-        img->cctorFailed = static_cast<Dn2CppObject**>(
-            dn2cpp_alloc(img->typeCount * sizeof(Dn2CppObject*)));
+        dn2cpp_gc_store_ref(&img->cctorFailed, static_cast<Dn2CppObject**>(
+            dn2cpp_alloc(img->typeCount * sizeof(Dn2CppObject*))));
         for (uint32_t t = 0; t < img->typeCount; t++)
         {
             if ((img->types[t].flags & DN2CPP_BPI_TF_HAS_CCTOR) == 0)
@@ -1919,14 +1920,15 @@ Dn2CppInterpImage* dn2cpp_patch_load(const void* blobPtr, size_t len)
         interp_fail("BPI: a field table with no type table");
     if (img->typeCount > 0)
     {
-        img->patchTypes = static_cast<const Dn2CppTypeInfo**>(
-            dn2cpp_alloc(img->typeCount * sizeof(const Dn2CppTypeInfo*)));
+        dn2cpp_gc_store_ref(&img->patchTypes, static_cast<const Dn2CppTypeInfo**>(
+            dn2cpp_alloc(img->typeCount * sizeof(const Dn2CppTypeInfo*))));
         if (img->fieldCount > 0)
         {
-            img->instFieldOffsets = static_cast<uint32_t*>(
-                dn2cpp_alloc_atomic(img->fieldCount * sizeof(uint32_t)));
+            dn2cpp_gc_store_ref(&img->instFieldOffsets, static_cast<uint32_t*>(
+                dn2cpp_alloc_atomic(img->fieldCount * sizeof(uint32_t))));
             std::memset(img->instFieldOffsets, 0, img->fieldCount * sizeof(uint32_t));
-            img->instFieldKinds = static_cast<uint8_t*>(dn2cpp_alloc_atomic(img->fieldCount));
+            dn2cpp_gc_store_ref(&img->instFieldKinds,
+                static_cast<uint8_t*>(dn2cpp_alloc_atomic(img->fieldCount)));
             std::memset(img->instFieldKinds, 0, img->fieldCount);
         }
         for (uint32_t t = 0; t < img->typeCount; t++)
@@ -2021,7 +2023,8 @@ Dn2CppInterpImage* dn2cpp_patch_load(const void* blobPtr, size_t len)
             // Wire the interned Type before the ti is published (loader is
             // single-threaded), so GetType()/typeof on patch types take the
             // same lock-free typeObject path as AOT types.
-            ti->typeObject = dn2cpp_get_type_from_handle_slow(ti);
+            dn2cpp_gc_store_ref(&ti->typeObject,
+                static_cast<const Dn2CppType*>(dn2cpp_get_type_from_handle_slow(ti)));
             if (bt.vtableDescOff != DN2CPP_BPI_REF_NONE)
             {
                 // Vtable overrides: copy the base vtable at the converter-baked
@@ -2190,9 +2193,9 @@ Dn2CppInterpImage* dn2cpp_patch_load(const void* blobPtr, size_t len)
             buf[typeLen] = '.';
             std::memcpy(buf + typeLen + 1, name, nameLen);
             std::memcpy(buf + typeLen + 1 + nameLen, "()", 3);
-            names[i] = buf;
+            dn2cpp_gc_store_ref(&names[i], static_cast<const char*>(buf));
         }
-        img->frameNames = names;
+        dn2cpp_gc_store_ref(&img->frameNames, static_cast<const char* const*>(names));
     }
 
     if (img->typeCount > 0)
@@ -2372,9 +2375,10 @@ static void exc_seed_and_run_base_ctor(const ImportBinding& b, Dn2CppObject* sel
 {
     auto* e = reinterpret_cast<Dn2CppExceptionObject*>(self);
     if (b.excMsgArg >= 0)
-        e->message = reinterpret_cast<Dn2CppString*>(callArgs[b.excMsgArg]);
+        dn2cpp_gc_store_ref(&e->message,
+            reinterpret_cast<Dn2CppString*>(callArgs[b.excMsgArg]));
     if (b.excInnerArg >= 0)
-        e->inner = callArgs[b.excInnerArg];
+        dn2cpp_gc_store_ref(&e->inner, callArgs[b.excInnerArg]);
     // Seed the base COR_E_EXCEPTION default before the base body runs, matching the
     // AOT newobj intercept: a derived ctor's own set_HResult (above this in the
     // chain) then overwrites it with the per-type value. The general newobj that

--- a/runtime/core/dn2cpp_interp.cpp
+++ b/runtime/core/dn2cpp_interp.cpp
@@ -1586,7 +1586,10 @@ void build_patch_itf_map(const Dn2CppInterpImage* img, Dn2CppTypeInfo* ti,
             continue;
         entries[n++] = base->interfaces[bi];
     }
-    ti->interfaces = entries;
+    // The fill loops allocate, so an incremental cycle may blacken `entries`
+    // (and `ti`) mid-build; dirty both at publication.
+    dn2cpp_gc_write_barrier(entries);
+    dn2cpp_gc_store_ref(&ti->interfaces, static_cast<const Dn2CppInterfaceEntry*>(entries));
     ti->interfaceCount = static_cast<int32_t>(n);
 }
 
@@ -1816,8 +1819,9 @@ Dn2CppInterpImage* dn2cpp_patch_load(const void* blobPtr, size_t len)
     // them), then members.
     if (img->importCount > 0)
     {
-        img->bindings = static_cast<ImportBinding*>(
-            dn2cpp_alloc(img->importCount * sizeof(ImportBinding)));
+        // img is old by now (much allocation since its own): barrier the store.
+        dn2cpp_gc_store_ref(&img->bindings, static_cast<ImportBinding*>(
+            dn2cpp_alloc(img->importCount * sizeof(ImportBinding))));
         for (uint32_t i = 0; i < img->importCount; i++)
         {
             if (img->imports[i].kind != DN2CPP_BPI_IMPORT_TYPE)
@@ -1869,7 +1873,8 @@ Dn2CppInterpImage* dn2cpp_patch_load(const void* blobPtr, size_t len)
             interp_fail("BPI: static slot index out of bounds");
     }
     if (staticCount > 0)
-        img->statics = static_cast<Slot*>(dn2cpp_alloc(staticCount * sizeof(Slot)));
+        dn2cpp_gc_store_ref(&img->statics,
+            static_cast<Slot*>(dn2cpp_alloc(staticCount * sizeof(Slot))));
     img->staticCount = staticCount;
 
     // Per-type lazy-cctor guard flags plus the per-type failure slots (the
@@ -2058,7 +2063,9 @@ Dn2CppInterpImage* dn2cpp_patch_load(const void* blobPtr, size_t len)
                                     "(signature shape outside the bridged surface)");
                     vt[slot] = fn;
                 }
-                ti->vtable = vt;
+                // The slot-fill above allocates nothing, but `vt`'s own alloc
+                // may have blackened `ti`; barrier the publish.
+                dn2cpp_gc_store_ref(&ti->vtable, vt);
             }
             // Interface implementations: a type with an ItfDesc run gets an
             // extended interface-dispatch map (base entries plus its own
@@ -2068,7 +2075,7 @@ Dn2CppInterpImage* dn2cpp_patch_load(const void* blobPtr, size_t len)
             // sharing the base's interface map.
             if (bt.itfDescOff != DN2CPP_BPI_REF_NONE)
                 build_patch_itf_map(img, ti, base, bt.itfDescOff);
-            img->patchTypes[t] = ti;
+            dn2cpp_gc_store_ref(&img->patchTypes[t], static_cast<const Dn2CppTypeInfo*>(ti));
         }
     }
 
@@ -2143,8 +2150,10 @@ Dn2CppInterpImage* dn2cpp_patch_load(const void* blobPtr, size_t len)
         ti->flags = DN2CPP_TF_ARRAY | DN2CPP_TF_SEALED;
         ti->elementType = el;
         ti->arrayRank = 1;
-        ti->typeObject = dn2cpp_get_type_from_handle_slow(ti);
-        img->bindings[i].type = ti;
+        // The Type-object alloc may blacken the fresh `ti`; barrier both stores.
+        dn2cpp_gc_store_ref(&ti->typeObject,
+            static_cast<const Dn2CppType*>(dn2cpp_get_type_from_handle_slow(ti)));
+        dn2cpp_gc_store_ref(&img->bindings[i].type, static_cast<const Dn2CppTypeInfo*>(ti));
     }
 
     // A register-format image gets one linear verification scan per method
@@ -2201,7 +2210,7 @@ Dn2CppInterpImage* dn2cpp_patch_load(const void* blobPtr, size_t len)
             dn2cpp_type_registry_add(img->patchTypes[t]->name, img->patchTypes[t]);
     }
 
-    img->nextLoaded = g_loadedImages;
+    dn2cpp_gc_store_ref(&img->nextLoaded, g_loadedImages);
     g_loadedImages = img;
     return img;
 }
@@ -3565,7 +3574,7 @@ ExecResult interp_run(InterpFrame& f, uint32_t pc)
                                     // that cannot answer degrades.
                                     check_patch_delegate_null_this(img, c->methodIdx, dti,
                                         static_cast<Dn2CppObject*>(targetSlot.ref));
-                                    c->boundThis = static_cast<Dn2CppObject*>(targetSlot.ref);
+                                    dn2cpp_gc_store_ref(&c->boundThis, static_cast<Dn2CppObject*>(targetSlot.ref));
                                     const void* thunk = find_dg_thunk(dti);
                                     if (thunk == nullptr)
                                         interp_fail("BPI bind: no delegate thunk (Invoke signature outside the bridged surface)");
@@ -4782,7 +4791,7 @@ ExecResult interp_run_reg(InterpFrame& f, uint32_t pc)
                                     // that cannot answer degrades.
                                     check_patch_delegate_null_this(img, c->methodIdx, dti,
                                         static_cast<Dn2CppObject*>(targetSlot.ref));
-                                    c->boundThis = static_cast<Dn2CppObject*>(targetSlot.ref);
+                                    dn2cpp_gc_store_ref(&c->boundThis, static_cast<Dn2CppObject*>(targetSlot.ref));
                                     const void* thunk = find_dg_thunk(dti);
                                     if (thunk == nullptr)
                                         interp_fail("BPI bind: no delegate thunk (Invoke signature outside the bridged surface)");
@@ -5729,7 +5738,7 @@ int32_t dn2cpp_hotupdate_load_dir(Dn2CppString* dirPath)
         {
             cap *= 2;
             auto* grown = static_cast<Candidate*>(dn2cpp_alloc(cap * sizeof(Candidate)));
-            std::memcpy(grown, cands, count * sizeof(Candidate));
+            dn2cpp_gc_memmove_refs(grown, cands, count * sizeof(Candidate)); // entries carry GC name pointers
             cands = grown;
         }
         char* nameCopy = static_cast<char*>(dn2cpp_alloc_atomic(nameLen + 1));
@@ -5738,6 +5747,8 @@ int32_t dn2cpp_hotupdate_load_dir(Dn2CppString* dirPath)
         cands[count].len = len;
         cands[count].version = reinterpret_cast<const Dn2CppBpiHeader*>(blob)->patchVersion;
         cands[count].name = nameCopy;
+        // The per-entry name alloc may blacken `cands` mid-scan; dirty the entry.
+        dn2cpp_gc_write_barrier(&cands[count]);
         count++;
     }
     closedir(dp);

--- a/runtime/core/dn2cpp_marshal.cpp
+++ b/runtime/core/dn2cpp_marshal.cpp
@@ -900,7 +900,9 @@ Dn2CppArrayN* dn2cpp_pinvoke_byvalarr_out_n(const void* src, int32_t n, int32_t 
 // P/Invoke string[] marshalling. A string[] marshals as an array of
 // NUL-terminated buffer pointers — UTF-8 (default/Ansi) or UTF-16 (CharSet.Unicode) —
 // one per element (a null element -> a null pointer). The pointer array is GC-allocated
-// (Boehm-conservative scanning roots the per-element buffers across the native call); it
+// and roots the per-element buffers across the native call — but only if every fill
+// store is barrier'd: the encode calls allocate, so an incremental cycle can blacken
+// the pointer array mid-fill and unbarriered slots are never rescanned. It
 // is never null even for an empty array, matching real .NET. copyIn != 0 ([In]/[In,Out])
 // encodes each element in; copyIn == 0 ([Out]-only) zeroes the slots (no input read).
 void** dn2cpp_pinvoke_strarr_to_utf8(Dn2CppArrayRef* arr, int32_t copyIn)
@@ -910,9 +912,9 @@ void** dn2cpp_pinvoke_strarr_to_utf8(Dn2CppArrayRef* arr, int32_t copyIn)
     int32_t n = arr->length;
     void** buf = static_cast<void**>(dn2cpp_alloc(static_cast<size_t>(n > 0 ? n : 1) * sizeof(void*)));
     for (int32_t i = 0; i < n; i++)
-        buf[i] = copyIn
+        dn2cpp_gc_store_ref(&buf[i], copyIn
             ? static_cast<void*>(dn2cpp_pinvoke_str_to_utf8(reinterpret_cast<Dn2CppString*>(arr->data[i])))
-            : nullptr;
+            : nullptr);
     return buf;
 }
 
@@ -923,9 +925,9 @@ void** dn2cpp_pinvoke_strarr_to_utf16(Dn2CppArrayRef* arr, int32_t copyIn)
     int32_t n = arr->length;
     void** buf = static_cast<void**>(dn2cpp_alloc(static_cast<size_t>(n > 0 ? n : 1) * sizeof(void*)));
     for (int32_t i = 0; i < n; i++)
-        buf[i] = copyIn
+        dn2cpp_gc_store_ref(&buf[i], copyIn
             ? static_cast<void*>(dn2cpp_pinvoke_str_to_utf16(reinterpret_cast<Dn2CppString*>(arr->data[i])))
-            : nullptr;
+            : nullptr);
     return buf;
 }
 
@@ -938,9 +940,9 @@ void** dn2cpp_pinvoke_strarr_to_ansi(Dn2CppArrayRef* arr, int32_t copyIn)
     int32_t n = arr->length;
     void** buf = static_cast<void**>(dn2cpp_alloc(static_cast<size_t>(n > 0 ? n : 1) * sizeof(void*)));
     for (int32_t i = 0; i < n; i++)
-        buf[i] = copyIn
+        dn2cpp_gc_store_ref(&buf[i], copyIn
             ? static_cast<void*>(dn2cpp_pinvoke_str_to_ansi(reinterpret_cast<Dn2CppString*>(arr->data[i])))
-            : nullptr;
+            : nullptr);
     return buf;
 }
 
@@ -976,10 +978,12 @@ void dn2cpp_pinvoke_strarr_from_utf8(Dn2CppArrayRef* arr, void** buf, void** inb
     for (int32_t i = 0; i < n; i++)
     {
         char* p = static_cast<char*>(buf[i]);
-        arr->data[i] = p == nullptr
-            ? nullptr
+        // The caller's array is old and possibly black; every write-back store
+        // must dirty its slot (the decode allocates on every iteration).
+        dn2cpp_gc_store_ref(&arr->data[i], p == nullptr
+            ? static_cast<Dn2CppObject*>(nullptr)
             : reinterpret_cast<Dn2CppObject*>(
-                  dn2cpp_string_from_utf8(p, static_cast<int32_t>(std::strlen(p))));
+                  dn2cpp_string_from_utf8(p, static_cast<int32_t>(std::strlen(p)))));
         if (p != nullptr && (inbuf == nullptr || p != inbuf[i]))
             std::free(p);
     }
@@ -995,10 +999,11 @@ void dn2cpp_pinvoke_strarr_from_ansi(Dn2CppArrayRef* arr, void** buf, void** inb
     for (int32_t i = 0; i < n; i++)
     {
         char* p = static_cast<char*>(buf[i]);
-        arr->data[i] = p == nullptr
-            ? nullptr
+        // See _from_utf8: the write-back store must dirty its slot.
+        dn2cpp_gc_store_ref(&arr->data[i], p == nullptr
+            ? static_cast<Dn2CppObject*>(nullptr)
             : reinterpret_cast<Dn2CppObject*>(
-                  dn2cpp_string_from_ansi(p, static_cast<int32_t>(std::strlen(p))));
+                  dn2cpp_string_from_ansi(p, static_cast<int32_t>(std::strlen(p)))));
         if (p != nullptr && (inbuf == nullptr || p != inbuf[i]))
             std::free(p);
     }
@@ -1020,7 +1025,9 @@ void dn2cpp_pinvoke_strarr_from_utf16(Dn2CppArrayRef* arr, void** buf, void** in
         int32_t len = 0;
         while (p[len] != u'\0')
             len++;
-        arr->data[i] = reinterpret_cast<Dn2CppObject*>(dn2cpp_string_from_chars(p, len));
+        // See _from_utf8: the write-back store must dirty its slot.
+        dn2cpp_gc_store_ref(&arr->data[i],
+            reinterpret_cast<Dn2CppObject*>(dn2cpp_string_from_chars(p, len)));
         if (inbuf == nullptr || p != inbuf[i])
             std::free(p);
     }

--- a/runtime/core/dn2cpp_tasks.cpp
+++ b/runtime/core/dn2cpp_tasks.cpp
@@ -556,7 +556,7 @@ static void dn2cpp_pending_timer_link(Dn2CppTimer* e)
 {
     std::lock_guard<std::mutex> lk(g_sched_pending_mtx);
     e->gcprev = nullptr;
-    e->gcnext = g_pending_timers;
+    dn2cpp_gc_store_ref(&e->gcnext, g_pending_timers);
     if (g_pending_timers != nullptr)
         dn2cpp_gc_store_ref(&g_pending_timers->gcprev, e);
     g_pending_timers = e;
@@ -805,12 +805,12 @@ static Dn2CppTask* dn2cpp_task_when_all_impl(Dn2CppArrayRef* tasks, int32_t kind
             dn2cpp_throw_argument();
     }
     auto* s = static_cast<Dn2CppWhenAllState*>(dn2cpp_alloc(sizeof(Dn2CppWhenAllState)));
-    s->result = dn2cpp_task_alloc();
-    s->tasks = tasks;
+    dn2cpp_gc_store_ref(&s->result, dn2cpp_task_alloc());
+    dn2cpp_gc_store_ref(&s->tasks, tasks);
     s->remaining = tasks->length;
     s->kind = kind;
     s->elemSize = elemSize;
-    s->arrTi = arrTi;
+    dn2cpp_gc_store_ref(&s->arrTi, arrTi);
     if (tasks->length == 0)
     {
         dn2cpp_when_all_finish(s); // no inputs: already done (empty array)
@@ -889,7 +889,7 @@ Dn2CppTask* dn2cpp_task_when_any(Dn2CppArrayRef* tasks)
             dn2cpp_throw_argument_null();
     }
     auto* s = static_cast<Dn2CppWhenAnyState*>(dn2cpp_alloc(sizeof(Dn2CppWhenAnyState)));
-    s->result = dn2cpp_task_alloc();
+    dn2cpp_gc_store_ref(&s->result, dn2cpp_task_alloc());
     s->done = 0;
     for (int32_t i = 0; i < tasks->length; i++)
     {
@@ -1021,8 +1021,8 @@ static Dn2CppObject* dn2cpp_make_canceled_exception_of(const Dn2CppTypeInfo* ti,
     o->type = ti;
     // The default message real .NET's parameterless ctor bakes in — observable
     // through Message and through the AggregateException a blocking wait wraps.
-    reinterpret_cast<Dn2CppExceptionObject*>(o)->message =
-        dn2cpp_string_from_utf8(msg, static_cast<int32_t>(std::strlen(msg)));
+    dn2cpp_gc_store_ref(&reinterpret_cast<Dn2CppExceptionObject*>(o)->message,
+        dn2cpp_string_from_utf8(msg, static_cast<int32_t>(std::strlen(msg))));
     return o;
 }
 
@@ -1059,7 +1059,7 @@ static void dn2cpp_task_set_canceled(Dn2CppTask* t)
 Dn2CppTask* dn2cpp_task_from_canceled()
 {
     auto* t = dn2cpp_task_alloc();
-    t->exception = dn2cpp_make_task_canceled_exception();
+    dn2cpp_gc_store_ref(&t->exception, dn2cpp_make_task_canceled_exception());
     t->status = DN2CPP_TASK_CANCELED;
     return t;
 }
@@ -1260,7 +1260,7 @@ static void dn2cpp_cts_link_one(Dn2CppCancelSource* child, Dn2CppCancelSource* p
         std::lock_guard<std::mutex> lk(g_cts_mtx);
         if (!parent->canceled)
         {
-            r->next = parent->regs;
+            dn2cpp_gc_store_ref(&r->next, parent->regs);
             dn2cpp_gc_store_ref(&parent->regs, r);
             return;
         }
@@ -1349,7 +1349,7 @@ Dn2CppCancelReg* dn2cpp_cts_register(Dn2CppCancelSource* src, Dn2CppObject* call
         std::lock_guard<std::mutex> lk(g_cts_mtx);
         if (!src->canceled)
         {
-            r->next = src->regs;
+            dn2cpp_gc_store_ref(&r->next, src->regs);
             dn2cpp_gc_store_ref(&src->regs, r);
             return r;
         }
@@ -1382,7 +1382,7 @@ Dn2CppCancelReg* dn2cpp_cts_register_state(Dn2CppCancelSource* src, Dn2CppObject
         std::lock_guard<std::mutex> lk(g_cts_mtx);
         if (!src->canceled)
         {
-            r->next = src->regs;
+            dn2cpp_gc_store_ref(&r->next, src->regs);
             dn2cpp_gc_store_ref(&src->regs, r);
             return r;
         }
@@ -1431,7 +1431,7 @@ Dn2CppCancelReg* dn2cpp_cts_register_state_token(Dn2CppCancelSource* src, Dn2Cpp
         std::lock_guard<std::mutex> lk(g_cts_mtx);
         if (!src->canceled)
         {
-            r->next = src->regs;
+            dn2cpp_gc_store_ref(&r->next, src->regs);
             dn2cpp_gc_store_ref(&src->regs, r);
             return r;
         }
@@ -1697,7 +1697,7 @@ Dn2CppTask* dn2cpp_task_delay_ct(int64_t ms, Dn2CppCancelSource* src)
             raced = src->canceled != 0;  // a Cancel() between the check above and here
             if (!raced)
             {
-                r->next = src->regs;
+                dn2cpp_gc_store_ref(&r->next, src->regs);
                 dn2cpp_gc_store_ref(&src->regs, r);
             }
         }
@@ -2278,7 +2278,7 @@ static void dn2cpp_thread_materialize_current(int32_t managedId)
     node->t = t;
     {
         std::lock_guard<std::mutex> lk(g_materialized_mtx);
-        node->next = g_materialized_threads;
+        dn2cpp_gc_store_ref(&node->next, g_materialized_threads);
         g_materialized_threads = node;
     }
     g_current_thread = t;
@@ -2368,7 +2368,7 @@ static DN2CPP_GC_STATIC_ROOT Dn2CppPoolNode* g_pool_pending = nullptr; // static
 // graph is rooted before any worker can pop it.
 static void dn2cpp_pool_link(Dn2CppPoolNode* node)
 {
-    node->next = g_pool_pending;
+    dn2cpp_gc_store_ref(&node->next, g_pool_pending);
     g_pool_pending = node;
 }
 
@@ -3058,7 +3058,7 @@ Dn2CppTask* dn2cpp_task_wait_async(Dn2CppTask* t, Dn2CppCancelSource* src)
                 raced = src->canceled != 0;  // a Cancel() between the poll above and here
                 if (!raced)
                 {
-                    r->next = src->regs;
+                    dn2cpp_gc_store_ref(&r->next, src->regs);
                     dn2cpp_gc_store_ref(&src->regs, r);
                 }
             }
@@ -3271,7 +3271,7 @@ Dn2CppTask* dn2cpp_vts_task(Dn2CppObject* vts, int16_t version,
     auto* b = static_cast<Dn2CppVtsBridge*>(dn2cpp_alloc(sizeof(Dn2CppVtsBridge)));
     b->header.type = &dn2cpp_vts_bridge_type;
     b->vts = vts;
-    b->task = dn2cpp_task_alloc();
+    dn2cpp_gc_store_ref(&b->task, dn2cpp_task_alloc());
     b->getResultFn = getResultFn;
     b->version = version;
     b->resultKind = resultKind;

--- a/runtime/core/dn2cpp_tasks.cpp
+++ b/runtime/core/dn2cpp_tasks.cpp
@@ -324,7 +324,7 @@ static void dn2cpp_pending_cont_link(Dn2CppCont* c)
 {
     std::lock_guard<std::mutex> lk(g_sched_pending_mtx);
     c->gcprev = nullptr;
-    c->gcnext = g_pending_conts;
+    dn2cpp_gc_store_ref(&c->gcnext, g_pending_conts);
     if (g_pending_conts != nullptr)
         dn2cpp_gc_store_ref(&g_pending_conts->gcprev, c);
     g_pending_conts = c;
@@ -462,7 +462,7 @@ static bool dn2cpp_task_try_queue_cont(Dn2CppTask* t, void (*fn)(void*), void* s
     std::lock_guard<std::mutex> lk(g_task_mtx);
     if (t->status != DN2CPP_TASK_PENDING)
         return false;
-    c->next = t->continuations;
+    dn2cpp_gc_store_ref(&c->next, t->continuations);
     dn2cpp_gc_store_ref(&t->continuations, c);
     return true;
 }
@@ -2195,7 +2195,7 @@ void dn2cpp_thread_start(Dn2CppThread* t)
 
 void dn2cpp_thread_start_param(Dn2CppThread* t, Dn2CppObject* arg)
 {
-    t->arg = arg;
+    dn2cpp_gc_store_ref(&t->arg, arg);
     t->sync = new Dn2CppThreadSync();
     dn2cpp_thread_spawn(t, true);
 }
@@ -2379,6 +2379,7 @@ static void dn2cpp_pool_unlink_locked(Dn2CppPoolNode* node)
         if (*pp == node)
         {
             *pp = node->next;
+            dn2cpp_gc_write_barrier_if_heap(pp); // pp may name the static head
             node->next = nullptr;
             break;
         }

--- a/runtime/core/dn2cpp_threading.cpp
+++ b/runtime/core/dn2cpp_threading.cpp
@@ -325,8 +325,11 @@ static void dn2cpp_parallel_run(int64_t count, void* ctx, void (*fn)(void*, int6
                 ExcNode** pp = &excHead;
                 while (*pp != nullptr && (*pp)->index < i)
                     pp = &(*pp)->next;
-                node->next = *pp;
+                // The chain mixes a stack head with heap nodes, and allocation
+                // happens while it exists — barrier both linking stores.
+                dn2cpp_gc_store_ref(&node->next, *pp);
                 *pp = node;
+                dn2cpp_gc_write_barrier_if_heap(pp);
                 excCount++;
             }
         }

--- a/runtime/core/dn2cpp_threading.cpp
+++ b/runtime/core/dn2cpp_threading.cpp
@@ -941,10 +941,12 @@ int32_t dn2cpp_event_wait_any(Dn2CppArrayRef* handles)
 }
 
 // ===== CountdownEvent / Barrier =============================================
-// Counter-based synchronization primitives, modeled like the semaphore/event above:
-// native-allocated (so the std::mutex/condition_variable get real ctors) with a managed
-// type header, built at newobj (the real handle-allocating ctors are skipped). They live
-// for the program (a small, bounded leak, like monitors).
+// Counter-based synchronization primitives, modeled like the semaphore/event above,
+// with a managed type header, built at newobj (the real handle-allocating ctors are
+// skipped). They live for the program (a small, bounded leak, like monitors).
+// CountdownEvent holds only ints, so it is native-allocated; Barrier holds a managed
+// reference (postPhase), so it must be GC-allocated like Timer — the collector never
+// scans native-heap words — with placement new constructing the mutex/cv in place.
 // Both are non-const and externally visible for the same reason dn2cpp_timer_type is:
 // the generated init prologue installs their IDisposable dispatch row, whose
 // entry names program-specific emitted type-info the runtime cannot spell.
@@ -1086,12 +1088,13 @@ struct Dn2CppBarrier : Dn2CppObject
 
 Dn2CppObject* dn2cpp_barrier_new(int32_t participantCount, Dn2CppObject* postPhaseAction)
 {
-    auto* b = new Dn2CppBarrier();
+    auto* raw = dn2cpp_alloc(sizeof(Dn2CppBarrier)); // GC-allocated: postPhase must be scanned
+    auto* b = new (raw) Dn2CppBarrier();
     b->type = &dn2cpp_barrier_type;
     b->total = participantCount;
     b->waiting = 0;
     b->phase = 0;
-    b->postPhase = postPhaseAction;
+    dn2cpp_gc_store_ref(&b->postPhase, postPhaseAction);
     return b;
 }
 

--- a/runtime/core/dn2cpp_typeinfo.cpp
+++ b/runtime/core/dn2cpp_typeinfo.cpp
@@ -693,7 +693,7 @@ void dn2cpp_type_registry_add(const char* name, const Dn2CppTypeInfo* type)
     auto* e = static_cast<Dn2CppDynTypeReg*>(dn2cpp_alloc(sizeof(Dn2CppDynTypeReg)));
     e->name = name;
     e->type = type;
-    e->next = g_dyn_type_registry;
+    dn2cpp_gc_store_ref(&e->next, g_dyn_type_registry);
     g_dyn_type_registry = e;
 }
 

--- a/runtime/core/intrinsics/dn2cpp_system_array.cpp
+++ b/runtime/core/intrinsics/dn2cpp_system_array.cpp
@@ -205,12 +205,14 @@ void dn2cpp_array_sort_object(Dn2CppObject* arr, int32_t index, int32_t length,
     if (length <= 1)
         return;
     // Box the [index, index+length) window into a managed (GC-scanned) ref buffer, so the boxes
-    // survive a collection a comparison may trigger; buf itself is stack-rooted here. Sort the
-    // buffer with the proven ref primitive, then write the permutation back — dn2cpp_array_set_value
+    // survive a collection a comparison may trigger. A stack root keeps `buf` itself alive but
+    // not its contents once an incremental cycle blackens it mid-fill — the boxing loop
+    // allocates each iteration, so every store is barrier'd. Sort the buffer with the proven
+    // ref primitive, then write the permutation back — dn2cpp_array_set_value
     // applies real .NET's SetValue coercion (unbox to the element's stored rep, widening/exactness).
     Dn2CppArrayRef* buf = dn2cpp_newarr_ref(length);
     for (int32_t i = 0; i < length; i++)
-        buf->data[i] = dn2cpp_array_get_value(arr, static_cast<int64_t>(index + i));
+        dn2cpp_gc_store_ref(&buf->data[i], dn2cpp_array_get_value(arr, static_cast<int64_t>(index + i)));
     Dn2CppBoxedOrderCtx ctx{ icomparable_ti, comparer, icomparer_ti, comparer_slot };
     dn2cpp_array_sort_cmp_ref(buf, 0, length, &ctx, &dn2cpp_boxed_order);
     for (int32_t i = 0; i < length; i++)

--- a/runtime/core/intrinsics/dn2cpp_system_collections_concurrent.cpp
+++ b/runtime/core/intrinsics/dn2cpp_system_collections_concurrent.cpp
@@ -68,13 +68,15 @@ static void dn2cpp_blockingcoll_enqueue_locked(Dn2CppBlockingCollection* c, Dn2C
 {
     auto* node = static_cast<Dn2CppBlockingNode*>(dn2cpp_alloc(sizeof(Dn2CppBlockingNode)));
     node->type = &dn2cpp_blockingnode_type;
-    node->value = boxedOrRef;
+    dn2cpp_gc_store_ref(&node->value, boxedOrRef);
     node->next = nullptr;
+    // The collection and the old tail are old and possibly black, and they live
+    // in different blocks — each linking store must dirty its own slot.
     if (c->tail != nullptr)
-        c->tail->next = node;
+        dn2cpp_gc_store_ref(&c->tail->next, node);
     else
-        c->head = node;
-    c->tail = node;
+        dn2cpp_gc_store_ref(&c->head, node);
+    dn2cpp_gc_store_ref(&c->tail, node);
     c->ctl->count++;
 }
 

--- a/runtime/core/intrinsics/dn2cpp_system_datetime.cpp
+++ b/runtime/core/intrinsics/dn2cpp_system_datetime.cpp
@@ -395,18 +395,20 @@ Dn2CppArrayRef* dn2cpp_dtfi_invariant_abbrev_month_names(const Dn2CppTypeInfo* a
     static const char* const names[13] = {
         "Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec",""};
     Dn2CppArrayRef* a = dn2cpp_newarr_ref_t(13, arrType);
+    // The string alloc may blacken `a` mid-loop; barrier each store.
     for (int32_t i = 0; i < 13; i++)
-        a->data[i] = reinterpret_cast<Dn2CppObject*>(
-            dn2cpp_string_from_utf8(names[i], static_cast<int32_t>(std::strlen(names[i]))));
+        dn2cpp_gc_store_ref(&a->data[i], reinterpret_cast<Dn2CppObject*>(
+            dn2cpp_string_from_utf8(names[i], static_cast<int32_t>(std::strlen(names[i])))));
     return a;
 }
 Dn2CppArrayRef* dn2cpp_dtfi_invariant_abbrev_day_names(const Dn2CppTypeInfo* arrType)
 {
     static const char* const names[7] = {"Sun","Mon","Tue","Wed","Thu","Fri","Sat"};
     Dn2CppArrayRef* a = dn2cpp_newarr_ref_t(7, arrType);
+    // The string alloc may blacken `a` mid-loop; barrier each store.
     for (int32_t i = 0; i < 7; i++)
-        a->data[i] = reinterpret_cast<Dn2CppObject*>(
-            dn2cpp_string_from_utf8(names[i], static_cast<int32_t>(std::strlen(names[i]))));
+        dn2cpp_gc_store_ref(&a->data[i], reinterpret_cast<Dn2CppObject*>(
+            dn2cpp_string_from_utf8(names[i], static_cast<int32_t>(std::strlen(names[i])))));
     return a;
 }
 

--- a/runtime/core/intrinsics/dn2cpp_system_globalization.cpp
+++ b/runtime/core/intrinsics/dn2cpp_system_globalization.cpp
@@ -203,7 +203,7 @@ static const Dn2CppNumberFormatInfo* dn2cpp_culture_intern(const Dn2CppCultureRo
     auto* node = static_cast<Dn2CppCultureCacheNode*>(dn2cpp_alloc(sizeof(Dn2CppCultureCacheNode)));
     node->nfi = *dn2cpp_nfi_invariant();
     node->row = row;
-    node->next = g_cultureCache;
+    dn2cpp_gc_store_ref(&node->next, g_cultureCache);
     g_cultureCache = node;
     if (row == nullptr)
     {
@@ -474,7 +474,7 @@ Dn2CppObject* dn2cpp_nfi_wrap(const Dn2CppNumberFormatInfo* n, int32_t kind)
     auto* node = static_cast<Dn2CppNfiBoxNode*>(dn2cpp_alloc(sizeof(Dn2CppNfiBoxNode)));
     node->box.type = ti;
     node->box.nfi = n;
-    node->next = g_nfiBoxes;
+    dn2cpp_gc_store_ref(&node->next, g_nfiBoxes);
     g_nfiBoxes = node;
     return &node->box;
 }

--- a/runtime/core/intrinsics/dn2cpp_system_globalization.cpp
+++ b/runtime/core/intrinsics/dn2cpp_system_globalization.cpp
@@ -196,10 +196,10 @@ static const Dn2CppNumberFormatInfo* dn2cpp_culture_intern(const Dn2CppCultureRo
                            : (p->row == nullptr && dn2cpp_string_equals(p->nfi.cultureName, name)))
             return &p->nfi;
     }
-    // Allocate and LINK first, then fill: once linked, the node is reachable
-    // from a scanned static slot, so every string allocated below is rooted the
-    // instant it is stored rather than resting on the conservative stack scan.
-    // The invariant copy keeps every field valid meanwhile.
+    // Allocate and LINK first, then fill; the invariant copy keeps every field
+    // valid meanwhile. Linking makes the node reachable for a full collection,
+    // but under incremental GC it also lets a cycle blacken the node mid-fill —
+    // a store of a non-static-rooted value into it must be barrier'd.
     auto* node = static_cast<Dn2CppCultureCacheNode*>(dn2cpp_alloc(sizeof(Dn2CppCultureCacheNode)));
     node->nfi = *dn2cpp_nfi_invariant();
     node->row = row;
@@ -211,7 +211,7 @@ static const Dn2CppNumberFormatInfo* dn2cpp_culture_intern(const Dn2CppCultureRo
         // callers that key behavior on the name (e.g. RegexCaseEquivalences'
         // Turkish/NonTurkish tiering) stay faithful, and the LCID says "this
         // culture has none" rather than claiming to be the invariant one.
-        node->nfi.cultureName = name;
+        dn2cpp_gc_store_ref(&node->nfi.cultureName, name); // `name` is only stack-rooted
         node->nfi.lcid = 4096;
         return &node->nfi;
     }
@@ -479,14 +479,16 @@ Dn2CppObject* dn2cpp_nfi_wrap(const Dn2CppNumberFormatInfo* n, int32_t kind)
     return &node->box;
 }
 
-void dn2cpp_nfi_set_number_decimal(Dn2CppNumberFormatInfo* n, Dn2CppString* v) { n->numberDecimal = v; }
-void dn2cpp_nfi_set_number_group(Dn2CppNumberFormatInfo* n, Dn2CppString* v) { n->numberGroup = v; }
-void dn2cpp_nfi_set_negative_sign(Dn2CppNumberFormatInfo* n, Dn2CppString* v) { n->negativeSign = v; }
-void dn2cpp_nfi_set_nan(Dn2CppNumberFormatInfo* n, Dn2CppString* v) { n->nan = v; }
-void dn2cpp_nfi_set_pos_inf(Dn2CppNumberFormatInfo* n, Dn2CppString* v) { n->posInf = v; }
-void dn2cpp_nfi_set_neg_inf(Dn2CppNumberFormatInfo* n, Dn2CppString* v) { n->negInf = v; }
-void dn2cpp_nfi_set_percent_symbol(Dn2CppNumberFormatInfo* n, Dn2CppString* v) { n->percentSymbol = v; }
-void dn2cpp_nfi_set_currency_symbol(Dn2CppNumberFormatInfo* n, Dn2CppString* v) { n->currencySymbol = v; }
+// The NFI lives in an old, possibly black cache node: each setter store must
+// dirty its slot for the incremental cycle.
+void dn2cpp_nfi_set_number_decimal(Dn2CppNumberFormatInfo* n, Dn2CppString* v) { dn2cpp_gc_store_ref(&n->numberDecimal, v); }
+void dn2cpp_nfi_set_number_group(Dn2CppNumberFormatInfo* n, Dn2CppString* v) { dn2cpp_gc_store_ref(&n->numberGroup, v); }
+void dn2cpp_nfi_set_negative_sign(Dn2CppNumberFormatInfo* n, Dn2CppString* v) { dn2cpp_gc_store_ref(&n->negativeSign, v); }
+void dn2cpp_nfi_set_nan(Dn2CppNumberFormatInfo* n, Dn2CppString* v) { dn2cpp_gc_store_ref(&n->nan, v); }
+void dn2cpp_nfi_set_pos_inf(Dn2CppNumberFormatInfo* n, Dn2CppString* v) { dn2cpp_gc_store_ref(&n->posInf, v); }
+void dn2cpp_nfi_set_neg_inf(Dn2CppNumberFormatInfo* n, Dn2CppString* v) { dn2cpp_gc_store_ref(&n->negInf, v); }
+void dn2cpp_nfi_set_percent_symbol(Dn2CppNumberFormatInfo* n, Dn2CppString* v) { dn2cpp_gc_store_ref(&n->percentSymbol, v); }
+void dn2cpp_nfi_set_currency_symbol(Dn2CppNumberFormatInfo* n, Dn2CppString* v) { dn2cpp_gc_store_ref(&n->currencySymbol, v); }
 
 // NumberGroupSizes / CurrencyGroupSizes / PercentGroupSizes — the getter. A
 // fresh array per call, matching real .NET's defensive copy: two reads are not

--- a/runtime/core/intrinsics/dn2cpp_system_reflection.cpp
+++ b/runtime/core/intrinsics/dn2cpp_system_reflection.cpp
@@ -428,8 +428,9 @@ Dn2CppArrayRef* dn2cpp_enum_get_values_boxed(Dn2CppType* t)
     const Dn2CppTypeInfo* ti = t->typeInfo;
     int32_t n = ti->enumMemberCount;
     Dn2CppArrayRef* arr = dn2cpp_newarr_ref(n);
+    // The box alloc may blacken `arr` mid-loop; barrier each store.
     for (int32_t i = 0; i < n; i++)
-        arr->data[i] = dn2cpp_enum_box(ti, ti->enumMembers[i].value);
+        dn2cpp_gc_store_ref(&arr->data[i], dn2cpp_enum_box(ti, ti->enumMembers[i].value));
     return arr;
 }
 
@@ -2875,9 +2876,10 @@ static Dn2CppArrayRef* dn2cpp_attr_table_to_array(const Dn2CppAttrInfo* tab, int
         if (const Dn2CppTypeInfo* arrTi = dn2cpp_find_array_ti(filter))
             reinterpret_cast<Dn2CppObject*>(arr)->type = arrTi;
     int32_t k = 0;
+    // create() allocates and may blacken `arr` mid-loop; barrier each store.
     for (int32_t i = 0; i < count; i++)
         if (filter == nullptr || dn2cpp_type_is_a(tab[i].attrType, filter))
-            arr->data[k++] = tab[i].create();
+            dn2cpp_gc_store_ref(&arr->data[k++], tab[i].create());
     return arr;
 }
 
@@ -3262,9 +3264,10 @@ Dn2CppArrayRef* dn2cpp_assembly_get_manifest_resource_names(const char* name)
         std::fprintf(stderr, "DN2CPP_MANIFEST_TRACE names asm=%s -> %d\n",
             (e != nullptr && e->name != nullptr) ? e->name : "<unregistered>", n);
     Dn2CppArrayRef* arr = dn2cpp_newarr_ref(n);
+    // The string alloc may blacken `arr` mid-loop; barrier each store.
     for (int32_t i = 0; i < n; i++)
-        arr->data[i] = reinterpret_cast<Dn2CppObject*>(dn2cpp_string_from_utf8(
-            e->resources[i].name, static_cast<int32_t>(std::strlen(e->resources[i].name))));
+        dn2cpp_gc_store_ref(&arr->data[i], reinterpret_cast<Dn2CppObject*>(dn2cpp_string_from_utf8(
+            e->resources[i].name, static_cast<int32_t>(std::strlen(e->resources[i].name)))));
     return arr;
 }
 
@@ -3494,7 +3497,8 @@ static Dn2CppArrayRef* dn2cpp_attr_table_to_data_array(const Dn2CppAttrInfo* tab
         auto* d = static_cast<Dn2CppAttrDataRef*>(dn2cpp_alloc(sizeof(Dn2CppAttrDataRef)));
         d->type = &dn2cpp_customattributedata_type;
         d->attr = &tab[i];
-        arr->data[i] = reinterpret_cast<Dn2CppObject*>(d);
+        // The wrapper alloc may blacken `arr` mid-loop; barrier each store.
+        dn2cpp_gc_store_ref(&arr->data[i], reinterpret_cast<Dn2CppObject*>(d));
     }
     return arr;
 }
@@ -3978,9 +3982,10 @@ Dn2CppArrayRef* dn2cpp_methodref_get_parameter_types(Dn2CppMethodRef* m)
 {
     int32_t n = dn2cpp_methodref_require(m)->paramCount;
     Dn2CppArrayRef* arr = dn2cpp_newarr_ref(n);
+    // A fabricated Type alloc may blacken `arr` mid-loop; barrier each store.
     for (int32_t i = 0; i < n; i++)
-        arr->data[i] = reinterpret_cast<Dn2CppObject*>(
-            dn2cpp_get_type_from_handle(m->method->parameters[i].paramType));
+        dn2cpp_gc_store_ref(&arr->data[i], reinterpret_cast<Dn2CppObject*>(
+            dn2cpp_get_type_from_handle(m->method->parameters[i].paramType)));
     return arr;
 }
 

--- a/runtime/core/intrinsics/dn2cpp_system_reflection.cpp
+++ b/runtime/core/intrinsics/dn2cpp_system_reflection.cpp
@@ -410,9 +410,9 @@ Dn2CppArrayRef* dn2cpp_enum_get_names(Dn2CppType* t)
     int32_t n = ti->enumMemberCount;
     Dn2CppArrayRef* arr = dn2cpp_newarr_ref(n);
     for (int32_t i = 0; i < n; i++)
-        arr->data[i] = reinterpret_cast<Dn2CppObject*>(
+        dn2cpp_gc_store_ref(&arr->data[i], reinterpret_cast<Dn2CppObject*>(
             dn2cpp_string_from_utf8(ti->enumMembers[i].name,
-                static_cast<int32_t>(std::strlen(ti->enumMembers[i].name))));
+                static_cast<int32_t>(std::strlen(ti->enumMembers[i].name)))));
     return arr;
 }
 
@@ -1730,7 +1730,7 @@ static const Dn2CppMethodInfo* dn2cpp_meta_row(const Dn2CppMetaMember* d,
             r->args[i] = args[i];
         r->row.genericArgs = r->args;
     }
-    r->next = g_meta_rows;
+    dn2cpp_gc_store_ref(&r->next, g_meta_rows);
     g_meta_rows = r;
     return &r->row;
 }
@@ -1871,7 +1871,7 @@ Dn2CppArrayRef* dn2cpp_methodref_get_parameters(Dn2CppMethodRef* m)
         p->position = i;
         p->owner = m->method;
         p->ownerReflected = m->reflectedType;
-        arr->data[i] = reinterpret_cast<Dn2CppObject*>(p);
+        dn2cpp_gc_store_ref(&arr->data[i], reinterpret_cast<Dn2CppObject*>(p));
     }
     return arr;
 }
@@ -2506,7 +2506,7 @@ Dn2CppArrayRef* dn2cpp_propref_get_index_parameters(Dn2CppPropRef* p)
         pr->position = i;
         pr->owner = acc;
         pr->ownerReflected = p->reflectedType;
-        arr->data[i] = reinterpret_cast<Dn2CppObject*>(pr);
+        dn2cpp_gc_store_ref(&arr->data[i], reinterpret_cast<Dn2CppObject*>(pr));
     }
     return arr;
 }
@@ -3128,7 +3128,7 @@ Dn2CppObject* dn2cpp_asm_wrap(const char* h, int32_t kind)
     auto* node = static_cast<Dn2CppAsmBoxNode*>(dn2cpp_alloc(sizeof(Dn2CppAsmBoxNode)));
     node->box.type = ti;
     node->box.name = h;
-    node->next = g_asmBoxes;
+    dn2cpp_gc_store_ref(&node->next, g_asmBoxes);
     g_asmBoxes = node;
     return &node->box;
 }

--- a/runtime/core/intrinsics/dn2cpp_system_string.cpp
+++ b/runtime/core/intrinsics/dn2cpp_system_string.cpp
@@ -1043,8 +1043,8 @@ Dn2CppArrayRef* dn2cpp_str_split(Dn2CppString* s, const char16_t* sepChars, int3
             if (!removeEmpty || segEnd > segStart)
             {
                 if (out != nullptr)
-                    out->data[kept] = reinterpret_cast<Dn2CppObject*>(
-                        dn2cpp_str_substring(s, segStart, segEnd - segStart));
+                    dn2cpp_gc_store_ref(&out->data[kept], reinterpret_cast<Dn2CppObject*>(
+                        dn2cpp_str_substring(s, segStart, segEnd - segStart)));
                 kept++;
             }
             if (kept == count - 1)
@@ -1075,8 +1075,8 @@ Dn2CppArrayRef* dn2cpp_str_split(Dn2CppString* s, const char16_t* sepChars, int3
         if (!removeEmpty || lastEnd > lastStart)
         {
             if (out != nullptr)
-                out->data[kept] = reinterpret_cast<Dn2CppObject*>(
-                    dn2cpp_str_substring(s, lastStart, lastEnd - lastStart));
+                dn2cpp_gc_store_ref(&out->data[kept], reinterpret_cast<Dn2CppObject*>(
+                    dn2cpp_str_substring(s, lastStart, lastEnd - lastStart)));
             kept++;
         }
         return kept;
@@ -1951,7 +1951,8 @@ Dn2CppArrayRef* dn2cpp_array_clone_ref(Dn2CppArrayRef* src)
     if (src == nullptr)
         dn2cpp_throw_null_reference();
     Dn2CppArrayRef* dst = dn2cpp_newarr_ref_t(src->length, src->type);
-    std::memcpy(dst->data, src->data, static_cast<size_t>(src->length) * sizeof(Dn2CppObject*));
+    dn2cpp_gc_memmove_refs(dst->data, src->data,
+        static_cast<size_t>(src->length) * sizeof(Dn2CppObject*));
     return dst;
 }
 
@@ -1960,7 +1961,8 @@ Dn2CppArrayN* dn2cpp_array_clone_n(Dn2CppArrayN* src)
     if (src == nullptr)
         dn2cpp_throw_null_reference();
     Dn2CppArrayN* dst = dn2cpp_newarr_n_t(src->length, src->elemSize, src->type);
-    std::memcpy(dst->data, src->data, static_cast<size_t>(src->length) * static_cast<size_t>(src->elemSize));
+    dn2cpp_gc_memmove_refs(dst->data, src->data,
+        static_cast<size_t>(src->length) * static_cast<size_t>(src->elemSize));
     return dst;
 }
 
@@ -2184,7 +2186,8 @@ Dn2CppArrayRef* dn2cpp_array_subarray_ref(Dn2CppArrayRef* src, int32_t offset, i
         dn2cpp_throw_argument_null(); // catchable, matching ThrowHelper.ThrowArgumentNullException
     Dn2CppArrayRef* dst = dn2cpp_newarr_ref_t(length, src->type);
     if (length > 0)
-        std::memcpy(dst->data, src->data + offset, static_cast<size_t>(length) * sizeof(Dn2CppObject*));
+        dn2cpp_gc_memmove_refs(dst->data, src->data + offset,
+            static_cast<size_t>(length) * sizeof(Dn2CppObject*));
     return dst;
 }
 
@@ -2194,8 +2197,9 @@ Dn2CppArrayN* dn2cpp_array_subarray_n(Dn2CppArrayN* src, int32_t offset, int32_t
         dn2cpp_throw_argument_null(); // catchable, matching ThrowHelper.ThrowArgumentNullException
     Dn2CppArrayN* dst = dn2cpp_newarr_n_t(length, src->elemSize, src->type);
     if (length > 0)
-        std::memcpy(dst->data, src->data + static_cast<size_t>(offset) * src->elemSize,
-                    static_cast<size_t>(length) * static_cast<size_t>(src->elemSize));
+        dn2cpp_gc_memmove_refs(dst->data,
+            src->data + static_cast<size_t>(offset) * src->elemSize,
+            static_cast<size_t>(length) * static_cast<size_t>(src->elemSize));
     return dst;
 }
 
@@ -2222,8 +2226,8 @@ Dn2CppArrayRef* dn2cpp_argv_to_string_array(int argc, char** argv, const Dn2CppT
     for (int32_t i = 0; i < n; i++)
     {
         const char* s = argv[i + 1];
-        arr->data[i] = reinterpret_cast<Dn2CppObject*>(
-            dn2cpp_string_from_utf8(s, static_cast<int32_t>(std::strlen(s))));
+        dn2cpp_gc_store_ref(&arr->data[i], reinterpret_cast<Dn2CppObject*>(
+            dn2cpp_string_from_utf8(s, static_cast<int32_t>(std::strlen(s)))));
     }
     return arr;
 }

--- a/runtime/core/intrinsics/dn2cpp_system_string.cpp
+++ b/runtime/core/intrinsics/dn2cpp_system_string.cpp
@@ -2000,7 +2000,8 @@ Dn2CppObject* dn2cpp_array_clone_dyn(Dn2CppObject* src)
             dst->lowerBounds[i] = mdSrc->lowerBounds[i]; // newmdarr zeroes them; a clone keeps the source's
             total *= mdSrc->lengths[i];
         }
-        std::memcpy(dst->data, mdSrc->data, static_cast<size_t>(total) * static_cast<size_t>(mdSrc->elemSize));
+        dn2cpp_gc_memmove_refs(dst->data, mdSrc->data,
+            static_cast<size_t>(total) * static_cast<size_t>(mdSrc->elemSize));
         return dst;
     }
     const Dn2CppTypeInfo* el = t->elementType;

--- a/runtime/core/intrinsics/dn2cpp_system_text.cpp
+++ b/runtime/core/intrinsics/dn2cpp_system_text.cpp
@@ -32,7 +32,9 @@ static void dn2cpp_sb_ensure(Dn2CppStringBuilder* sb, int32_t needed)
     auto* newBuf = static_cast<char16_t*>(dn2cpp_alloc_atomic(static_cast<size_t>(newCap) * sizeof(char16_t)));
     if (sb->buf != nullptr && sb->length > 0)
         std::memcpy(newBuf, sb->buf, static_cast<size_t>(sb->length) * sizeof(char16_t));
-    sb->buf = newBuf;
+    // sb may be old and black; the swap store must dirty it or the new buffer
+    // is invisible to an incremental cycle.
+    dn2cpp_gc_store_ref(&sb->buf, newBuf);
     sb->capacity = newCap;
 }
 
@@ -246,7 +248,7 @@ Dn2CppStringBuilder* dn2cpp_sb_replace_str_range(Dn2CppStringBuilder* sb, Dn2Cpp
             dst[w++] = sb->buf[i++];
         }
     }
-    sb->buf = dst;
+    dn2cpp_gc_store_ref(&sb->buf, dst); // see dn2cpp_sb_grow
     sb->length = newLen;
     sb->capacity = newLen > 0 ? newLen : 1;
     return sb;
@@ -412,7 +414,7 @@ int32_t dn2cpp_sb_ensure_capacity(Dn2CppStringBuilder* sb, int32_t capacity)
         auto* newBuf = static_cast<char16_t*>(dn2cpp_alloc_atomic(static_cast<size_t>(capacity) * sizeof(char16_t)));
         if (sb->buf != nullptr && sb->length > 0)
             std::memcpy(newBuf, sb->buf, static_cast<size_t>(sb->length) * sizeof(char16_t));
-        sb->buf = newBuf;
+        dn2cpp_gc_store_ref(&sb->buf, newBuf); // see dn2cpp_sb_grow
         sb->capacity = capacity;
     }
     return sb->capacity;

--- a/runtime/core/intrinsics/dn2cpp_system_threading.cpp
+++ b/runtime/core/intrinsics/dn2cpp_system_threading.cpp
@@ -669,9 +669,11 @@ Dn2CppObject* dn2cpp_threadlocal_get(Dn2CppObject* o)
         return n->value;
     auto* node = static_cast<Dn2CppThreadLocalNode*>(dn2cpp_alloc(sizeof(Dn2CppThreadLocalNode)));
     node->threadId = id;
-    node->value = initial;
-    node->next = h->head;
-    h->head = node;
+    // h (and any existing node) is old and possibly black: every publishing
+    // store must dirty its slot for the incremental cycle.
+    dn2cpp_gc_store_ref(&node->value, initial);
+    dn2cpp_gc_store_ref(&node->next, h->head);
+    dn2cpp_gc_store_ref(&h->head, node);
     return initial;
 }
 
@@ -682,14 +684,15 @@ void dn2cpp_threadlocal_set(Dn2CppObject* o, Dn2CppObject* boxedOrRef)
     std::lock_guard<std::mutex> lk(g_threadlocal_mtx);
     if (Dn2CppThreadLocalNode* n = dn2cpp_threadlocal_find(h, id))
     {
-        n->value = boxedOrRef;
+        // The node is old and possibly black — the overwrite must dirty it.
+        dn2cpp_gc_store_ref(&n->value, boxedOrRef);
         return;
     }
     auto* node = static_cast<Dn2CppThreadLocalNode*>(dn2cpp_alloc(sizeof(Dn2CppThreadLocalNode)));
     node->threadId = id;
-    node->value = boxedOrRef;
-    node->next = h->head;
-    h->head = node;
+    dn2cpp_gc_store_ref(&node->value, boxedOrRef);
+    dn2cpp_gc_store_ref(&node->next, h->head);
+    dn2cpp_gc_store_ref(&h->head, node);
 }
 
 int32_t dn2cpp_threadlocal_is_created(Dn2CppObject* o)

--- a/runtime/godot/dn2cpp_godot.cpp
+++ b/runtime/godot/dn2cpp_godot.cpp
@@ -1697,9 +1697,11 @@ namespace
         if (tag == DN2CPP_GD_PACKED_STRING)
         {
             Dn2CppArrayRef* arr = dn2cpp_newarr_ref_t(len, dn2cpp_array_ti(&dn2cpp_string_type, 1));
+            // ManagedStringFromGd allocates, so an incremental cycle may blacken
+            // `arr` mid-loop; each store must re-dirty its slot.
             for (int32_t i = 0; i < len; i++)
-                arr->data[i] = reinterpret_cast<Dn2CppObject*>(
-                    ManagedStringFromGd(static_cast<const GdString*>(PackedElemPtr(tag, p, i))));
+                dn2cpp_gc_store_ref(&arr->data[i], reinterpret_cast<Dn2CppObject*>(
+                    ManagedStringFromGd(static_cast<const GdString*>(PackedElemPtr(tag, p, i)))));
             return arr;
         }
         int32_t es = PackedElemSize(tag);
@@ -2290,8 +2292,13 @@ namespace
         int32_t n = argc > 0 ? static_cast<int32_t>(argc) : 0;
         Dn2CppArrayN* arr = dn2cpp_newarr_n(n, (int32_t)sizeof(Dn2CppGodotVariant));
         auto* dst = reinterpret_cast<Dn2CppGodotVariant*>(arr->data);
+        // DecodeVariant allocates, so an incremental cycle may blacken `arr`
+        // mid-loop; each store must re-dirty its slot or the ref is lost.
         for (int32_t i = 0; i < n; i++)
+        {
             DecodeVariant(p_args[i], &dst[i]);
+            dn2cpp_gc_write_barrier(&dst[i]);
+        }
         if (g_callable_dispatch != nullptr)
         {
             try
@@ -2429,8 +2436,13 @@ namespace
         if (len < 0) len = 0;
         Dn2CppArrayN* arr = dn2cpp_newarr_n(len, (int32_t)sizeof(Dn2CppGodotVariant));
         auto* dst = reinterpret_cast<Dn2CppGodotVariant*>(arr->data);
+        // DecodeVariant allocates, so an incremental cycle may blacken `arr`
+        // mid-loop; each store must re-dirty its slot or the ref is lost.
         for (int32_t i = 0; i < len; i++)
+        {
             DecodeVariant(gd_array_index(p, i), &dst[i]);
+            dn2cpp_gc_write_barrier(&dst[i]);
+        }
         return arr;
     }
 
@@ -2774,8 +2786,11 @@ void dn2cpp_godot_sweep_anchored_refcounted()
             // pointer there keeps pinning the object forever (the same
             // "clear before running" reasoning the finalizer ring itself
             // uses).
+            // The moved slot must be re-dirtied like the insert path's store:
+            // under MANUAL_VDB an unbarriered store into this table is invisible
+            // to an incremental cycle, and this table is the shim's only root.
             int32_t last = --g_refcounted_anchor_count;
-            g_refcounted_anchor_table[i] = g_refcounted_anchor_table[last];
+            dn2cpp_gc_store_ref(&g_refcounted_anchor_table[i], g_refcounted_anchor_table[last]);
             g_refcounted_anchor_table[last] = nullptr;
             continue;
         }

--- a/src/Dn2Cpp.Transpiler/CppTypes.cs
+++ b/src/Dn2Cpp.Transpiler/CppTypes.cs
@@ -57,70 +57,8 @@ internal static class CppTypes
                 ? "int64_t" : "int32_t")
             : t.Class!.IsValueType ? t.Class!.CppStructName
             : t.Class!.CppStructPtrName,
-        TypeKind.External => t.ExternalName switch
-        {
-            // The special-type table shared with the Class arm above
-            // (CoreIntrinsics.SpecialTypeCppName — the entries' rationale lives at
-            // the table). Every arm below is External-arm-scoped: a loaded Class of
-            // the same name would answer differently (see the table's doc comment).
-            _ when CoreIntrinsics.SpecialTypeCppName(t.ExternalName) is { } stn => stn,
-            // A Class-kind System.Object/System.Type never takes these shapes (an
-            // `object`/typeof slot decodes as Primitive/intrinsic; a loaded TypeDef
-            // of the name would fall through to the transpiled t_* pointer), so the
-            // mapping is scoped to the unresolved-TypeRef form.
-            "System.Object" => "Dn2CppObject*",
-            "System.Type" => "Dn2CppType*",
-            // The runtime-raised exception types referenced without the CoreLib
-            // IL (typed catch locals, throw temps): the same managed object
-            // reference — their shared runtime handles carry the type identity.
-            // (A LOADED exception class transpiles normally — Class-arm fallback —
-            // which is why this predicate arm is not in the shared table.)
-            _ when CoreIntrinsics.RuntimeExceptionTypeInfo(t.ExternalName) is not null
-                => "Dn2CppObject*",
-            // Any other unloaded BCL exception name (System.SystemException, …): the same
-            // managed object reference. Reached when a corelib-less app exception derives
-            // from one and a signature names the base. No shared runtime handle exists for
-            // these, so a typed catch/isinst of one still fails loudly at token mapping;
-            // only the REFERENCE shape is answered here.
-            _ when t.ExternalName is { } exn && CoreIntrinsics.IsExternalBclExceptionName(exn)
-                => "Dn2CppObject*",
-            // ParallelOptions lives in the System.Threading.Tasks.Parallel.dll facade
-            // (like ParallelLoopResult in the shared table), so when only CoreLib is
-            // referenced its TypeRef resolves to External rather than a loaded Class.
-            // It is a runtime object (newobj-intercepted, like Timer/SemaphoreSlim),
-            // so the same opaque "Dn2CppObject*" reference shape as those. External-
-            // scoped: unlike ParallelLoopResult it has NO IntrinsicCppName, so a
-            // loaded Class of the name would render as its transpiled t_* pointer.
-            "System.Threading.Tasks.ParallelOptions" => "Dn2CppObject*",
-            // ParallelLoopState — the Break/Stop object the runtime passes into the
-            // Action<T, ParallelLoopState> body overloads. Same facade-assembly split
-            // and same External-only scoping as ParallelOptions above; it has no
-            // public constructor (only the runtime ever creates one), so it is never
-            // newobj-intercepted — every member is dispatched through runtime helper
-            // calls instead of direct field access, hence the same opaque
-            // "Dn2CppObject*" shape as ParallelOptions.
-            "System.Threading.Tasks.ParallelLoopState" => "Dn2CppObject*",
-            // The synchronization primitives that live in the System.Threading.dll facade
-            // rather than in CoreLib, for exactly the ParallelOptions reason above: with
-            // only CoreLib referenced their TypeRef resolves to External, and they are
-            // newobj-intercepted runtime objects (dn2cpp_countdown_new / _barrier_new /
-            // _rwlock_new), so the opaque managed reference is the right shape.
-            //
-            // Only a REAL IL local of the type asks for a rendering — a `new CountdownEvent(2)`
-            // consumed inline never materializes one — so without these arms the transpile
-            // fails with "External type ... is not supported yet" over code whose ctor
-            // intercept, members and IDisposable row all already work.
-            "System.Threading.CountdownEvent" => "Dn2CppObject*",
-            "System.Threading.Barrier" => "Dn2CppObject*",
-            "System.Threading.ReaderWriterLockSlim" => "Dn2CppObject*",
-            // Dynamic-code-generation surface types (DynamicMethod, CallSite, ...)
-            // referenced without their assembly loaded: every constructor/member is
-            // intercepted to a runtime PlatformNotSupportedException throw, so an
-            // instance can never exist — the reference shape is a plain opaque
-            // object pointer.
-            _ when CoreIntrinsics.IsDynamicCodegenType(t.ExternalName ?? "") => "Dn2CppObject*",
-            _ => throw new NotSupportedException($"External type {t.ExternalName} is not supported yet"),
-        },
+        TypeKind.External => ExternalCppName(t.ExternalName)
+            ?? throw new NotSupportedException($"External type {t.ExternalName} is not supported yet"),
         TypeKind.SZArray => ArrayCppType(t.Element!),
         TypeKind.MDArray => "Dn2CppMDArray*",
         // A managed pointer (`ref T`) must stride by T's real storage width, not the
@@ -147,6 +85,89 @@ internal static class CppTypes
             + "should have been used); this is a reachability/decode bug, not an input one"),
         _ => throw new NotSupportedException(t.ToString()),
     };
+
+    /// <summary>The C++ rendering for an unresolved-TypeRef (External) name, or null when
+    /// the name has no mapping. The single source for the External arm of <see cref="Of"/>
+    /// (which turns null into its not-supported throw) AND for
+    /// <see cref="TypeDesc.ContainsGcReferences"/> via <see cref="IsGcRefCppType"/> —
+    /// deriving both from one cascade is what keeps the GC write-barrier gates closed for
+    /// every name this maps to a managed pointer.</summary>
+    public static string? ExternalCppName(string? name) => name switch
+    {
+        // The special-type table shared with the Class arm of Of
+        // (CoreIntrinsics.SpecialTypeCppName — the entries' rationale lives at
+        // the table). Every arm below is External-arm-scoped: a loaded Class of
+        // the same name would answer differently (see the table's doc comment).
+        _ when CoreIntrinsics.SpecialTypeCppName(name) is { } stn => stn,
+        // A Class-kind System.Object/System.Type never takes these shapes (an
+        // `object`/typeof slot decodes as Primitive/intrinsic; a loaded TypeDef
+        // of the name would fall through to the transpiled t_* pointer), so the
+        // mapping is scoped to the unresolved-TypeRef form.
+        "System.Object" => "Dn2CppObject*",
+        "System.Type" => "Dn2CppType*",
+        // The runtime-raised exception types referenced without the CoreLib
+        // IL (typed catch locals, throw temps): the same managed object
+        // reference — their shared runtime handles carry the type identity.
+        // (A LOADED exception class transpiles normally — Class-arm fallback —
+        // which is why this predicate arm is not in the shared table.)
+        _ when CoreIntrinsics.RuntimeExceptionTypeInfo(name) is not null
+            => "Dn2CppObject*",
+        // Any other unloaded BCL exception name (System.SystemException, …): the same
+        // managed object reference. Reached when a corelib-less app exception derives
+        // from one and a signature names the base. No shared runtime handle exists for
+        // these, so a typed catch/isinst of one still fails loudly at token mapping;
+        // only the REFERENCE shape is answered here.
+        _ when name is { } exn && CoreIntrinsics.IsExternalBclExceptionName(exn)
+            => "Dn2CppObject*",
+        // ParallelOptions lives in the System.Threading.Tasks.Parallel.dll facade
+        // (like ParallelLoopResult in the shared table), so when only CoreLib is
+        // referenced its TypeRef resolves to External rather than a loaded Class.
+        // It is a runtime object (newobj-intercepted, like Timer/SemaphoreSlim),
+        // so the same opaque "Dn2CppObject*" reference shape as those. External-
+        // scoped: unlike ParallelLoopResult it has NO IntrinsicCppName, so a
+        // loaded Class of the name would render as its transpiled t_* pointer.
+        "System.Threading.Tasks.ParallelOptions" => "Dn2CppObject*",
+        // ParallelLoopState — the Break/Stop object the runtime passes into the
+        // Action<T, ParallelLoopState> body overloads. Same facade-assembly split
+        // and same External-only scoping as ParallelOptions above; it has no
+        // public constructor (only the runtime ever creates one), so it is never
+        // newobj-intercepted — every member is dispatched through runtime helper
+        // calls instead of direct field access, hence the same opaque
+        // "Dn2CppObject*" shape as ParallelOptions.
+        "System.Threading.Tasks.ParallelLoopState" => "Dn2CppObject*",
+        // The synchronization primitives that live in the System.Threading.dll facade
+        // rather than in CoreLib, for exactly the ParallelOptions reason above: with
+        // only CoreLib referenced their TypeRef resolves to External, and they are
+        // newobj-intercepted runtime objects (dn2cpp_countdown_new / _barrier_new /
+        // _rwlock_new), so the opaque managed reference is the right shape.
+        //
+        // Only a REAL IL local of the type asks for a rendering — a `new CountdownEvent(2)`
+        // consumed inline never materializes one — so without these arms the transpile
+        // fails with "External type ... is not supported yet" over code whose ctor
+        // intercept, members and IDisposable row all already work.
+        "System.Threading.CountdownEvent" => "Dn2CppObject*",
+        "System.Threading.Barrier" => "Dn2CppObject*",
+        "System.Threading.ReaderWriterLockSlim" => "Dn2CppObject*",
+        // Dynamic-code-generation surface types (DynamicMethod, CallSite, ...)
+        // referenced without their assembly loaded: every constructor/member is
+        // intercepted to a runtime PlatformNotSupportedException throw, so an
+        // instance can never exist — the reference shape is a plain opaque
+        // object pointer.
+        _ when CoreIntrinsics.IsDynamicCodegenType(name ?? "") => "Dn2CppObject*",
+        _ => null,
+    };
+
+    /// <summary>Whether a C++ rendering is a pointer to a GC-managed object. Judged from
+    /// the rendering itself rather than a per-name list so the write-barrier gates
+    /// (<see cref="TypeDesc.ContainsGcReferences"/>) close automatically for every name
+    /// <see cref="ExternalCppName"/> maps to a managed pointer. A <c>const</c>-qualified
+    /// pointer names runtime/static data (assembly names, type-info tables), never GC
+    /// storage.</summary>
+    public static bool IsGcRefCppType(string? cpp) =>
+        cpp is not null
+        && cpp.EndsWith("*", StringComparison.Ordinal)
+        && !cpp.StartsWith("const ", StringComparison.Ordinal)
+        && cpp != "void*";
 
     /// <summary>The precise native-ABI C++ type for a P/Invoke parameter/return that
     /// is **blittable** — an integer/floating primitive, <c>IntPtr</c>/<c>UIntPtr</c>,

--- a/src/Dn2Cpp.Transpiler/MethodCompiler.EmitIntrinsic.InterpString.cs
+++ b/src/Dn2Cpp.Transpiler/MethodCompiler.EmitIntrinsic.InterpString.cs
@@ -219,6 +219,9 @@ internal sealed partial class MethodCompiler
                 var src = Pop();
                 var dest = Pop();
                 Emit($"std::memmove((void*)({dest.Expr}), (void*)({src.Expr}), (size_t)({size.Expr}));");
+                // The destination is untyped, so it may have received references:
+                // barrier conservatively, like the raw cpblk lowering.
+                Emit($"dn2cpp_gc_write_barrier_if_heap((void*)({dest.Expr}));");
                 return true;
             }
             case ("System.Runtime.CompilerServices.Unsafe", "InitBlock"):
@@ -228,6 +231,8 @@ internal sealed partial class MethodCompiler
                 var val = Pop();
                 var dest = Pop();
                 Emit($"std::memset((void*)({dest.Expr}), (int)({val.Expr}), (size_t)({size.Expr}));");
+                // Untyped destination: barrier conservatively (see CopyBlock above).
+                Emit($"dn2cpp_gc_write_barrier_if_heap((void*)({dest.Expr}));");
                 return true;
             }
 

--- a/src/Dn2Cpp.Transpiler/Model.cs
+++ b/src/Dn2Cpp.Transpiler/Model.cs
@@ -204,7 +204,12 @@ internal sealed class TypeDesc
         TypeKind.SZArray or TypeKind.MDArray => true,
         TypeKind.ByRef => true,   // a by-ref field is a managed reference
         TypeKind.Pointer => false, // unmanaged pointer
-        TypeKind.External => ExternalName is "System.String" or "System.Object",
+        // Derived from the same cascade that renders the C++ storage type: a name
+        // CppTypes maps to a GC-managed pointer (Exception, Type, the reflection
+        // infos, …) contains a reference, so every write-barrier gate keyed on this
+        // predicate agrees with the emitted field/element type. A name with no
+        // mapping cannot be stored anywhere and stays "no references".
+        TypeKind.External => CppTypes.IsGcRefCppType(CppTypes.ExternalCppName(ExternalName)),
         TypeKind.ExternalGeneric => true, // a base-image generic reference type
         TypeKind.Class when Class!.IsEnum => false,
         TypeKind.Class when Class!.IsValueType =>


### PR DESCRIPTION
## Summary

- derive GC-reference classification from the C++ type mapping
- barrier generated, core-runtime, and Godot managed-reference stores and bulk moves
- close loader, task, array-fill, and linked-list publication gaps found during logic review

## Validation

- dotnet build src/Dn2Cpp.Cli -c Release
- gates/build-and-run-weak-references.sh
- gates/build-and-run-hotupdate-subset.sh
- gates/build-and-run-shadow-stack.sh
- gates/build-and-run-async-combinators.sh
- gates/build-and-run-threadpool.sh
- gates/build-and-run-string-core.sh
- gates/build-and-run-reflect-types.sh
- gates/build-and-run-enum-ops.sh
- gates/build-and-run-array-core.sh