### PR TITLE
Give Debugger logging NativeAOT's answers

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -237,6 +237,12 @@ arm decides it:
   **An unmodeled shape throws, always.** Cut by NAME, lower by SHAPE, end the
   table in a throw.
 
+**The debugger-logging surface is NativeAOT's**: `Debugger.IsLogging` const-folds
+false and `Debugger.LogInternal` is `Bounded` `Silent`, so `DebugProvider` keeps
+only its `Interop.Sys.SysLog` arm and a `Trace`/`Debug` write goes to syslog
+(stderr on wasm), never to stdout — asserted by the misc-intrinsics section of
+`gates/build-and-run-selfhost-prim-subset.sh`.
+
 The sub-word integers sit in both arms and take the loud side in both: their
 `ToString`/`Parse`/`TryParse`/`TryFormat` reach the number-formatting cascade, so
 falling through trades a loud failure for silent bloat. .NET gives all eight

--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -131,10 +131,12 @@ user identity, and the low-level monitor.
   already-blittable shapes, so those calls direct-link once the modules are
   admitted to `Compilation.IsRuntimeProvidedPInvokeModule`. The port is a line in
   the transpiler and a `target_link_libraries` row.
-- **wasm defines three.**
+- **wasm defines four.**
   `runtime/core/platform/wasm/dn2cpp_system_native_wasm.cpp` supplies
   `SystemNative_GetCryptographicallySecureRandomBytes`, whose caller is not a
-  P/Invoke at all, plus the `pal_time.c` clocks behind
+  P/Invoke at all, `SystemNative_SysLog` — the Trace/Debug sink `DebugProvider`
+  falls to once `Debugger.IsLogging` const-folds false, hence reached by any game
+  that logs — plus the `pal_time.c` clocks behind
   `Stopwatch.GetTimestamp` and `Environment.TickCount64`. Both user calls resolve
   from MemberReferences to real CoreLib bodies and reach P/Invokes. An in-CoreLib
   MethodDefinition call to `TickCount64` can instead take the

--- a/gates/build-and-run-selfhost-prim-subset.sh
+++ b/gates/build-and-run-selfhost-prim-subset.sh
@@ -37,7 +37,14 @@
 #       * System.Numerics.BitOperations.{TrailingZeroCount, LeadingZeroCount, PopCount,
 #         Log2} over int/uint/long/ulong, lowered to the ctz/clz/popcount clang builtins
 #         at the argument's width (the nint/nuint overloads stay BCL-as-IL);
-#       * Debugger.IsAttached, the GC.CollectionCount / GetGCMemoryInfo bindings over
+#       * Debugger.IsAttached, and the Trace/Debug write path: Debugger.IsLogging
+#         const-folds false (NativeAOT parity), which prunes DebugProvider's
+#         Debugger.Log arm and leaves the transpiled Interop.Sys.SysLog leaf — so a
+#         Trace.WriteLine links the SystemNative_SysLog PAL entry and, like a direct
+#         Debugger.Log, prints nothing. Trace puts System.Diagnostics.TraceSource on
+#         the -r set below, and TraceListener.Attributes pulls
+#         System.Collections.Specialized in behind it;
+#       * the GC.CollectionCount / GetGCMemoryInfo bindings over
 #         the vendored Boehm GC, and AssemblyLoadContext.LoadFromAssemblyPath's trap;
 #       * the Thrive startup shape AppDomain.CurrentDomain.GetAssemblies().Where(...)
 #         .Count() — the degraded set must carry the DECLARED Assembly[] runtime
@@ -66,4 +73,5 @@
 # + tree-shake -> native binary -> run, asserting the output diffs exact vs real .NET.
 source "$(dirname "$0")/_common.sh"
 
-corelib_diff_gate SelfHostPrimSubset System.Linq
+corelib_diff_gate SelfHostPrimSubset System.Linq System.Diagnostics.TraceSource \
+    System.Collections.Specialized

