### PR TITLE
Add editor release workflow skills

### DIFF
--- a/skills/mac-release/SKILL.md
+++ b/skills/mac-release/SKILL.md
@@ -1,0 +1,249 @@
+---
+name: mac-release
+description: Run and verify the dn2cpp macOS-side release workflow for the Godot fork, including pinned toolchain setup, self-host rebuild, Web/macOS/editor packaging, draft release creation, and the mandatory macOS-to-Windows handoff. Use when cutting a new release, rebuilding Mac release artifacts, preparing a Windows handoff, or diagnosing a missing handoff or draft-release asset.
+---
+
+# Mac Release Workflow
+
+Read docs/RELEASE.md Phase 0, Phase A, and Phase B before acting. Treat that
+document and the repository scripts as the source of truth. This skill fixes
+the ordering and stop conditions that are easy to miss.
+
+## Invariants
+
+- Work from the dn2cpp checkout's clean main, including no untracked files.
+  Ensure the exact commit is reachable from origin/main.
+- Resolve the fork through gates/_godot_fork.sh. Keep its dn2cpp/main
+  worktree clean and ensure its exact commit is reachable from
+  origin/dn2cpp/main.
+- Set a concrete V and its immediately preceding PREV release. Use the exact
+  form <godot-version>-dn2cpp.<X>.<Y>; increment Y for a dn2cpp-only change
+  and increment X with Y=0 when the fork moves.
+- Treat a separately completed gates/pre-merge.sh run as a prerequisite. Do
+  not launch it automatically in this workflow. If the user has not confirmed
+  it, stop before packaging and request the result.
+- Keep the release unpublished on Mac. Mac creates a draft; Windows completes
+  and publishes it.
+- Upload the handoff immediately after creating the draft. Do not report the
+  Mac phase complete until GitHub shows
+  internal-handoff-$V-macos-to-windows.tgz on that draft.
+
+## Phase 0: inspect and prepare
+
+Run the command blocks in one shell, or enable errexit and pipefail in each
+shell:
+
+~~~
+set -e -o pipefail
+~~~
+
+Set concrete values before running commands:
+
+~~~
+V='REPLACE_WITH_NEW_RELEASE_VERSION'
+PREV='REPLACE_WITH_PREVIOUS_RELEASE_VERSION'
+REPO='takuma-komatsu/godot-dn2cpp'
+~~~
+
+Replace both placeholders before running anything. Before the confirmed
+pre-merge run, update dist/release-notes-template.md's hand-written change
+bullets and compare URL for this release. Commit and push that change, and
+commit and push any required docs/EDITOR-GUIDE.ja.md change. The merge-gate
+confirmation must refer to this exact dn2cpp HEAD; --prev-version supplies the
+heading version, but it does not update the bullets or compare URL.
+
+Confirm both values from the fork's tags/releases. Never infer them from a
+stale artifact directory and never use the same value for both.
+
+Inspect both repositories:
+
+~~~
+git fetch origin
+git checkout main
+git status --porcelain --untracked-files=all
+git merge-base --is-ancestor HEAD origin/main
+git rev-parse HEAD
+
+source gates/_godot_fork.sh
+godot_fork_resolve
+git -C "$FORK" fetch --tags --prune --prune-tags --force origin
+git -C "$FORK" checkout dn2cpp/main
+git -C "$FORK" status --porcelain --untracked-files=no
+git -C "$FORK" merge-base --is-ancestor HEAD origin/dn2cpp/main
+git -C "$FORK" rev-parse HEAD
+echo "fork_root=$FORK_ROOT"
+echo "fork=$FORK"
+~~~
+
+Require empty status output and successful ancestry checks. Push intended
+commits before continuing; no release script pushes them. Run gh auth status
+in the same permission context that will run the release and handoff commands.
+If authentication works only in an approved/escalated shell, use that context
+for all GitHub calls and for scripts that write the fork cache.
+
+For a new version, move the entire old output directory aside. Resolve the
+destination first and never overwrite an existing directory:
+
+~~~
+if [ -e "artifacts/release-$PREV" ]; then
+    echo "error: artifacts/release-$PREV already exists; inspect it before moving anything" >&2
+    exit 1
+fi
+if [ -d artifacts/release ]; then
+    mv artifacts/release artifacts/release-$PREV
+fi
+~~~
+
+Do not copy selected files or leave old metadata in artifacts/release.
+
+## Phase A: build the Mac lanes
+
+Run these commands in order, using each setup script's default output path:
+
+~~~
+./gates/setup-buildtools.sh
+./gates/setup-emsdk.sh
+./gates/selfhost-emit.sh
+./gates/setup-godot-fork.sh 2>&1 | tee /tmp/setup-godot-fork.log
+./gates/setup-godot-fork-web.sh 2>&1 | tee /tmp/setup-godot-fork-web.log
+
+./dist/package-web-template.sh --version "$V"
+./dist/package-macos-template.sh --version "$V"
+./dist/package-editor-macos.sh --version "$V" --dn2cpp-commit "$(git rev-parse HEAD)" 2>&1 | tee /tmp/pkg-editor-macos.log
+~~~
+
+Do not pass --out to either setup script, use CRI=1, disable the editor
+packager's default smoke, or use --allow-partial-prebuilt. The Web package
+must precede the macOS template, and both must precede the editor package.
+Treat the Web smoke's final HTTP-server SIGTERM as teardown only when the gate
+otherwise reports success.
+
+Expect these files under artifacts/release:
+
+~~~
+Godot-$V-macos-arm64.zip
+godot-$V-web-template.zip
+godot-$V-web-template.zip.provenance
+godot-$V-macos-arm64-template.zip
+editor-macos.metadata
+web.metadata
+macos.metadata
+SHA256SUMS.txt                 # exactly 3 rows before Windows
+~~~
+
+Verify the set and hashes before touching GitHub:
+
+~~~
+test -f "artifacts/release/Godot-$V-macos-arm64.zip"
+test -f "artifacts/release/godot-$V-web-template.zip"
+test -f "artifacts/release/godot-$V-web-template.zip.provenance"
+test -f "artifacts/release/godot-$V-macos-arm64-template.zip"
+test -f artifacts/release/editor-macos.metadata
+test -f artifacts/release/web.metadata
+test -f artifacts/release/macos.metadata
+test "$(wc -l < artifacts/release/SHA256SUMS.txt | tr -d ' ')" -eq 3
+(cd artifacts/release && shasum -a 256 -c SHA256SUMS.txt)
+~~~
+
+Check that metadata says release_version=$V, that editor-macos.metadata names
+the current git rev-parse HEAD, and that Web metadata agrees with the staged
+toolchain. Never edit metadata or checksums by hand.
+
+## Phase A-6: rehearse and create the draft
+
+Run the dry run and inspect the rendered notes:
+
+~~~
+./dist/release-github.sh --repo "$REPO" --version "$V" --prev-version "$PREV" --dry-run
+~~~
+
+Read artifacts/release/RELEASE-NOTES.md. Require no @@ placeholders or HTML
+comments, the three active lanes editor-macos, web, and macos, and the correct
+previous-release heading. If this fails, rerun the packager that produced the
+odd metadata without changing the committed tree. If the committed source or
+template needs correction, restart Phase 0: commit and push it, reconfirm the
+merge gate for the new HEAD, rerun Phase A, and then repeat the dry run. Do not
+edit rendered notes to bypass a check.
+
+Create the draft without --publish:
+
+~~~
+./dist/release-github.sh --repo "$REPO" --version "$V" --prev-version "$PREV" 2>&1 | tee /tmp/release-macos.log
+~~~
+
+Verify the release before handoff:
+
+~~~
+gh release view "$V" --repo "$REPO" --json isDraft,targetCommitish,assets --jq '{isDraft,targetCommitish,assets:[.assets[]|{name,digest}]}'
+gh release view "$V" --repo "$REPO" --json body --jq .body
+~~~
+
+Require isDraft: true, the fork commit as targetCommitish, four initial assets
+(three lane assets plus SHA256SUMS.txt), and a body without @@ or <!--. Do not
+publish from Mac and do not add a Windows checksum row.
+
+## Phase B: mandatory Windows handoff
+
+Run this immediately after creating the draft:
+
+~~~
+./dist/release-handoff.sh put --repo "$REPO" --version "$V" 2>&1 | tee /tmp/release-handoff-put.log
+~~~
+
+Require the uploaded asset
+internal-handoff-$V-macos-to-windows.tgz. Its exact seven members are the
+three metadata files, the three-row SHA256SUMS.txt, the Web template zip and
+provenance, and web_emcc.txt from FORK_ROOT. Keep the tarball outside
+artifacts/release; it is an internal transport asset, not a release lane.
+
+Compare the digest printed by put with the digest GitHub serves:
+
+~~~
+LOCAL_HANDOFF_SHA="$(sed -n 's/.*sha256 \([0-9a-f]\{64\}\)$/\1/p' /tmp/release-handoff-put.log | tail -1)"
+REMOTE_HANDOFF_SHA="$(gh release view "$V" --repo "$REPO" --json assets --jq '.assets[] | select(.name | startswith("internal-handoff-")) | .digest' | sed 's/^sha256://')"
+test -n "$LOCAL_HANDOFF_SHA"
+test "$LOCAL_HANDOFF_SHA" = "$REMOTE_HANDOFF_SHA"
+~~~
+
+Verify the asset remotely and leave the release as a draft:
+
+~~~
+gh release view "$V" --repo "$REPO" --json isDraft,assets --jq '{isDraft,assets:[.assets[]|{name,size,digest}]}'
+~~~
+
+Require a non-empty handoff entry named
+internal-handoff-$V-macos-to-windows.tgz and isDraft: true. If it is missing,
+rerun put and verify again; put is intentionally repeatable. Never finish the
+Mac phase based only on a successful local packaging log.
+
+Give Windows this fixed continuation:
+
+~~~
+./dist/release-handoff.sh get --repo "$REPO" --version "$V"
+# Check out the dn2cpp_commit from artifacts/release/editor-macos.metadata.
+# Run Windows Phase C from docs/RELEASE.md.
+./dist/release-handoff.sh drop --repo "$REPO" --version "$V"
+./dist/release-github.sh --repo "$REPO" --version "$V" --prev-version "$PREV" --lane editor-windows --uploaded-lane editor-macos --uploaded-lane web --uploaded-lane macos --publish
+~~~
+
+Windows must run drop before publishing and must not run
+setup-godot-fork-web.sh; Mac supplies the Web template and web_emcc.txt.
+
+## Stop conditions and recovery
+
+- Stop when either repository is dirty, a commit is not pushed, the host
+  commits disagree, or the merge-gate result is unconfirmed.
+- Stop on an emcc, engine_provenance, base_pin, corelib_framework, or
+  dn2cpp_commit mismatch. Rebuild the affected lane from the same pinned tree;
+  never rewrite metadata.
+- If buildtools or emsdk rows are absent from the toolchain, rerun setup with
+  default output paths before rebuilding the fork and editor.
+- If Web metadata and bundled emcc disagree, run
+  FORCE=1 ./gates/setup-godot-fork-web.sh, then repackage Web before rerunning
+  the Mac editor package.
+- If the handoff is absent from the draft, run release-handoff.sh put with
+  --repo "$REPO"; do not publish an unverified handoff.
+- If the release was published prematurely or put refuses because it is no
+  longer a draft, stop and report the exact GitHub state before changing it.
+- Keep GitHub calls, fork-cache writes, and setup downloads in one approved
+  execution context. Never expose authentication tokens in logs.

