### PR TITLE
Lower GC allocated-bytes queries to runtime counters

### DIFF
--- a/gates/build-and-run-selfhost-prim-subset.sh
+++ b/gates/build-and-run-selfhost-prim-subset.sh
@@ -57,10 +57,11 @@
 #     allocated on another Thread — the line that separates per-thread
 #     accounting from a process-wide approximation. The approximate total is
 #     asserted non-negative and monotone ONLY: real .NET's figure reads stale
-#     per-thread buffers and a fresh 1 MiB may not appear. The precise total
-#     has no such carve-out and must cover the 1 MiB. It sits in this bucket
-#     because it starts a Thread: this gate is the bucket's sole driver, so no
-#     wasm axis reaches the section.
+#     per-thread buffers and a fresh 1 MiB may not appear. It is also read while
+#     a worker allocates, covering the synchronized Boehm statistics path. The
+#     precise total has no such carve-out and must cover the 1 MiB. It sits in
+#     this bucket because it starts a Thread: this gate is the bucket's sole
+#     driver, so no wasm axis reaches the section.
 # Driven by the real System.Private.CoreLib (passed with -r) -> cross-assembly resolve
 # + tree-shake -> native binary -> run, asserting the output diffs exact vs real .NET.
 source "$(dirname "$0")/_common.sh"

--- a/gates/build-and-run-selfhost-prim-subset.sh
+++ b/gates/build-and-run-selfhost-prim-subset.sh
@@ -48,6 +48,19 @@
 #     It is driven LAST, after the sections above: it forces a GC.Collect() and prints
 #     process-wide GC facts, so nothing else may inherit its collection.
 #
+#  GcAllocatedBytesSubset — GC.GetAllocatedBytesForCurrentThread and
+#     GC.GetTotalAllocatedBytes(bool), lowered to the runtime's thread_local
+#     accounting at the three dn2cpp_alloc entry points. Raw counts differ
+#     (dn2cpp counts requested bytes, pinned included), so the section asserts
+#     invariants: the per-thread counter is non-negative, monotone, covers a
+#     1 MiB allocation, stays flat across a quiet window and across 8 MiB
+#     allocated on another Thread — the line that separates per-thread
+#     accounting from a process-wide approximation. The approximate total is
+#     asserted non-negative and monotone ONLY: real .NET's figure reads stale
+#     per-thread buffers and a fresh 1 MiB may not appear. The precise total
+#     has no such carve-out and must cover the 1 MiB. It sits in this bucket
+#     because it starts a Thread: this gate is the bucket's sole driver, so no
+#     wasm axis reaches the section.
 # Driven by the real System.Private.CoreLib (passed with -r) -> cross-assembly resolve
 # + tree-shake -> native binary -> run, asserting the output diffs exact vs real .NET.
 source "$(dirname "$0")/_common.sh"

--- a/runtime/core/dn2cpp_core.h
+++ b/runtime/core/dn2cpp_core.h
@@ -2389,6 +2389,12 @@ int32_t dn2cpp_gc_collection_count();
 int64_t dn2cpp_gc_heap_size_bytes();
 int64_t dn2cpp_gc_free_bytes();
 
+// GC.GetAllocatedBytesForCurrentThread / GC.GetTotalAllocatedBytes(precise): cumulative
+// allocation counters, never decreasing. The per-thread one counts REQUESTED bytes (no
+// granule rounding); pinned blocks are included, so both sit slightly above real .NET.
+int64_t dn2cpp_gc_allocated_bytes_current_thread();
+int64_t dn2cpp_gc_total_allocated_bytes();
+
 [[noreturn]] void dn2cpp_fail(const char* message);
 
 // What an EMPTY virtual slot holds. A null pointer there would jump to address 0 when

