### PR TITLE
Keep the stderr of a gate run that died

### DIFF
--- a/gates/_common.sh
+++ b/gates/_common.sh
@@ -1918,11 +1918,19 @@ _dump_obj_symbols_nix() {
 }
 
 # assert_output ACTUAL EXPECTED — print ACTUAL; if it differs from EXPECTED, echo
-# the expectation to stderr and fail; otherwise print "OK".
+# both sides to stderr and fail; otherwise print "OK". ACTUAL is labelled on the
+# failure path too: unlabelled, a run that printed nothing reads as a missing
+# expectation rather than as an empty actual.
 assert_output() {
     local actual="$1" expected="$2"
     echo "$actual"
     if [ "$actual" != "$expected" ]; then
+        if [ -n "$actual" ]; then
+            echo "FAIL: actual:" >&2
+            echo "$actual" >&2
+        else
+            echo "FAIL: actual: <empty>" >&2
+        fi
         echo "FAIL: expected:" >&2
         echo "$expected" >&2
         return 1

--- a/gates/_common.sh
+++ b/gates/_common.sh
@@ -2851,6 +2851,82 @@ run_bounded() {
     run_with_watchdog "${DN2CPP_RUN_WATCHDOG_SECS:-600}" "$@"
 }
 
+# ── Run diagnostics ───────────────────────────────────────────────────────────
+# A gate that redirects a run's stderr to a temp dir and deletes that dir on EXIT
+# throws away the only account of a binary that died before writing a byte — the
+# failing assert then reports an empty actual and no cause. These print the
+# account before the dir goes, so use them wherever a run's stderr is captured.
+
+# _gate_run_termination CODE STDERR_FILE — one line classifying how a run ended.
+_gate_run_termination() {
+    local code="$1" stderr_file="$2" signal_no signal_name
+    if [ -z "$code" ]; then
+        echo "termination: not run" >&2
+    elif [ -f "$stderr_file" ] && \
+            grep -qF 'WATCHDOG: no exit after ' "$stderr_file"; then
+        echo "termination: watchdog" >&2
+    elif [ "$code" -ge 128 ] && [ "$code" -le 255 ]; then
+        signal_no=$((code - 128))
+        signal_name=$(kill -l "$signal_no" 2>/dev/null || true)
+        echo "termination: signal $signal_no${signal_name:+ ($signal_name)}" >&2
+    elif [ "$code" -eq 0 ]; then
+        echo "termination: normal exit" >&2
+    else
+        echo "termination: nonzero exit" >&2
+    fi
+}
+
+# gate_run_diag LABEL CODE STDOUT STDERR_FILE — one run arm's full account.
+gate_run_diag() {
+    local label="$1" code="$2" stdout="$3" stderr_file="$4"
+
+    echo "---- $label diagnostics ----" >&2
+    echo "exit code: ${code:-<not run>}" >&2
+    _gate_run_termination "$code" "$stderr_file"
+    if [ -n "$stdout" ]; then
+        echo "stdout:" >&2
+        printf '%s\n' "$stdout" >&2
+    else
+        echo "stdout: <empty>" >&2
+    fi
+    if [ -s "$stderr_file" ]; then
+        echo "stderr:" >&2
+        cat "$stderr_file" >&2
+    else
+        echo "stderr: <empty>" >&2
+    fi
+}
+
+# gate_run_diag_once — call the sourcing gate's optional gate_run_diagnostics
+# hook, at most once: the assert path and the EXIT path both reach for it.
+_GATE_RUN_DIAG_DONE=0
+gate_run_diag_once() {
+    [ "$_GATE_RUN_DIAG_DONE" -eq 0 ] || return 0
+    _GATE_RUN_DIAG_DONE=1
+    if declare -F gate_run_diagnostics >/dev/null; then
+        gate_run_diagnostics
+    fi
+}
+
+# gate_run_logs_init SLUG LABEL — mint the run-stderr dir as _GATE_RUN_LOG_DIR
+# and arm its cleanup. A hook, not a bare trap: the gate may hold a lock.
+gate_run_logs_init() {
+    _GATE_RUN_LOG_DIR=$(mktemp -d "${TMPDIR:-/tmp}/dn2cpp_$1.XXXXXX")
+    _GATE_RUN_LOG_LABEL="$2"
+    gate_add_exit_hook gate_run_logs_cleanup
+}
+
+# gate_run_logs_cleanup — drop the logs on success, keep and explain them on
+# failure. Reads the exit status through _GATE_EXIT_RC: a hook cannot see `$?`.
+gate_run_logs_cleanup() {
+    if [ "${_GATE_EXIT_RC:-0}" -eq 0 ]; then
+        rm -rf "$_GATE_RUN_LOG_DIR"
+        return
+    fi
+    gate_run_diag_once
+    echo "$_GATE_RUN_LOG_LABEL stderr logs preserved in $_GATE_RUN_LOG_DIR" >&2
+}
+
 # wait_ready_line NAME PID OUT ERR [SECONDS] — echo the first COMPLETE line the
 # background server PID writes to OUT, or print the evidence and return 1.
 # A pid that already exited fails at once: waiting the deadline out for a dead
@@ -3146,6 +3222,9 @@ gate_add_exit_hook() {
 }
 _gate_run_exit_hooks() {
     local rc=$? i
+    # A hook runs under `|| true` and sees the previous hook's status, never the
+    # script's, so the status a hook needs is published here.
+    _GATE_EXIT_RC="$rc"
     for (( i = ${#_gate_exit_hooks[@]} - 1; i >= 0; i-- )); do
         eval "${_gate_exit_hooks[i]}" || true
     done

--- a/gates/build-and-run-external-ref-barrier.sh
+++ b/gates/build-and-run-external-ref-barrier.sh
@@ -79,8 +79,18 @@ fi
 echo "== 4/4 Compiling C++ and running (STW + incremental; exact diff vs real .NET) =="
 compile_console "$OUT" "$project"
 
-log_dir=$(mktemp -d "${TMPDIR:-/tmp}/dn2cpp_extrefbarrier.XXXXXX")
-trap 'rm -rf "$log_dir"' EXIT
+gate_run_logs_init extrefbarrier "$project"
+log_dir="$_GATE_RUN_LOG_DIR"
+stw=
+stw_code=
+incremental=
+incremental_code=
+
+gate_run_diagnostics() {
+    gate_run_diag "$project STW" "$stw_code" "$stw" "$log_dir/stw.log"
+    gate_run_diag "$project incremental" "$incremental_code" "$incremental" \
+        "$log_dir/incremental.log"
+}
 
 set +e
 expected=$(run_bounded dotnet "$app"); expected_code=$?
@@ -91,10 +101,15 @@ incremental=$(DN2CPP_GC_INCREMENTAL=1 DN2CPP_GC_STATS=1 \
 set -e
 _gate_scratch_cleanup
 
-assert_output "$stw" "$expected"
-assert_exit_code "$stw_code" "$expected_code"
-assert_output "$incremental" "$expected"
-assert_exit_code "$incremental_code" "$expected_code"
+assertions_failed=0
+assert_output "$stw" "$expected" || assertions_failed=1
+assert_exit_code "$stw_code" "$expected_code" || assertions_failed=1
+assert_output "$incremental" "$expected" || assertions_failed=1
+assert_exit_code "$incremental_code" "$expected_code" || assertions_failed=1
+if [ "$assertions_failed" -ne 0 ]; then
+    gate_run_diag_once
+    exit 1
+fi
 
 if [ "$(grep -cF 'external reference stores:' <<<"$incremental")" -ne 1 ]; then
     echo "FAIL: the external-reference section did not run exactly once" >&2

--- a/gates/build-and-run-gc-upstream.sh
+++ b/gates/build-and-run-gc-upstream.sh
@@ -29,66 +29,18 @@ fi
 echo "== 4/4 Compiling C++ (upstream GC backend) and running (STW + incremental; exact diff vs real .NET) =="
 compile_console "$out" "$project"
 
-log_dir=$(mktemp -d "${TMPDIR:-/tmp}/dn2cpp_gcupstream.XXXXXX")
+gate_run_logs_init gcupstream GC-upstream
+log_dir="$_GATE_RUN_LOG_DIR"
 stw=
 stw_code=
 incremental=
 incremental_code=
-diagnostics_printed=0
 
-print_arm_diagnostics() {
-    local label="$1" code="$2" stdout="$3" stderr_file="$4"
-    local signal_no signal_name
-
-    echo "---- GC-upstream $label diagnostics ----" >&2
-    echo "exit code: ${code:-<not run>}" >&2
-    if [ -z "$code" ]; then
-        echo "termination: not run" >&2
-    elif [ -f "$stderr_file" ] && \
-            grep -qF 'WATCHDOG: no exit after ' "$stderr_file"; then
-        echo "termination: watchdog" >&2
-    elif [ "$code" -ge 128 ] && [ "$code" -le 255 ]; then
-        signal_no=$((code - 128))
-        signal_name=$(kill -l "$signal_no" 2>/dev/null || true)
-        echo "termination: signal $signal_no${signal_name:+ ($signal_name)}" >&2
-    elif [ "$code" -eq 0 ]; then
-        echo "termination: normal exit" >&2
-    else
-        echo "termination: nonzero exit" >&2
-    fi
-    if [ -n "$stdout" ]; then
-        echo "stdout:" >&2
-        printf '%s\n' "$stdout" >&2
-    else
-        echo "stdout: <empty>" >&2
-    fi
-    if [ -s "$stderr_file" ]; then
-        echo "stderr:" >&2
-        cat "$stderr_file" >&2
-    else
-        echo "stderr: <empty>" >&2
-    fi
-}
-
-print_run_diagnostics() {
-    print_arm_diagnostics "STW" "$stw_code" "$stw" "$log_dir/stw.log"
-    print_arm_diagnostics "incremental" "$incremental_code" "$incremental" \
+gate_run_diagnostics() {
+    gate_run_diag "GC-upstream STW" "$stw_code" "$stw" "$log_dir/stw.log"
+    gate_run_diag "GC-upstream incremental" "$incremental_code" "$incremental" \
         "$log_dir/incremental.log"
-    diagnostics_printed=1
 }
-
-cleanup_run_logs() {
-    local code=$?
-    if [ "$code" -eq 0 ]; then
-        rm -rf "$log_dir"
-        return
-    fi
-    if [ "$diagnostics_printed" -eq 0 ]; then
-        print_run_diagnostics
-    fi
-    echo "GC-upstream stderr logs preserved in $log_dir" >&2
-}
-trap cleanup_run_logs EXIT
 
 set +e
 _gate_run_argv
@@ -111,7 +63,7 @@ assert_exit_code "$stw_code" "$expected_code" || assertions_failed=1
 assert_output "$incremental" "$expected" || assertions_failed=1
 assert_exit_code "$incremental_code" "$expected_code" || assertions_failed=1
 if [ "$assertions_failed" -ne 0 ]; then
-    print_run_diagnostics
+    gate_run_diag_once
     exit 1
 fi
 

--- a/gates/build-and-run-gc-write-barrier.sh
+++ b/gates/build-and-run-gc-write-barrier.sh
@@ -48,8 +48,18 @@ _cmake_step "$out/dn2cpp-build.log" "building the write-barrier probe" \
     "$CMAKE" --build "$out"
 
 echo "== 3/3 Running the probe (STW + incremental) =="
-log_dir=$(mktemp -d "${TMPDIR:-/tmp}/dn2cpp_gcbarrier.XXXXXX")
-trap 'rm -rf "$log_dir"' EXIT
+gate_run_logs_init gcbarrier "write-barrier probe"
+log_dir="$_GATE_RUN_LOG_DIR"
+stw=
+stw_code=
+incremental=
+incremental_code=
+
+gate_run_diagnostics() {
+    gate_run_diag "write-barrier probe STW" "$stw_code" "$stw" "$log_dir/stw.log"
+    gate_run_diag "write-barrier probe incremental" "$incremental_code" \
+        "$incremental" "$log_dir/incremental.log"
+}
 
 set +e
 stw=$(DN2CPP_GC_INCREMENTAL=0 DN2CPP_GC_STATS=1 \
@@ -74,13 +84,14 @@ fi
 # Stop-the-world has no window at all, so every subject survives — including the
 # unbarriered ones, which is the control on the incremental arm below. No window
 # to report either, which is why the arms differ by that line.
+assertions_failed=0
 assert_output "$(strip_cr_win "$stw")" "incremental mode: off
 plain store: lost 0 of 64
 barriered store: lost 0 of 64
 plain memmove: lost 0 of 64
 dn2cpp_gc_memmove_refs: lost 0 of 64
-unpublished control: lost 0 of 64"
-assert_exit_code "$stw_code" 0
+unpublished control: lost 0 of 64" || assertions_failed=1
+assert_exit_code "$stw_code" 0 || assertions_failed=1
 
 # Incremental: an unbarriered store is lost at every increment count (the payload
 # is allocated white inside the cycle and the block stored into is clean-marked,
@@ -95,7 +106,11 @@ barriered store: lost 0 of 64
 plain memmove: lost 64 of 64
 dn2cpp_gc_memmove_refs: lost 0 of 64
 unpublished control: lost 64 of 64
-window held: 64 of 64"
-assert_exit_code "$incremental_code" 0
+window held: 64 of 64" || assertions_failed=1
+assert_exit_code "$incremental_code" 0 || assertions_failed=1
+if [ "$assertions_failed" -ne 0 ]; then
+    gate_run_diag_once
+    exit 1
+fi
 
 gate_cache_commit

--- a/gates/build-and-run-godot-anchor-churn.sh
+++ b/gates/build-and-run-godot-anchor-churn.sh
@@ -48,8 +48,18 @@ _cmake_step "$out/dn2cpp-build.log" "building the anchor-churn probe" \
     "$CMAKE" --build "$out"
 
 echo "== 3/3 Running the probe (STW + incremental) =="
-log_dir=$(mktemp -d "${TMPDIR:-/tmp}/dn2cpp_anchorchurn.XXXXXX")
-trap 'rm -rf "$log_dir"' EXIT
+gate_run_logs_init anchorchurn "anchor-churn probe"
+log_dir="$_GATE_RUN_LOG_DIR"
+stw=
+stw_code=
+incremental=
+incremental_code=
+
+gate_run_diagnostics() {
+    gate_run_diag "anchor-churn probe STW" "$stw_code" "$stw" "$log_dir/stw.log"
+    gate_run_diag "anchor-churn probe incremental" "$incremental_code" \
+        "$incremental" "$log_dir/incremental.log"
+}
 
 set +e
 stw=$(DN2CPP_GC_INCREMENTAL=0 DN2CPP_GC_STATS=1 \
@@ -73,10 +83,11 @@ fi
 
 # Stop-the-world has no window at all, so this arm is the control on the probe
 # itself: full churn, every shim survives, every teardown reclaims.
+assertions_failed=0
 assert_output "$(strip_cr_win "$stw")" "incremental mode: off
 kept shims lost: 0 of 6144
-reclaimed at teardown: 6144 of 6144"
-assert_exit_code "$stw_code" 0
+reclaimed at teardown: 6144 of 6144" || assertions_failed=1
+assert_exit_code "$stw_code" 0 || assertions_failed=1
 
 # Incremental: every trial's compaction ran inside an observed split of the
 # table's scan (the probe exits non-zero naming the trial otherwise), so the
@@ -84,7 +95,11 @@ assert_exit_code "$stw_code" 0
 assert_output "$(strip_cr_win "$incremental")" "incremental mode: on
 kept shims lost: 0 of 6144
 reclaimed at teardown: 6144 of 6144
-window held: 16 of 16"
-assert_exit_code "$incremental_code" 0
+window held: 16 of 16" || assertions_failed=1
+assert_exit_code "$incremental_code" 0 || assertions_failed=1
+if [ "$assertions_failed" -ne 0 ]; then
+    gate_run_diag_once
+    exit 1
+fi
 
 gate_cache_commit

--- a/gates/build-and-run-weak-references.sh
+++ b/gates/build-and-run-weak-references.sh
@@ -49,8 +49,18 @@ fi
 echo "== 4/4 Compiling C++ and running (STW + incremental; exact diff vs real .NET) =="
 compile_console "$out" "$project"
 
-log_dir=$(mktemp -d "${TMPDIR:-/tmp}/dn2cpp_weakrefs.XXXXXX")
-trap 'rm -rf "$log_dir"' EXIT
+gate_run_logs_init weakrefs WeakReferences
+log_dir="$_GATE_RUN_LOG_DIR"
+stw=
+stw_code=
+incremental=
+incremental_code=
+
+gate_run_diagnostics() {
+    gate_run_diag "WeakReferences STW" "$stw_code" "$stw" "$log_dir/stw.log"
+    gate_run_diag "WeakReferences incremental" "$incremental_code" "$incremental" \
+        "$log_dir/incremental.log"
+}
 
 set +e
 _gate_run_argv
@@ -67,10 +77,15 @@ incremental=$(DN2CPP_GC_INCREMENTAL=1 DN2CPP_GC_STATS=1 \
 set -e
 _gate_scratch_cleanup
 
-assert_output "$stw" "$expected"
-assert_exit_code "$stw_code" "$expected_code"
-assert_output "$incremental" "$expected"
-assert_exit_code "$incremental_code" "$expected_code"
+assertions_failed=0
+assert_output "$stw" "$expected" || assertions_failed=1
+assert_exit_code "$stw_code" "$expected_code" || assertions_failed=1
+assert_output "$incremental" "$expected" || assertions_failed=1
+assert_exit_code "$incremental_code" "$expected_code" || assertions_failed=1
+if [ "$assertions_failed" -ne 0 ]; then
+    gate_run_diag_once
+    exit 1
+fi
 
 if ! grep -qF '[dn2cpp] GC mode: stop-the-world' "$log_dir/stw.log"; then
     echo "FAIL: WeakReferences STW arm did not report stop-the-world mode" >&2

--- a/gates/measure-suppress-scan.sh
+++ b/gates/measure-suppress-scan.sh
@@ -19,8 +19,19 @@ _corelib_gate_core "$project" "$out"
 echo "== 2/2 Compiling C++ and running (exact diff vs real .NET + suppress-set walk cost) =="
 compile_console "$out" "$project"
 
-log_dir=$(mktemp -d "${TMPDIR:-/tmp}/dn2cpp_suppresscost.XXXXXX")
-trap 'rm -rf "$log_dir"' EXIT
+gate_run_logs_init suppresscost suppress-scan
+log_dir="$_GATE_RUN_LOG_DIR"
+native=
+native_code=
+expected=
+expected_code=
+
+gate_run_diagnostics() {
+    gate_run_diag "suppress-scan native" "$native_code" "$native" \
+        "$log_dir/native.log"
+    gate_run_diag "suppress-scan oracle" "$expected_code" "$expected" \
+        "$log_dir/oracle.log"
+}
 
 set +e
 _gate_run_argv
@@ -32,8 +43,13 @@ expected=$(run_bounded dotnet "$_CG_APP" \
 set -e
 _gate_scratch_cleanup
 
-assert_output "$native" "$expected"
-assert_exit_code "$native_code" "$expected_code"
+assertions_failed=0
+assert_output "$native" "$expected" || assertions_failed=1
+assert_exit_code "$native_code" "$expected_code" || assertions_failed=1
+if [ "$assertions_failed" -ne 0 ]; then
+    gate_run_diag_once
+    exit 1
+fi
 
 # A native Windows binary writes CRLF, which every number below would carry.
 stats=$(LC_ALL=C tr -d '\r' <"$log_dir/native.log")


### PR DESCRIPTION
## 概要

ゲートが実行アームの stderr を temp ディレクトリへ捨てたうえで EXIT で消していたため、
native バイナリが 1 バイトも出さずに落ちると「actual が空」しか残らず原因が消えていた。
分類と保存を `gates/_common.sh` の診断ヘルパ族へ共通化し、同型の 6 ゲートへ展開した。

- `gate_run_logs_init` / `gate_run_diag` / `gate_run_diag_once` / `gate_run_logs_cleanup` を新設。
  終了コードから watchdog・シグナル（名前つき）・異常終了を分類し、失敗時のみログを保存して場所を告げる。
- 実装が 1 ゲートにローカルで生えていた `build-and-run-gc-upstream.sh` は共通版へ移送（**出力バイト一致**）。
- 各ゲートのアサートを `assertions_failed` 集約形にした。
  「最初の assert で即死」→「全アサート後にまとめて落ちる」の挙動差は**意図的**で、
  片方のアームが死んでももう片方の証拠が隠れなくなる方向（gc-upstream が既に採っていた形）。
- `assert_output` の不一致時 stderr に actual 側のラベルを追加（空なら `<empty>`）。stdout は不変。

## 背景（何が消えていたか）

macOS CI で `weak-references` が落ちた際、ゲートログに残ったのは actual = 空文字列と expected だけだった。
native は数秒で異常終了していたが、原因を持つ stderr は
`gates/build-and-run-weak-references.sh` の `mktemp -d` + `trap 'rm -rf …' EXIT` が消していた。
`assert_output` が落ちると `set -e` で即終了し、トラップがログごと原因を持ち去る構造。
同じ穴は以前 `gc-upstream` でも観測され、そのときは 1 ゲートの中だけで塞がれていた。
（関連: #31 — 既にクローズ済みのため参照のみ）

変更後、同じ失敗は以下のように出る:

```
FAIL: actual: <empty>
FAIL: expected:
alive=True
OK
FAIL: native exited 134, expected 0
---- WeakReferences STW diagnostics ----
exit code: 134
termination: signal 6 (ABRT)
stdout: <empty>
stderr:
dyld: symbol not found
WeakReferences stderr logs preserved in /var/folders/…/dn2cpp_weakrefs.cflqiH
```

## 検証

- `bash -n` を変更した 7 スクリプト全てに通過、`git diff --check` clean。
- **gc-upstream 挙動不変**: 変更前後で `DN2CPP_GATE_CACHE=0` の全出力を取得し diff
  → MSBuild の経過時間行 1 本を除き空。失敗経路（`DN2CPP_RUN_WATCHDOG_SECS=0`）でも
  mktemp サフィックスを正規化したうえで **diff 空**。
- 分類の単体確認: normal exit / not run / nonzero / `signal 6 (ABRT)` / watchdog の 5 系統。
- 回帰（`DN2CPP_GATE_CACHE=0`、いずれも exit 0）: weak-references / external-ref-barrier /
  gc-write-barrier / godot-anchor-churn / measure-suppress-scan / gc-upstream、
  加えて doc-claims（78 claims）と verify-locks（43 checks）。
- `SKIP_GODOT=1 ./gates/run-all-gates.sh`。