--- a/runtime/core/platform/posix/dn2cpp_system_native.cpp
+++ b/runtime/core/platform/posix/dn2cpp_system_native.cpp
@@ -49,6 +49,7 @@
 #include <sys/time.h>
 #include <sys/types.h>
 #include <sys/utsname.h>
+#include <syslog.h>
 #include <unistd.h>
 
 #if defined(__APPLE__)
@@ -447,6 +448,23 @@ int32_t SystemNative_Write(intptr_t fd, const void* buffer, int32_t bufferSize)
     {
     }
     return (int32_t)n;
+}
+
+// pal_io.c SystemNative_SysLog: the sink DebugProvider.WriteToDebugger falls to
+// once Debugger.IsLogging const-folds false, i.e. where Trace/Debug output goes on
+// this lane — syslog, not stdout, exactly as under NativeAOT. `message` is the
+// format ("%s") and `arg1` its argument; the PAL passes both through unchanged, and
+// the managed SysLogPriority values are the host's LOG_* already.
+void SystemNative_SysLog(int32_t priority, const char* message, const char* arg1)
+{
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
+#endif
+    ::syslog(priority, message, arg1);
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 }
 
 int32_t SystemNative_PRead(intptr_t fd, void* buffer, int32_t bufferSize, int64_t fileOffset)

--- a/runtime/core/platform/wasm/dn2cpp_system_native_wasm.cpp
+++ b/runtime/core/platform/wasm/dn2cpp_system_native_wasm.cpp
@@ -3,7 +3,7 @@
 //
 // The bulk of that surface (platform/posix/dn2cpp_system_native.cpp) is the
 // file-I/O P/Invoke closure, and it is deliberately NOT part of the wasm build.
-// Three things it also defines are not file I/O, and each is here for its own
+// Four things it also defines are not file I/O, and each is here for its own
 // reason — the exclusion was written for the closure and covers none of them.
 //
 //   * The CSPRNG has a caller that is not a P/Invoke at all and IS compiled on
@@ -13,6 +13,8 @@
 //     user MemberReference to Environment.TickCount64 reach through their real
 //     BCL bodies. In-CoreLib MethodDefinition calls to TickCount64 can instead
 //     lower to dn2cpp_tickcount64. The engine's Time API is a separate surface.
+//   * SysLog is the Trace/Debug sink DebugProvider falls to, reached by any game
+//     that logs; it is a console entry point, not a file one.
 //
 // Only what a call site actually reaches is defined here. Stopwatch.Frequency is
 // a constant on this CoreLib, so the POSIX twin's timestamp-resolution entry does
@@ -31,6 +33,7 @@
 // Environment.TickCount64.
 
 #include <cstdint>
+#include <cstdio>   // fprintf — the SysLog stand-in
 #include <ctime>    // clock_gettime
 #include <unistd.h> // getentropy
 
@@ -92,6 +95,25 @@ int64_t SystemNative_GetLowResolutionTimestamp(void)
     if (::clock_gettime(CLOCK_MONOTONIC, &ts) != 0)
         return 0;
     return (int64_t)ts.tv_sec * 1000 + (int64_t)(ts.tv_nsec / 1000000);
+}
+
+// pal_io.c SystemNative_SysLog, the sink DebugProvider.WriteToDebugger falls to
+// once Debugger.IsLogging const-folds false — a Trace/Debug write reaches it from
+// any game that logs, and on a side module an undefined one throws at the first
+// call. A browser has no syslog, so this writes stderr (the browser console);
+// `message` is the format ("%s") and `arg1` its argument, as on the POSIX twin.
+void SystemNative_SysLog(int32_t priority, const char* message, const char* arg1)
+{
+    (void)priority;
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
+#endif
+    ::fprintf(stderr, message, arg1);
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+    ::fputc('\n', stderr);
 }
 
 } // extern "C"