--- a/runtime/core/dn2cpp_gc.cpp
+++ b/runtime/core/dn2cpp_gc.cpp
@@ -2221,8 +2221,10 @@ int64_t dn2cpp_gc_allocated_bytes_current_thread()
 int64_t dn2cpp_gc_total_allocated_bytes()
 {
 #ifdef DN2CPP_USE_BOEHM_GC
-    // Boehm's own lifetime total across all threads (granule-rounded).
-    return static_cast<int64_t>(GC_get_total_bytes());
+    // GC_get_total_bytes is unsynchronized; take its value under Boehm's lock.
+    GC_word total = 0;
+    GC_get_heap_usage_safe(nullptr, nullptr, nullptr, nullptr, &total);
+    return static_cast<int64_t>(total);
 #else
     return static_cast<int64_t>(g_gc_total_bytes_fallback.load(std::memory_order_relaxed));
 #endif

--- a/runtime/core/dn2cpp_gc.cpp
+++ b/runtime/core/dn2cpp_gc.cpp
@@ -854,6 +854,23 @@ void dn2cpp_cctor_run_startup(void (*ensure)(), const char* type)
     }
 }
 
+// GC.GetAllocatedBytesForCurrentThread accounting: per-thread cumulative REQUESTED
+// bytes (no granule rounding), pinned blocks included — slightly above real .NET.
+static thread_local uint64_t t_gc_bytes_allocated;
+#ifndef DN2CPP_USE_BOEHM_GC
+// Process total for GC.GetTotalAllocatedBytes when Boehm's own lifetime counter
+// (GC_get_total_bytes) is not there to answer.
+static std::atomic<uint64_t> g_gc_total_bytes_fallback;
+#endif
+
+static inline void gc_account_alloc(size_t size)
+{
+    t_gc_bytes_allocated += size;
+#ifndef DN2CPP_USE_BOEHM_GC
+    g_gc_total_bytes_fallback.fetch_add(size, std::memory_order_relaxed);
+#endif
+}
+
 void* dn2cpp_alloc(size_t size)
 {
 #ifdef DN2CPP_USE_BOEHM_GC
@@ -865,6 +882,7 @@ void* dn2cpp_alloc(size_t size)
 #endif
     if (p == nullptr)
         dn2cpp_fail("OutOfMemoryException");
+    gc_account_alloc(size);
     return p;
 }
 
@@ -882,6 +900,7 @@ void* dn2cpp_alloc_atomic(size_t size)
 #endif
     if (p == nullptr)
         dn2cpp_fail("OutOfMemoryException");
+    gc_account_alloc(size);
     return p;
 }
 
@@ -952,6 +971,7 @@ void* dn2cpp_alloc_pinned(size_t size)
 #endif
     if (p == nullptr)
         dn2cpp_fail("OutOfMemoryException");
+    gc_account_alloc(size);
     return p;
 }
 
@@ -2190,6 +2210,21 @@ int64_t dn2cpp_gc_get_total_memory(int32_t forceFullCollection)
 #else
     (void)forceFullCollection;
     return 0; // heap usage is not modeled under the calloc fallback
+#endif
+}
+
+int64_t dn2cpp_gc_allocated_bytes_current_thread()
+{
+    return static_cast<int64_t>(t_gc_bytes_allocated);
+}
+
+int64_t dn2cpp_gc_total_allocated_bytes()
+{
+#ifdef DN2CPP_USE_BOEHM_GC
+    // Boehm's own lifetime total across all threads (granule-rounded).
+    return static_cast<int64_t>(GC_get_total_bytes());
+#else
+    return static_cast<int64_t>(g_gc_total_bytes_fallback.load(std::memory_order_relaxed));
 #endif
 }
 

--- a/samples/dotnet/SelfHostPrimSubset/GcAllocatedBytesSubset.cs
+++ b/samples/dotnet/SelfHostPrimSubset/GcAllocatedBytesSubset.cs
@@ -16,6 +16,9 @@ internal static class Program
     private static byte[] s_keep;
     private static byte[] s_keepOther;
     private static long s_sink;
+    private static int s_totalReaderStart;
+    private static int s_totalAllocatorReady;
+    private static int s_totalAllocatorDone;
 
     // Allocation-free by construction; the dn2cpp side's quiet delta is exactly 0.
     private static long Spin()
@@ -64,6 +67,34 @@ internal static class Program
         long t1 = GC.GetTotalAllocatedBytes(false);
         Console.WriteLine($"total-allocated-nonneg={t0 >= 0}");
         Console.WriteLine($"total-allocated-monotone={t1 >= t0}");
