### PR TITLE
gc-upstreamゲートの失敗診断を保持

### DIFF
--- a/gates/build-and-run-gc-upstream.sh
+++ b/gates/build-and-run-gc-upstream.sh
@@ -30,7 +30,65 @@ echo "== 4/4 Compiling C++ (upstream GC backend) and running (STW + incremental;
 compile_console "$out" "$project"
 
 log_dir=$(mktemp -d "${TMPDIR:-/tmp}/dn2cpp_gcupstream.XXXXXX")
-trap 'rm -rf "$log_dir"' EXIT
+stw=
+stw_code=
+incremental=
+incremental_code=
+diagnostics_printed=0
+
+print_arm_diagnostics() {
+    local label="$1" code="$2" stdout="$3" stderr_file="$4"
+    local signal_no signal_name
+
+    echo "---- GC-upstream $label diagnostics ----" >&2
+    echo "exit code: ${code:-<not run>}" >&2
+    if [ -z "$code" ]; then
+        echo "termination: not run" >&2
+    elif [ -f "$stderr_file" ] && \
+            grep -qF 'WATCHDOG: no exit after ' "$stderr_file"; then
+        echo "termination: watchdog" >&2
+    elif [ "$code" -ge 128 ] && [ "$code" -le 255 ]; then
+        signal_no=$((code - 128))
+        signal_name=$(kill -l "$signal_no" 2>/dev/null || true)
+        echo "termination: signal $signal_no${signal_name:+ ($signal_name)}" >&2
+    elif [ "$code" -eq 0 ]; then
+        echo "termination: normal exit" >&2
+    else
+        echo "termination: nonzero exit" >&2
+    fi
+    if [ -n "$stdout" ]; then
+        echo "stdout:" >&2
+        printf '%s\n' "$stdout" >&2
+    else
+        echo "stdout: <empty>" >&2
+    fi
+    if [ -s "$stderr_file" ]; then
+        echo "stderr:" >&2
+        cat "$stderr_file" >&2
+    else
+        echo "stderr: <empty>" >&2
+    fi
+}
+
+print_run_diagnostics() {
+    print_arm_diagnostics "STW" "$stw_code" "$stw" "$log_dir/stw.log"
+    print_arm_diagnostics "incremental" "$incremental_code" "$incremental" \
+        "$log_dir/incremental.log"
+    diagnostics_printed=1
+}
+
+cleanup_run_logs() {
+    local code=$?
+    if [ "$code" -eq 0 ]; then
+        rm -rf "$log_dir"
+        return
+    fi
+    if [ "$diagnostics_printed" -eq 0 ]; then
+        print_run_diagnostics
+    fi
+    echo "GC-upstream stderr logs preserved in $log_dir" >&2
+}
+trap cleanup_run_logs EXIT
 
 set +e
 _gate_run_argv
@@ -47,10 +105,15 @@ incremental=$(DN2CPP_GC_INCREMENTAL=1 DN2CPP_GC_STATS=1 \
 set -e
 _gate_scratch_cleanup
 
-assert_output "$stw" "$expected"
-assert_exit_code "$stw_code" "$expected_code"
-assert_output "$incremental" "$expected"
-assert_exit_code "$incremental_code" "$expected_code"
+assertions_failed=0
+assert_output "$stw" "$expected" || assertions_failed=1
+assert_exit_code "$stw_code" "$expected_code" || assertions_failed=1
+assert_output "$incremental" "$expected" || assertions_failed=1
+assert_exit_code "$incremental_code" "$expected_code" || assertions_failed=1
+if [ "$assertions_failed" -ne 0 ]; then
+    print_run_diagnostics
+    exit 1
+fi
 
 # The version line is the ONLY direct evidence the upstream tree, not the
 # default Unity fork (which prints 7.7.0), was actually linked into this


### PR DESCRIPTION
Fixes #31

## 概要

- STW / incremental のネイティブ実行が失敗した際、終了コードを保持します。
- 実行ごとに終了理由、stdout、stderrを表示します。
- 失敗時は診断ログを保持し、成功時のみ一時ディレクトリを削除します。

## 検証

- `bash -n gates/build-and-run-gc-upstream.sh`
- `git diff --check`
- 事前ビルド済みCLIを使った gc-upstream ゲートの通常実行
- `DN2CPP_RUN_WATCHDOG_SECS=0` でwatchdog失敗を強制し、終了コード137、watchdog判定、空のstdout、stderr、ログ保存先の表示を確認