--- a/samples/dotnet/SelfHostPrimSubset/MiscIntrinsicSubset.cs
+++ b/samples/dotnet/SelfHostPrimSubset/MiscIntrinsicSubset.cs
@@ -60,6 +60,14 @@ internal static class Program
         // oracle runs under `dotnet` with none attached.
         Console.WriteLine($"dbg={System.Diagnostics.Debugger.IsAttached}");
 
+        // Debugger.IsLogging const-folds false (NativeAOT parity), so a Trace/Debug
+        // write lands in SystemNative_SysLog and a direct Debugger.Log is a bound
+        // no-op. Neither may reach stdout — the oracle agrees, hence the marker line
+        // below: a section whose subject prints nothing cannot prove it ran.
+        System.Diagnostics.Trace.WriteLine("must not reach stdout");
+        System.Diagnostics.Debugger.Log(0, null, "must not reach stdout");
+        Console.WriteLine($"dbg_log={System.Diagnostics.Debugger.IsAttached}|done");
+
         // GC statistics bind to the vendored Boehm GC. Raw counts are nondeterministic,
         // so assert only what holds identically on real .NET: non-negative and monotone.
         int cc0 = GC.CollectionCount(0);

--- a/src/Dn2Cpp.Transpiler/CoreIntrinsics.cs
+++ b/src/Dn2Cpp.Transpiler/CoreIntrinsics.cs
@@ -743,6 +743,11 @@ internal static partial class CoreIntrinsics
         // present. Neither is a degrade.
         [("System.Diagnostics.Debugger", "IsManagedDebuggerAttached")] = BoundedVerdict.Silent,
         [("System.Diagnostics.Debugger", "BreakInternal")] = BoundedVerdict.Silent,
+        // The public Debugger.Log calls LogInternal unconditionally (no IsLogging guard),
+        // so app code reaching Log directly does not benefit from the IsLogging fold.
+        // Bound at the LibraryImport WRAPPER, never at its `<LogInternal>g____PInvoke|N_0`
+        // stub — that ordinal is a Roslyn artifact and moves with a CoreLib update.
+        [("System.Diagnostics.Debugger", "LogInternal")] = BoundedVerdict.Silent,
         // ComWrappers' COM-vftbl builders — three bodyless QCall externs reached only
         // through ComWrappers..cctor, which TypeDescriptor.GetConverter drags in. With no
         // COM RCW ever created, TryGetComInstance answers false (a true answer: no COM
@@ -1935,7 +1940,13 @@ internal static partial class CoreIntrinsics
     /// value feeds the BranchLiveness verdict: the
     /// `if (!TryEnsure...) CallOnEmptyStack(...)` re-dispatch arm (Regex's
     /// deep-recursion escape hatch) is pruned, keeping StackHelper's
-    /// Task.Run/ContinueWith plumbing out of the tree.</summary>
+    /// Task.Run/ContinueWith plumbing out of the tree.
+    ///
+    /// Debugger.IsLogging: constant-false, NativeAOT's hard-coded answer — a
+    /// transpiled binary has no VM to log into. BranchLiveness prunes
+    /// DebugProvider.WriteToDebugger's then-arm (Debugger.Log, whose leaf is the
+    /// bodyless QCall LogInternal) and leaves Interop.Sys.SysLog the live sink,
+    /// where NativeAOT's Trace/Debug output goes on Unix.</summary>
     private static readonly Dictionary<(string Type, string Method), bool> s_constFoldedGetters = new()
     {
         [("System.Globalization.GlobalizationMode", "get_Invariant")] = true,
@@ -1944,6 +1955,7 @@ internal static partial class CoreIntrinsics
         [("System.Runtime.CompilerServices.RuntimeFeature", "get_IsDynamicCodeCompiled")] = false,
         [("System.Runtime.CompilerServices.RuntimeHelpers", "TryEnsureSufficientExecutionStack")] = true,
         [("System.Threading.StackHelper", "TryEnsureSufficientExecutionStack")] = true,
+        [("System.Diagnostics.Debugger", "IsLogging")] = false,
     };
 
     /// <summary>Method names appearing in <see cref="s_constFoldedGetters"/> —