+
+        // Read the process total while another thread repeatedly allocates. This
+        // keeps the query on Boehm's synchronized statistics path, not its
+        // lock-free getter, under the concurrent workload callers use.
+        var totalAllocator = new Thread(() =>
+        {
+            while (Volatile.Read(ref s_totalReaderStart) == 0)
+                Thread.Yield();
+            for (int i = 0; i < 32; i++)
+            {
+                s_keepOther = new byte[1 << 20];
+                Volatile.Write(ref s_totalAllocatorReady, 1);
+                Thread.Yield();
+            }
+            Volatile.Write(ref s_totalAllocatorDone, 1);
+        });
+        totalAllocator.Start();
+        Volatile.Write(ref s_totalReaderStart, 1);
+        while (Volatile.Read(ref s_totalAllocatorReady) == 0)
+            Thread.Yield();
+        int totalReads = 0;
+        do
+        {
+            _ = GC.GetTotalAllocatedBytes(false);
+            totalReads++;
+        } while (Volatile.Read(ref s_totalAllocatorDone) == 0);
+        totalAllocator.Join();
+        Console.WriteLine($"total-allocated-concurrent-read={totalReads > 0}");
 
         // Precise total has no staleness carve-out: a 1 MiB allocation must be
         // covered on both runtimes.

--- a/samples/dotnet/SelfHostPrimSubset/GcAllocatedBytesSubset.cs
+++ b/samples/dotnet/SelfHostPrimSubset/GcAllocatedBytesSubset.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Threading;
+
+namespace GcAllocatedBytesSubset;
+
+// GC.GetAllocatedBytesForCurrentThread / GetTotalAllocatedBytes over the
+// runtime's thread_local allocation accounting. Raw byte counts differ between
+// the runtimes (dn2cpp counts requested bytes, pinned included), so only the
+// invariants both must satisfy are printed. Lives in this bucket because a
+// section may start a Thread here: this gate is the bucket's only driver and
+// has no wasm axis, where threads would throw.
+internal static class Program
+{
+    // Static keeps: a dropped store would let the JIT elide the very allocation
+    // the probe measures.
+    private static byte[] s_keep;
+    private static byte[] s_keepOther;
+    private static long s_sink;
+
+    // Allocation-free by construction; the dn2cpp side's quiet delta is exactly 0.
+    private static long Spin()
+    {
+        long s = 0;
+        for (int i = 0; i < 100000; i++)
+            s += i * 3;
+        return s;
+    }
+
+    internal static void __GateEntry()
+    {
+        long a0 = GC.GetAllocatedBytesForCurrentThread();
+        Console.WriteLine($"alloc-nonneg={a0 >= 0}");
+
+        s_keep = new byte[1 << 20];
+        long a1 = GC.GetAllocatedBytesForCurrentThread();
+        Console.WriteLine($"alloc-delta-covers={a1 - a0 >= (1 << 20)}");
+        Console.WriteLine($"alloc-monotone={a1 >= a0}");
+
+        // The decisive per-thread test: 8 MiB allocated on another thread must
+        // not show up in this thread's counter. The window's own cost on real
+        // .NET is the Thread object and Start/Join bookkeeping (hundreds of
+        // bytes measured); < 1 MiB leaves three orders of magnitude of margin
+        // while still convicting a process-wide approximation.
+        long b0 = GC.GetAllocatedBytesForCurrentThread();
+        var t = new Thread(() => { s_keepOther = new byte[8 << 20]; });
+        t.Start();
+        t.Join();
+        long b1 = GC.GetAllocatedBytesForCurrentThread();
+        Console.WriteLine($"alloc-thread-isolated={b1 - b0 < (1 << 20)}");
+
+        // A quiet window: warm Spin up first so tiered-JIT churn on real .NET
+        // lands outside it (measured 0 after warm-up); the threshold, not
+        // zero, keeps the oracle side flake-proof.
+        s_sink = Spin();
+        long q0 = GC.GetAllocatedBytesForCurrentThread();
+        s_sink += Spin();
+        long q1 = GC.GetAllocatedBytesForCurrentThread();
+        Console.WriteLine($"alloc-quiet-small={q1 - q0 < 4096}");
+
+        // Approximate total: real .NET reads stale per-thread buffers, so a
+        // fresh 1 MiB may not appear at all — assert only non-negative and
+        // monotone, never "it grew".
+        long t0 = GC.GetTotalAllocatedBytes(false);
+        long t1 = GC.GetTotalAllocatedBytes(false);
+        Console.WriteLine($"total-allocated-nonneg={t0 >= 0}");
+        Console.WriteLine($"total-allocated-monotone={t1 >= t0}");
+
+        // Precise total has no staleness carve-out: a 1 MiB allocation must be
+        // covered on both runtimes.
+        long p0 = GC.GetTotalAllocatedBytes(true);
+        s_keep = new byte[1 << 20];
+        long p1 = GC.GetTotalAllocatedBytes(true);
+        Console.WriteLine($"total-precise-covers={p1 - p0 >= (1 << 20)}");
+    }
+}