--- a/skills/mac-release/agents/openai.yaml
+++ b/skills/mac-release/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Mac Release Workflow"
+  short_description: "Package and hand off Mac releases safely"
+  default_prompt: "Use $mac-release to run and verify the dn2cpp macOS release handoff."

--- a/skills/windows-release/SKILL.md
+++ b/skills/windows-release/SKILL.md
@@ -1,0 +1,258 @@
+---
+name: windows-release
+description: Run and verify the dn2cpp Windows-side Godot editor release workflow, including macOS handoff retrieval, pinned toolchain setup, self-host rebuild, Windows packaging, smoke tests, draft cleanup, four-lane publication, and post-publish checks. Use when finishing a Godot editor release on Windows, rebuilding Windows release artifacts, or diagnosing handoff, MSVC, emcc, prebuilt-axis, checksum, or publish failures.
+---
+
+# Windows Release Workflow
+
+Read `docs/RELEASE.md` Phase 0, Phase B, Phase C, and Phase D before acting.
+Treat that document and the release scripts as the source of truth. This skill
+fixes the Windows continuation's ordering and stop conditions.
+
+## Preconditions
+
+- Use Git Bash/MSYS on Windows x86_64.
+- Use the exact `V`, immediately preceding `PREV`, and `REPO` chosen by the
+  Mac phase. The accepted version form is `<godot-version>-dn2cpp.<X>.<Y>`.
+- Require the Mac phase's `gates/pre-merge.sh` result for the exact dn2cpp
+  commit named by the handoff. Do not launch the merge gate automatically.
+- Require a host Python 3, Visual Studio's C++ workload, an Android NDK, the
+  pinned .NET SDK, and an authenticated `gh`.
+- Set `CMAKE_CXX_COMPILER=cl` before sourcing or running repository scripts so
+  `_common.sh` imports the MSVC environment. Do not rely on a Developer Prompt
+  being the parent of Git Bash.
+- Do not run `gates/setup-godot-fork-web.sh`: the Mac phase supplies the one
+  Web template and `web_emcc.txt` for this release.
+- Do not use `--allow-partial-prebuilt`, `--no-smoke`, `CRI=1`, or a custom
+  `--out` for the setup scripts. Missing prerequisites are release failures.
+
+Use one approved shell context for GitHub calls, fork-cache writes, setup
+downloads, and packaging. Keep authentication tokens out of logs.
+
+## Phase 0: import and pin the Mac handoff
+
+Run commands with errexit and pipefail:
+
+```bash
+set -e -o pipefail
+V='REPLACE_WITH_RELEASE_VERSION'
+PREV='REPLACE_WITH_PREVIOUS_RELEASE_VERSION'
+REPO='takuma-komatsu/godot-dn2cpp'
+```
+
+Confirm the source tree and fork are clean and pushed before changing the
+checkout. The Windows packager reads the whole dn2cpp tree, including
+untracked files.
+
+```bash
+git fetch origin
+test -z "$(git status --porcelain --untracked-files=all)"
+git merge-base --is-ancestor HEAD origin/main
+
+source gates/_godot_fork.sh
+godot_fork_resolve
+git -C "$FORK" fetch --tags --prune --prune-tags --force origin
+git -C "$FORK" checkout dn2cpp/main
+test -z "$(git -C "$FORK" status --porcelain --untracked-files=no)"
+git -C "$FORK" merge-base --is-ancestor HEAD origin/dn2cpp/main
+```
+
+Move the complete previous output directory aside before importing anything.
+Resolve the destination first and never overwrite an existing directory:
+
+```bash
+if [ -e "artifacts/release-$PREV" ]; then
+    echo "error: artifacts/release-$PREV already exists; inspect it first" >&2
+    exit 1
+fi
+if [ -d artifacts/release ]; then
+    mv artifacts/release "artifacts/release-$PREV"
+fi
+```
+
+Get the handoff from the draft release. It verifies the GitHub-served digest
+and the archive's exact seven members; never reconstruct metadata by hand.
+
+```bash
+./dist/release-handoff.sh get --repo "$REPO" --version "$V"
+IS_DRAFT="$(gh release view "$V" --repo "$REPO" --json isDraft --jq .isDraft)"
+test "$IS_DRAFT" = true || {
+    echo "error: release $V is not a draft; do not consume a published handoff" >&2
+    exit 1
+}
+```
+
+Require these files under `artifacts/release`:
+
+```text
+editor-macos.metadata
+web.metadata
+macos.metadata
+SHA256SUMS.txt                         # exactly 3 rows at this point
+godot-$V-web-template.zip
+godot-$V-web-template.zip.provenance
+```
+
+Require `web_emcc.txt` under `FORK_ROOT`. Read `dn2cpp_commit` from
+`editor-macos.metadata`; do not substitute the current branch tip:
+
+```bash
+DN2CPP_PIN="$(sed -n 's/^dn2cpp_commit=//p' artifacts/release/editor-macos.metadata)"
+test -n "$DN2CPP_PIN"
+git cat-file -e "$DN2CPP_PIN^{commit}"
+git merge-base --is-ancestor "$DN2CPP_PIN" origin/main
+git checkout "$DN2CPP_PIN"
+test -z "$(git status --porcelain --untracked-files=all)"
+```
+
+The handoff must come from a draft. If it is absent, the release is published,
+or a local old row/metadata file remains, stop and fix the state rather than
+editing the handoff or checksum file.
+
+## Phase C-1: prepare the Windows toolchain
+
+Run the setup scripts with their default output paths, then rebuild the
+self-host CLI before packaging:
+
+```bash
+export CMAKE_CXX_COMPILER=cl
+./gates/setup-buildtools.sh
+./gates/setup-emsdk.sh
+./gates/selfhost-emit.sh
+./gates/setup-godot-fork.sh 2>&1 | tee /tmp/setup-godot-fork-windows.log
+```
+
+Require the fork commit, engine provenance, and base pin to agree with the Mac
+metadata before packaging. The local provenance is derived from the same fork
+sources used by the packager:
+
+```bash
+source gates/_godot_fork.sh
+godot_fork_resolve
+BASE_COMMIT="$(head -1 "$FORK_PIN_EXPECTED")"
+WINDOWS_FORK_COMMIT="$(git -C "$FORK" rev-parse HEAD)"
+WINDOWS_ENGINE_PROVENANCE="$(godot_fork_engine_provenance)"
+MAC_FORK_COMMIT="$(sed -n 's/^fork_commit=//p' artifacts/release/editor-macos.metadata)"
+MAC_ENGINE_PROVENANCE="$(sed -n 's/^engine_provenance=//p' artifacts/release/editor-macos.metadata)"
+MAC_BASE_PIN="$(sed -n 's/^base_pin=//p' artifacts/release/editor-macos.metadata)"
+test "$WINDOWS_FORK_COMMIT" = "$MAC_FORK_COMMIT"
+test "$WINDOWS_ENGINE_PROVENANCE" = "$MAC_ENGINE_PROVENANCE"
+test "$BASE_COMMIT" = "$MAC_BASE_PIN"
+```
+
+The self-host stamp must also match the current `src/`, `runtime/`, and
+`third_party/` tree. Do not accept an old native binary because packaging can
+otherwise continue with a stale transpiler.
+
+## Phase C-2: confirm emcc agreement
+
+Compare the emcc recorded in the staged Windows bundle with the Mac Web
+metadata. Discover the layout from the size report instead of hard-coding its
+version:
+
+```bash
+BUNDLE="$(awk -F '\t' '$1 == "# bundle" { print $2 }' artifacts/toolchain/size-report.txt)"
+test -n "$BUNDLE"
+python -c 'import json,sys; print(json.load(open(sys.argv[1]))["emcc_version"])' \
+    "artifacts/toolchain/$BUNDLE/emsdk/emsdk.json"
+sed -n 's/^emcc=//p' artifacts/release/web.metadata
+```
+
+These values must be identical. Only the Mac host can re-bake the Web
+template; if they differ, stop and rerun the Mac Web setup and packaging in
+order.
+
+## Phase C-3: package and smoke-test the Windows editor
+
+Package from the pinned commit, leaving the default smoke tests enabled:
+
+```bash
+./dist/package-editor-windows.sh \
+    --version "$V" \
+    --dn2cpp-commit "$DN2CPP_PIN" \
+    2>&1 | tee /tmp/pkg-editor-windows.log
+```
+
+Require the log to show:
+
+- bundled cmake and ninja, not host fallbacks;
+- prebuilt `host`, `android-arm64-v8a`, and `web-wasm32` axes;
+- the Web template's emcc matching `web.metadata`;
+- both desktop and browser editor-export smoke gates green;
+- deterministic archive round-trip with all files SHA-256 identical.
+
+The script must produce `editor-windows.metadata`,
+`Godot-$V-windows-x86_64.zip`, and a fourth row in `SHA256SUMS.txt`. Check
+the metadata and checksum row; never edit either file manually.
+
+## Phase C-4/C-5: remove transport and rehearse publication
+
+Remove the internal handoff before any publish attempt:
+
+```bash
+./dist/release-handoff.sh drop --repo "$REPO" --version "$V"
+```
+
+Run the complete four-lane dry run. Naming only `editor-windows` would drop
+the other lanes from the rendered notes and checksum claims.
+
+```bash
+./dist/release-github.sh \
+    --repo "$REPO" \
+    --version "$V" \
+    --prev-version "$PREV" \
+    --lane editor-windows \
+    --uploaded-lane editor-macos \
+    --uploaded-lane web \
+    --uploaded-lane macos \
+    --publish --dry-run
+```
+
+Require all uploaded lanes to match GitHub's served digest and the published
+metadata in the draft. Read `artifacts/release/RELEASE-NOTES.md`; require the
+correct previous-release heading, all four lane sections, and no `@@` or
+`<!--` markers. A leftover handoff must fail this stage rather than being
+silently published.
+
+## Phase C-6/D: publish and verify
+
+Repeat the exact dry-run lane set without `--dry-run`:
+
+```bash
+./dist/release-github.sh \
+    --repo "$REPO" \
+    --version "$V" \
+    --prev-version "$PREV" \
+    --lane editor-windows \
+    --uploaded-lane editor-macos \
+    --uploaded-lane web \
+    --uploaded-lane macos \
+    --publish 2>&1 | tee /tmp/release-windows.log
+```
+
+Verify the published release:
+
+```bash
+gh release view "$V" --repo "$REPO" --json isDraft,targetCommitish,assets \
+    --jq '{isDraft,targetCommitish,assets:[.assets[]|{name,size,digest}]}'
+gh release view "$V" --repo "$REPO" --json body --jq .body
+```
+
+Require `isDraft: false`, the fork commit as `targetCommitish`, exactly five
+assets (two editors, two templates, and `SHA256SUMS.txt`), no internal handoff,
+and no `@@` or `<!--` markers. Check every guide URL in the body at the fixed
+dn2cpp commit, then download and verify the release once if the host is also
+the consumer.
+
+## Stop conditions
+
+- Stop on any dirty tree, unpushed commit, missing handoff, non-draft mismatch,
+  or disagreement in `dn2cpp_commit`, `fork_commit`, engine provenance,
+  `base_pin`, `corelib_framework`, or emcc.
+- Stop when MSVC, Python, NDK, fixed buildtools, Emscripten, or a required
+  prebuilt axis is missing. Do not paper over it with `--allow-partial-prebuilt`.
+- Never run `setup-godot-fork-web.sh` on Windows or hand-copy metadata from
+  the Mac host.
+- If publication fails after the package succeeds, leave the release as a
+  draft and rerun the complete four-lane command; never rerun with a subset.
+- Do not delete or recreate a tag or release to work around a validation error.

--- a/skills/windows-release/agents/openai.yaml
+++ b/skills/windows-release/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Windows Release Workflow"
+  short_description: "Package and publish Windows releases safely"
+  default_prompt: "Use $windows-release to finish and verify the dn2cpp Windows release handoff."


### PR DESCRIPTION
## Summary

- Track reusable macOS and Windows Godot editor release skills.
- Document Windows handoff retrieval, pinned MSVC/toolchain setup, self-host, packaging, smoke checks, and four-lane publication.
- Add post-publish validation and draft-handoff safeguards.

## Verification

- quick_validate.py skills/windows-release
- git diff --check
- Sol review: APPROVE