### PR DESCRIPTION
## 問題

Godot Web export が transpile 中に exit 2 で失敗する:

```
error: System.Diagnostics.Debugger.LogInternal: System.Diagnostics.Debugger::<LogInternal>g____PInvoke|10_0 is an InternalCall/extern method with no IL body and no intrinsic mapping
[chain: ... <- DebugProvider.WriteToDebugger <- DefaultTraceListener.Write <- Trace.WriteLine <- ...]
```

ゲームのログ経路(`Trace.WriteLine` → `DefaultTraceListener` → `DebugProvider.WriteToDebugger` → `Debugger.Log`)の末端が、マッピングの無い CoreLib QCall に行き着くのが原因。

## 修正 — NativeAOT parity

NativeAOT は `Debugger.cs` をソース差し替えしており、`IsLogging()` は定数 `false`、`Log` は実質 no-op、Trace/Debug の出力は syslog(Unix)/ `OutputDebugString`(Windows)行きでコンソールには出ない。本 PR は dn2cpp に同じ答えを与える:

- **Transpiler**(`CoreIntrinsics.cs`): `Debugger.IsLogging` を定数 `false` に fold(BranchLiveness が `WriteToDebugger` の `Debugger.Log` 側の枝を刈り、NativeAOT と同様に `Interop.Sys.SysLog` 側が生きた sink になる)。加えて `Debugger.LogInternal` を `Silent` で bound(public `Debugger.Log` の直接呼び出しをカバー。NativeAOT の `Log` は no-op なので、既定値がそのまま真の答え)。
- **Runtime PAL**: `SystemNative_SysLog` を posix(`syslog(3)` へ転送)と wasm(ブラウザに syslog は無いので stderr へ)に実装。`DebugProvider.WriteToStderr` が到達するのは実装済みの `SystemNative_Write`(pin 済み CoreLib 10.0.11 の IL で実測)なので、`SystemNative_Log` の追加は不要。
- **Gate**: `SelfHostPrimSubset` の misc-intrinsics バケットに新 section — `Trace.WriteLine` と直接の `Debugger.Log` が stdout に届かないことを、section が走ったことを証明する `Console.WriteLine` マーカー付きで実 .NET と diff(`corelib_diff_gate`)。バケットに参照が 2 つ追加で必要だった(`System.Diagnostics.TraceSource`、`System.Collections.Specialized`)— 理由は gate ヘッダーに記載。
- **Docs**: `docs/ARCHITECTURE.md` §4-B に 1 段落。`docs/PORTING.md` の wasm エントリ数を更新(doc-claims gate がカウントを検査している)。

## 検証

- `dotnet build src/Dn2Cpp.Cli -c Release` — OK
- selfhost-prim-subset(新 section、native/oracle がバイト一致。変更前後の oracle diff は `dbg_log=False|done` の 1 行純増のみ)、file-real、eventsource、console-error-subset、wasm-console、doc-claims — すべて green
- `SKIP_GODOT=1 ./gates/run-all-gates.sh` — 108/109 pass、0 fail、1 skip(`cri-wasm-smoke`、このマシンに CRI アセット未導入のため — 想定内)
- 生成 C++ に `SystemNative_SysLog` の呼び出しが実在しリンクも通る = fold と PAL 実装の両方が実際に効いている。

## 申し送り

挙動の注意: この変更後、`Trace.WriteLine` ベースのログは NativeAOT と同様デフォルトでは見えなくなる(Unix は syslog、Web は stderr)。ログを確実にコンソールへ出したいゲームは、ログ出力を `Console.WriteLine` 経由に切り替えるのが正道。

マージ前の残作業: 人間による `./gates/pre-merge.sh` の実行(AGENTS.md の規約どおり、ここでは未実行)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)