--- a/samples/dotnet/SelfHostPrimSubset/Program.cs
+++ b/samples/dotnet/SelfHostPrimSubset/Program.cs
@@ -55,5 +55,6 @@ internal static class Program
 
         // Driven last so nothing it does can perturb the sections above.
         MiscIntrinsicSubset.Program.__GateEntry();
+        GcAllocatedBytesSubset.Program.__GateEntry();
     }
 }

--- a/src/Dn2Cpp.Transpiler/Compilation.Resolve.cs
+++ b/src/Dn2Cpp.Transpiler/Compilation.Resolve.cs
@@ -430,7 +430,8 @@ internal sealed partial class Compilation
                 if (CoreIntrinsics.MrMarshalInterop.Matches(mrParent, mrName, Sig))
                     return null;
                 // The System.GC CUT family (shape-gated: SuppressFinalize / ReRegisterForFinalize
-                // / GetTotalMemory take one arg, Collect / WaitForPendingFinalizers none). The
+                // / GetTotalMemory / GetTotalAllocatedBytes take one arg, Collect /
+                // WaitForPendingFinalizers / GetAllocatedBytesForCurrentThread none). The
                 // predicate is shared with the emit route, so the two cannot disagree about
                 // which overloads are lowered. KeepAlive is EMIT-ONLY (route-without-cut), so
                 // the resolver deliberately does NOT reference MrGcKeepAlive — its real body

--- a/src/Dn2Cpp.Transpiler/CoreIntrinsics.Intercepts.cs
+++ b/src/Dn2Cpp.Transpiler/CoreIntrinsics.Intercepts.cs
@@ -193,7 +193,8 @@ internal enum InterceptEmitArm
     /// <summary>The System.GC surface lowered inline to the dn2cpp_gc_* /
     /// dn2cpp_keep_alive helpers — the arm dispatches by member name+shape over
     /// the whole family (SuppressFinalize / ReRegisterForFinalize / Collect /
-    /// WaitForPendingFinalizers / GetTotalMemory / KeepAlive). Shared by the cut
+    /// WaitForPendingFinalizers / GetTotalMemory / GetAllocatedBytesForCurrentThread /
+    /// GetTotalAllocatedBytes / KeepAlive). Shared by the cut
     /// row (<see cref="CoreIntrinsics.MrGc"/>) and the emit-only KeepAlive row
     /// (<see cref="CoreIntrinsics.MrGcKeepAlive"/> — route-without-cut).</summary>
     GcFamily,
@@ -886,20 +887,23 @@ internal static partial class CoreIntrinsics
         extra: static (_, _, sig) => sig().GenericParameterCount == 0);
 
     /// <summary>The System.GC CUT family (shape-gated): SuppressFinalize /
-    /// ReRegisterForFinalize / GetTotalMemory take one argument, Collect /
-    /// WaitForPendingFinalizers take none. KeepAlive is deliberately NOT here —
+    /// ReRegisterForFinalize / GetTotalMemory / GetTotalAllocatedBytes take one
+    /// argument, Collect / WaitForPendingFinalizers /
+    /// GetAllocatedBytesForCurrentThread take none. KeepAlive is deliberately NOT here —
     /// it is route-without-cut (<see cref="MrGcKeepAlive"/>), because an empty
     /// transpiled body is inlinable and -O2 would erase the liveness barrier it
     /// exists to provide. The shape gate lives inside the predicate; sig() is
-    /// touched only for the five named members, never for KeepAlive or an
+    /// touched only for the named members, never for KeepAlive or an
     /// unrelated GC member.</summary>
     public static readonly MemberRefIntercept MrGc = new(
         InterceptCutKind.Cut, InterceptEmitArm.GcFamily,
         typeGate: "System.GC",
         extra: static (_, n, sig) => n switch
         {
-            "SuppressFinalize" or "ReRegisterForFinalize" or "GetTotalMemory" => sig().ParameterTypes.Length == 1,
-            "Collect" or "WaitForPendingFinalizers" => sig().ParameterTypes.Length == 0,
+            "SuppressFinalize" or "ReRegisterForFinalize" or "GetTotalMemory"
+                or "GetTotalAllocatedBytes" => sig().ParameterTypes.Length == 1,
+            "Collect" or "WaitForPendingFinalizers"
+                or "GetAllocatedBytesForCurrentThread" => sig().ParameterTypes.Length == 0,
             _ => false,
         });
 

--- a/src/Dn2Cpp.Transpiler/CoreIntrinsics.cs
+++ b/src/Dn2Cpp.Transpiler/CoreIntrinsics.cs
@@ -1054,9 +1054,13 @@ internal static partial class CoreIntrinsics
         // kind) -> the Boehm heap-accounting fill of the GCMemoryInfoData the public
         // GetGCMemoryInfo news up. Both real bodies are bodyless FCalls into native GC
         // accounting dn2cpp answers from bdwgc instead.
+        // GetAllocatedBytesForCurrentThread (a bodyless InternalCall) and
+        // GetTotalAllocatedBytes (whose body branches to two bodyless InternalCalls)
+        // -> the dn2cpp_gc allocation counters.
         "System.GC" => name is "SuppressFinalize" or "ReRegisterForFinalize" or "Collect"
             or "WaitForPendingFinalizers" or "GetTotalMemory" or "KeepAlive"
-            or "_CollectionCount" or "GetMemoryInfo",
+            or "_CollectionCount" or "GetMemoryInfo"
+            or "GetAllocatedBytesForCurrentThread" or "GetTotalAllocatedBytes",
         // SpanHelpers.Memmove -> std::memmove. Cutting the managed entry makes both its
         // hand-unrolled Unsafe.* loop and the SpanHelpers::memmove InternalCall fallback
         // (MemmoveNative) unreachable.

--- a/src/Dn2Cpp.Transpiler/MethodCompiler.Call.cs
+++ b/src/Dn2Cpp.Transpiler/MethodCompiler.Call.cs
@@ -138,6 +138,15 @@ internal sealed partial class MethodCompiler
                         Push(StackKind.I8, "int64_t", $"dn2cpp_gc_get_total_memory((int32_t)({force.Expr}))");
                         return true;
                     }
+                    case "GetAllocatedBytesForCurrentThread":
+                        Push(StackKind.I8, "int64_t", "dn2cpp_gc_allocated_bytes_current_thread()");
+                        return true;
+                    case "GetTotalAllocatedBytes":
+                        // Boehm keeps one lifetime total; precise/approximate is a
+                        // distinction its accounting does not make, so drop the flag.
+                        Pop();
+                        Push(StackKind.I8, "int64_t", "dn2cpp_gc_total_allocated_bytes()");
+                        return true;
                     case "KeepAlive":
                     {
                         var o = Pop();
@@ -731,7 +740,8 @@ internal sealed partial class MethodCompiler
                     return;
                 // The System.GC surface -> dn2cpp_gc_* helpers. The cut family
                 // (SuppressFinalize / ReRegisterForFinalize / Collect /
-                // WaitForPendingFinalizers / GetTotalMemory, shape-gated) shares its
+                // WaitForPendingFinalizers / GetTotalMemory / GetAllocatedBytesFor-
+                // CurrentThread / GetTotalAllocatedBytes, shape-gated) shares its
                 // predicate with the reachability cut; KeepAlive is EMIT-ONLY
                 // (route-without-cut — an empty transpiled body is inlinable and -O2 erases
                 // the liveness barrier), so it is a distinct row the resolver never

--- a/src/Dn2Cpp.Transpiler/MethodCompiler.EmitIntrinsic.Interop.cs
+++ b/src/Dn2Cpp.Transpiler/MethodCompiler.EmitIntrinsic.Interop.cs
@@ -548,6 +548,19 @@ internal sealed partial class MethodCompiler
                 Push(StackKind.I8, "int64_t", $"dn2cpp_gc_get_total_memory((int32_t)({force.Expr}))");
                 return true;
             }
+            case ("System.GC", "GetAllocatedBytesForCurrentThread")
+                when callee.Signature.ParameterTypes.Length == 0 && callee.IsStatic:
+                Push(StackKind.I8, "int64_t", "dn2cpp_gc_allocated_bytes_current_thread()");
+                return true;
+            case ("System.GC", "GetTotalAllocatedBytes")
+                when callee.Signature.ParameterTypes.Length == 1 && callee.IsStatic:
+            {
+                // Boehm keeps one lifetime total; precise/approximate is a distinction
+                // its accounting does not make, so drop the flag.
+                Pop();
+                Push(StackKind.I8, "int64_t", "dn2cpp_gc_total_allocated_bytes()");
+                return true;
+            }
             case ("System.GC", "KeepAlive")
                 when callee.Signature.ParameterTypes.Length == 1 && callee.IsStatic:
             {


### PR DESCRIPTION
Closes #38.

`GC.GetAllocatedBytesForCurrentThread()` は IL ボディを持たない InternalCall で、
intrinsic マッピングが無いため転写が落ちていました。`GC.GetTotalAllocatedBytes(bool)`
も一段先の同じ穴です（ボディは持つが、分岐先 2 本がボディ無し InternalCall）。
どちらもランタイムのカウンタへ lowering します。

## per-thread の会計は近似ではなく本物

Boehm に per-thread の確保カウンタは無く、`GC_get_total_bytes()` はプロセス全体です。
それを返すと、ファイナライザスレッドや worker の確保がこのスレッドの確保として現れ、
この API に求められる唯一のこと — フレームが何も確保していないことの証明 — が壊れます。
ランタイムの GC ヒープ確保は `dn2cpp_alloc` / `dn2cpp_alloc_atomic` / `dn2cpp_alloc_pinned`
の 3 入口に完全に閉じているので、そこに `thread_local` カウンタを置けば名前どおりの
意味論が成立します。

カウンタは要求サイズ基準（granule 切り上げを含まない）で pinned ブロックも数えるため、
実 .NET よりわずかに過大方向です — 漏れを見るプローブとしては過大が安全側です。
`DN2CPP_NO_GC` の calloc フォールバックでも数えます。あの経路も実際に確保しており、
これは自前の帳簿だからです。

`GetTotalAllocatedBytes` は Boehm の lifetime total を読みます（フォールバックでは
relaxed atomic）。`precise` フラグは捨てます — その会計は precise/approximate を
区別しないためです。

## ゲート

`samples/dotnet/SelfHostPrimSubset/` に新セクションを追加しました。このバケットは
wasm 軸を持たず駆動ゲートが 1 本だけで、それがセクションで `Thread` を起こせる理由です。
出力は生の数値ではなく、両ランタイムが満たす不変条件だけです。決め手は
`alloc-thread-isolated`: 別スレッドで 8 MiB 確保しても、このスレッドのカウンタの差分は
1 MiB 未満（実測 368 B）に留まります。プロセス全体の近似ならここを通れません。

`total-allocated-monotone` は意図的に「増える」ことを主張していません。実 .NET の
approximate total は stale な per-thread バッファを読むため、1 MiB 確保しても
まったく動かないことがあります。precise オーバーロードにその逃げ道は無いので、
そちらで 1 MiB を含むことを主張しています。

## 検証

- `DN2CPP_GATE_CACHE=0 gates/build-and-run-selfhost-prim-subset.sh` green。変更前の出力が
  変更後の出力のバイト一致 prefix であること、およびオラクル・native とも 5 回反復して
  バイト一致することを確認。
- `gates/run-all-gates.sh`: 120/127 green、0 failed。7 スキップは self-host バイナリを
  ベイクしていない新規 worktree の chain E。
- `gates/pre-merge.sh` は未実行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpHUMKWW7uYtTqH3DGdXye