### PR TITLE
Add Unity-compatible stripping controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,8 @@ against either matching target-framework build.
 
 Unity-format `link.xml` files are also supported. Pass a project directory with
 the repeatable `--project-root <dir>` option; dn2cpp recursively finds files
-named exactly `link.xml` anywhere below each root. `Dn2Cpp.Build` supplies the
+named exactly `link.xml` anywhere below each root, excluding `bin`, `obj`,
+`.godot`, and `.git` directories. `Dn2Cpp.Build` supplies the
 MSBuild project directory automatically, and the forked editor supplies the C#
 project directory during export. Direct CLI use without `--project-root` does
 not search for XML files. A descriptor cannot add an assembly to the load set;

--- a/README.md
+++ b/README.md
@@ -112,6 +112,56 @@ throw), no HTTP transport (a browser has no socket layer), no real
 `FileStream` (the intercepted `File.*` subset works on MEMFS), and the GC
 is stop-the-world.
 
+### Preserving code from stripping
+
+dn2cpp recognizes Unity-compatible explicit preservation. Apply
+`[Dn2Cpp.Scripting.Preserve]` to an assembly, type, constructor, method,
+property, field, event, or delegate, or define your own attribute whose type or
+base type has the exact simple name `PreserveAttribute`. The latter avoids a
+managed dependency and is recognized regardless of namespace or assembly.
+
+The built-in attribute is in `Dn2Cpp.Runtime.dll`. Reference the copy produced
+by this checkout under `src/Dn2Cpp.Runtime/bin/<configuration>/<framework>/`,
+or the copy under `bin/` in a dn2cpp toolchain or editor bundle. There is no
+separate NuGet package for it.
+
+From a repository checkout, add a project reference:
+
+```xml
+<ItemGroup>
+  <ProjectReference Include="../dn2cpp/src/Dn2Cpp.Runtime/Dn2Cpp.Runtime.csproj" />
+</ItemGroup>
+```
+
+For a toolchain or editor bundle, reference its existing assembly instead:
+
+```xml
+<ItemGroup>
+  <Reference Include="Dn2Cpp.Runtime">
+    <HintPath>path/to/Dn2Cpp/bin/Dn2Cpp.Runtime.dll</HintPath>
+    <Private>false</Private>
+  </Reference>
+</ItemGroup>
+```
+
+Adjust the relative checkout path or bundle path to the project location. The
+assembly contains no platform-specific managed code, so a project may compile
+against either matching target-framework build.
+
+Unity-format `link.xml` files are also supported. Pass a project directory with
+the repeatable `--project-root <dir>` option; dn2cpp recursively finds files
+named exactly `link.xml` anywhere below each root. `Dn2Cpp.Build` supplies the
+MSBuild project directory automatically, and the forked editor supplies the C#
+project directory during export. Direct CLI use without `--project-root` does
+not search for XML files. A descriptor cannot add an assembly to the load set;
+the assembly must already be the input, an explicit or automatic reference, or
+a conditional default reference.
+
+Descriptors guarded by `feature="com"`, `feature="sre"`, or
+`feature="remoting"` apply only when the matching repeatable
+`--link-feature <name>` option is present. The editor enables `com` for Windows
+exports; all other feature values remain disabled unless explicitly requested.
+
 The full list, with the reasoning, is under *Permanent non-goals* below.
 
 ## Quick start

--- a/dist/nuget-smoke-test.sh
+++ b/dist/nuget-smoke-test.sh
@@ -15,10 +15,11 @@
 #   6. run the binary and byte-diff its output against `dotnet`,
 # then prove the Dn2Cpp.Build MSBuild package on top:
 #   7. pack Dn2Cpp.Build into the same feed and generate a scratch console app
-#      that references it from the local feed,
+#      that references it from the local feed; its project-local link.xml keeps
+#      one otherwise-unreachable method in the generated C++,
 #   8. `dotnet publish` the scratch app with the installed tool on PATH — the
-#      packaged targets must transpile + cmake-build it — and byte-diff the
-#      produced native binary against `dotnet run`.
+#      packaged targets must apply link.xml, transpile + cmake-build it — then
+#      byte-diff the produced native binary against `dotnet run`.
 #
 # NOT a regression gate: the filename is deliberately outside the
 # build-and-run-*.sh glob (like the sibling smoke-test.sh), so
@@ -161,9 +162,33 @@ cat > "$MSAPP/MsBuildSmoke.csproj" <<EOF
 </Project>
 EOF
 cat > "$MSAPP/Program.cs" <<'EOF'
-System.Console.WriteLine("hello from the Dn2Cpp.Build native publish");
-for (int i = 1; i <= 3; i++)
-    System.Console.WriteLine($"square({i}) = {i * i}");
+using System;
+
+namespace MsBuildSmoke;
+
+internal static class Program
+{
+    private static void Main()
+    {
+        Console.WriteLine("hello from the Dn2Cpp.Build native publish");
+        for (int i = 1; i <= 3; i++)
+            Console.WriteLine($"square({i}) = {i * i}");
+    }
+
+    private static void PreservedOnly()
+    {
+        Console.WriteLine("project link.xml preserved this method");
+    }
+}
+EOF
+cat > "$MSAPP/link.xml" <<'EOF'
+<linker>
+  <assembly fullname="MsBuildSmoke">
+    <type fullname="MsBuildSmoke.Program" preserve="nothing">
+      <method name="PreservedOnly" />
+    </type>
+  </assembly>
+</linker>
 EOF
 
 echo "== 8/8 dotnet publish must produce a working native binary =="
@@ -173,6 +198,18 @@ NUGET_PACKAGES="$PWD/$WORK/nuget-cache" PATH="$PWD/$TOOLS:$PATH" \
     dotnet publish "$MSAPP/MsBuildSmoke.csproj" -c "$CONFIG"
 NATIVE="$MSAPP/bin/$CONFIG/$TFM/publish/MsBuildSmoke"
 [ -x "$NATIVE" ] || { echo "error: publish produced no native binary: $NATIVE" >&2; exit 1; }
+MSGEN="$MSAPP/obj/$CONFIG/$TFM/dn2cpp"
+awk '
+    /^\/\/ MsBuildSmoke.Program::PreservedOnly$/ {
+        getline
+        if ($0 ~ /^inline void m_MsBuildSmoke_Program_PreservedOnly_[0-9]+\(\)$/)
+            found = 1
+    }
+    END { exit !found }
+' "$MSGEN/generated.h" || {
+    echo "error: Dn2Cpp.Build did not apply the project-local link.xml" >&2
+    exit 1
+}
 "$NATIVE" > "$WORK/msbuild-native.txt"
 dotnet "$MSAPP/bin/$CONFIG/$TFM/publish/MsBuildSmoke.dll" > "$WORK/msbuild-managed.txt"
 diff -u "$WORK/msbuild-managed.txt" "$WORK/msbuild-native.txt"

--- a/gates/build-and-run-preserve-control.sh
+++ b/gates/build-and-run-preserve-control.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Explicit stripping-control gate: built-in/custom/derived PreserveAttribute and
+# recursively merged Unity-format link.xml retain otherwise unreachable bodies.
+source "$(dirname "$0")/_common.sh"
+
+PROJECT=PreserveControl
+ROOT="samples/dotnet/$PROJECT"
+LIBPROJECT=samples/dotnet/PreserveControlLib
+ASSEMBLYPROJECT=samples/dotnet/PreserveAssemblyLib
+
+echo "== Building app and checking both Runtime target frameworks =="
+build_proj "$ROOT/$PROJECT.csproj"
+build_proj src/Dn2Cpp.Cli.Console/Dn2Cpp.Cli.Console.csproj
+if [ -z "${DN2CPP_SKIP_BUILD:-}" ]; then
+    dotnet build src/Dn2Cpp.Runtime/Dn2Cpp.Runtime.csproj -c "$CONFIG" -f net8.0 \
+        --nologo -v:minimal
+fi
+[ -f "src/Dn2Cpp.Runtime/bin/$CONFIG/net8.0/Dn2Cpp.Runtime.dll" ] \
+    || { echo "FAIL: Dn2Cpp.Runtime net8.0 output is missing" >&2; exit 1; }
+[ -f "src/Dn2Cpp.Runtime/bin/$CONFIG/net10.0/Dn2Cpp.Runtime.dll" ] \
+    || { echo "FAIL: Dn2Cpp.Runtime net10.0 output is missing" >&2; exit 1; }
+grep -q -- '--project-root &quot;$(MSBuildProjectDirectory)&quot;' \
+    src/Dn2Cpp.Build/build/Dn2Cpp.Build.targets \
+    || { echo "FAIL: Dn2Cpp.Build does not pass the consuming project root" >&2; exit 1; }
+
+APP="$ROOT/bin/$CONFIG/$TFM/$PROJECT.dll"
+LIBDLL="$LIBPROJECT/bin/$CONFIG/$TFM/PreserveControlLib.dll"
+ASSEMBLYDLL="$ASSEMBLYPROJECT/bin/$CONFIG/$TFM/PreserveAssemblyLib.dll"
+OUT=artifacts/preserve-control
+
+echo "== Transpiling with recursive project roots and the com feature =="
+transpile=$(invoke_cli "$APP" -r "$LIBDLL" -r "$ASSEMBLYDLL" --auto-ref --trim-reflection \
+    --project-root "$ROOT" --project-root "$ROOT/./" --link-feature com -o "$OUT" 2>&1)
+printf '%s\n' "$transpile"
+grep -q "NoSuchType" <<<"$transpile" \
+    || { echo "FAIL: a missing type did not produce a warning naming the target" >&2; exit 1; }
+grep -q "NoSuch&Member" <<<"$transpile" \
+    || { echo "FAIL: a missing member did not warn with its decoded entity" >&2; exit 1; }
+if grep -q "NoSuchAssembly" <<<"$transpile"; then
+    echo "FAIL: ignoreIfMissing did not suppress the missing-assembly warning" >&2
+    exit 1
+fi
+
+for symbol in BuiltInMethod SameNameMethod DerivedMethod get_PreservedProperty \
+        set_PreservedProperty add_PreservedEvent remove_PreservedEvent XmlMethod \
+        SignatureIntMarker get_XmlProperty add_XmlEvent remove_XmlEvent ComMethod GenericMethod \
+        ConditionalUsedMarker FieldSignatureType SignaturePropertyGetMarker \
+        SignatureEventAddMarker SignatureEventRemoveMarker AssemblyOnlyTarget__ctor AttributeMembers__ctor \
+        PreservedField dginvoke_PreserveControlLib_PreservedDelegate \
+        methtab_PreserveControlLib_PreservedDelegate SelectedChainLeaf FieldsModePayload \
+        ConditionalChainLeaf; do
+    grep -q "$symbol" "$OUT"/generated* \
+        || { echo "FAIL: preserved body $symbol is absent from generated C++" >&2; exit 1; }
+done
+for symbol in DroppedMethod NotKeptByTypeAttribute SignatureNoArgMarker set_XmlProperty \
+        SreMethod ConditionalUnusedMarker SignaturePropertySetMarker \
+        AssemblyMethodNotKept ConditionalUnusedChainLeaf \
+        NotSelected FieldsModeMethodDrop IgnoreIfUnreferencedMethod; do
+    if grep -Fq "_${symbol}_" "$OUT"/generated*; then
+        echo "FAIL: unselected body $symbol survived stripping" >&2
+        exit 1
+    fi
+done
+
+echo "== Assembly element without children preserves the whole assembly =="
+WHOLE=artifacts/preserve-control-whole
+invoke_cli "$APP" -r "$LIBDLL" -r "$ASSEMBLYDLL" --auto-ref --project-root "$ROOT" \
+    --link-feature remoting -o "$WHOLE"
+grep -Fq "_DroppedMethod_" "$WHOLE"/generated* \
+    || { echo "FAIL: childless assembly descriptor did not preserve all methods" >&2; exit 1; }
+
+if gate_cache_check "$OUT" "preserve-control|com" \
+        "$APP" "$LIBDLL" "$ASSEMBLYDLL" "$ROOT/link.xml" "$ROOT/Nested/link.xml" \
+        gates/expected/preserve-control.txt; then
+    gate_cache_hit_msg
+else
+    compile_console "$OUT" "$PROJECT"
+    native=$("./$OUT/$PROJECT")
+    assert_output "$(strip_cr_win "$native")" "$(cat gates/expected/preserve-control.txt)"
+    gate_cache_commit
+fi
+
+echo "== Invalid link feature and malformed XML fail before emission =="
+set +e
+feature_err=$(invoke_cli "$APP" -r "$LIBDLL" -r "$ASSEMBLYDLL" \
+    --link-feature typo -o artifacts/preserve-feature-bad 2>&1)
+feature_code=$?
+malformed_err=$(invoke_cli "$APP" -r "$LIBDLL" -r "$ASSEMBLYDLL" \
+    --project-root samples/dotnet/PreserveControlMalformed -o artifacts/preserve-malformed 2>&1)
+malformed_code=$?
+set -e
+[ "$feature_code" -ne 0 ] && grep -q "com, sre, or remoting" <<<"$feature_err" \
+    || { echo "FAIL: invalid --link-feature was not rejected clearly" >&2; exit 1; }
+[ "$malformed_code" -ne 0 ] && grep -q "PreserveControlMalformed/link.xml" <<<"$malformed_err" \
+    || { echo "FAIL: malformed link.xml did not fail naming its path" >&2; exit 1; }
+
+CONSOLE_CLI="src/Dn2Cpp.Cli.Console/bin/$CONFIG/$TFM/dn2cpp-console.dll"
+set +e
+console_err=$(dotnet exec "$CONSOLE_CLI" "$APP" --link-feature typo 2>&1)
+console_code=$?
+set -e
+[ "$console_code" -ne 0 ] && grep -q "com, sre, or remoting" <<<"$console_err" \
+    || { echo "FAIL: console CLI did not validate --link-feature" >&2; exit 1; }
+
+for fixture in PreserveControlUnknownElement PreserveControlUnknownPreserve \
+        PreserveControlUnknownFeature PreserveControlBadDeclaration \
+        PreserveControlIgnoredInvalid; do
+    set +e
+    schema_err=$(invoke_cli "$APP" -r "$LIBDLL" -r "$ASSEMBLYDLL" \
+        --project-root "samples/dotnet/$fixture" -o "artifacts/$fixture" 2>&1)
+    schema_code=$?
+    set -e
+    [ "$schema_code" -ne 0 ] && grep -q "$fixture/link.xml" <<<"$schema_err" \
+        || { echo "FAIL: $fixture did not hard-fail naming its descriptor" >&2; exit 1; }
+done
+
+echo "OK"

--- a/gates/build-and-run-preserve-control.sh
+++ b/gates/build-and-run-preserve-control.sh
@@ -27,10 +27,24 @@ APP="$ROOT/bin/$CONFIG/$TFM/$PROJECT.dll"
 LIBDLL="$LIBPROJECT/bin/$CONFIG/$TFM/PreserveControlLib.dll"
 ASSEMBLYDLL="$ASSEMBLYPROJECT/bin/$CONFIG/$TFM/PreserveAssemblyLib.dll"
 OUT=artifacts/preserve-control
+mkdir -p artifacts
+STALE_ROOT=$(mktemp -d "$PWD/artifacts/preserve-control-stale.XXXXXX")
+cleanup_stale_root() {
+    case "$STALE_ROOT" in
+        "$PWD"/artifacts/preserve-control-stale.*) rm -rf -- "$STALE_ROOT" ;;
+        *) echo "FAIL: refusing to clean unexpected temporary root $STALE_ROOT" >&2 ;;
+    esac
+}
+trap cleanup_stale_root EXIT
+for ignored_dir in bin obj .godot .git; do
+    mkdir -p "$STALE_ROOT/$ignored_dir"
+    printf '<stale-invalid-descriptor' > "$STALE_ROOT/$ignored_dir/link.xml"
+done
 
 echo "== Transpiling with recursive project roots and the com feature =="
 transpile=$(invoke_cli "$APP" -r "$LIBDLL" -r "$ASSEMBLYDLL" --auto-ref --trim-reflection \
-    --project-root "$ROOT" --project-root "$ROOT/./" --link-feature com -o "$OUT" 2>&1)
+    --project-root "$ROOT" --project-root "$ROOT/./" --project-root "$STALE_ROOT" \
+    --link-feature com -o "$OUT" 2>&1)
 printf '%s\n' "$transpile"
 grep -q "NoSuchType" <<<"$transpile" \
     || { echo "FAIL: a missing type did not produce a warning naming the target" >&2; exit 1; }
@@ -41,12 +55,12 @@ if grep -q "NoSuchAssembly" <<<"$transpile"; then
     exit 1
 fi
 
-for symbol in BuiltInMethod SameNameMethod DerivedMethod get_PreservedProperty \
+for symbol in BuiltInMethod SameNameMethod DerivedMethod AssemblyAwareDerivedMethod get_PreservedProperty \
         set_PreservedProperty add_PreservedEvent remove_PreservedEvent XmlMethod \
         SignatureIntMarker get_XmlProperty add_XmlEvent remove_XmlEvent ComMethod GenericMethod \
         ConditionalUsedMarker FieldSignatureType SignaturePropertyGetMarker \
         SignatureEventAddMarker SignatureEventRemoveMarker AssemblyOnlyTarget__ctor AttributeMembers__ctor \
-        PreservedField dginvoke_PreserveControlLib_PreservedDelegate \
+        PreservedField InitializedField dginvoke_PreserveControlLib_PreservedDelegate \
         methtab_PreserveControlLib_PreservedDelegate SelectedChainLeaf FieldsModePayload \
         ConditionalChainLeaf; do
     grep -q "$symbol" "$OUT"/generated* \
@@ -54,7 +68,7 @@ for symbol in BuiltInMethod SameNameMethod DerivedMethod get_PreservedProperty \
 done
 for symbol in DroppedMethod NotKeptByTypeAttribute SignatureNoArgMarker set_XmlProperty \
         SreMethod ConditionalUnusedMarker SignaturePropertySetMarker \
-        AssemblyMethodNotKept ConditionalUnusedChainLeaf \
+        AssemblyMethodNotKept NonDerivedMethod ConditionalUnusedChainLeaf \
         NotSelected FieldsModeMethodDrop IgnoreIfUnreferencedMethod; do
     if grep -Fq "_${symbol}_" "$OUT"/generated*; then
         echo "FAIL: unselected body $symbol survived stripping" >&2

--- a/gates/build-and-run-preserve-control.sh
+++ b/gates/build-and-run-preserve-control.sh
@@ -91,7 +91,8 @@ malformed_code=$?
 set -e
 [ "$feature_code" -ne 0 ] && grep -q "com, sre, or remoting" <<<"$feature_err" \
     || { echo "FAIL: invalid --link-feature was not rejected clearly" >&2; exit 1; }
-[ "$malformed_code" -ne 0 ] && grep -q "PreserveControlMalformed/link.xml" <<<"$malformed_err" \
+[ "$malformed_code" -ne 0 ] \
+    && grep -q "PreserveControlMalformed/link.xml" <<<"$(tr '\\' / <<<"$malformed_err")" \
     || { echo "FAIL: malformed link.xml did not fail naming its path" >&2; exit 1; }
 
 CONSOLE_CLI="src/Dn2Cpp.Cli.Console/bin/$CONFIG/$TFM/dn2cpp-console.dll"
@@ -110,7 +111,8 @@ for fixture in PreserveControlUnknownElement PreserveControlUnknownPreserve \
         --project-root "samples/dotnet/$fixture" -o "artifacts/$fixture" 2>&1)
     schema_code=$?
     set -e
-    [ "$schema_code" -ne 0 ] && grep -q "$fixture/link.xml" <<<"$schema_err" \
+    [ "$schema_code" -ne 0 ] \
+        && grep -q "$fixture/link.xml" <<<"$(tr '\\' / <<<"$schema_err")" \
         || { echo "FAIL: $fixture did not hard-fail naming its descriptor" >&2; exit 1; }
 done
 

--- a/gates/expected/preserve-control.txt
+++ b/gates/expected/preserve-control.txt
@@ -2,9 +2,12 @@ preserve control
 Outer_Nested_Int32
 ConditionalUsed
 built-in
+assembly-aware-derived
 preserved-field=17
 property-set
 property-get
 preserved-property=23
 dropped-method=True
 delegate-invoke=True
+initialized-field=41
+non-derived-dropped=True

--- a/gates/expected/preserve-control.txt
+++ b/gates/expected/preserve-control.txt
@@ -1,0 +1,10 @@
+preserve control
+Outer_Nested_Int32
+ConditionalUsed
+built-in
+preserved-field=17
+property-set
+property-get
+preserved-property=23
+dropped-method=True
+delegate-invoke=True

--- a/gates/run-all-gates.sh
+++ b/gates/run-all-gates.sh
@@ -365,6 +365,11 @@ ok "Gate cache inputs: runtime-tree=$DN2CPP_RUNTIME_HASH dotnet-runtimes=$DN2CPP
 # also builds its reference, so two processes could otherwise write the same
 # shared project's obj/bin at once. Order matters — libraries before dependents.
 ORDERED_PROJECTS=(
+    "src/Dn2Cpp.Runtime/Dn2Cpp.Runtime.csproj"
+    "src/Dn2Cpp.Cli.Console/Dn2Cpp.Cli.Console.csproj"
+    "samples/dotnet/PreserveControlLib/PreserveControlLib.csproj"
+    "samples/dotnet/PreserveAssemblyLib/PreserveAssemblyLib.csproj"
+    "samples/dotnet/PreserveControl/PreserveControl.csproj"
     "samples/dotnet/MiniCorlib/MiniCorlib.csproj"
     "samples/dotnet/XGenericMethodLib/XGenericMethodLib.csproj"
     "src/GodotSharpShim/GodotSharp.csproj"

--- a/samples/dotnet/PreserveAssemblyLib/CollisionAttribute.cs
+++ b/samples/dotnet/PreserveAssemblyLib/CollisionAttribute.cs
@@ -1,0 +1,7 @@
+using System;
+
+namespace PreserveCollision;
+
+public sealed class DuplicateAttribute : Attribute
+{
+}

--- a/samples/dotnet/PreserveAssemblyLib/Library.cs
+++ b/samples/dotnet/PreserveAssemblyLib/Library.cs
@@ -15,3 +15,17 @@ public sealed class AssemblyOnlyTarget
     private static void AssemblyMethodNotKept() => Console.WriteLine("assembly-method-drop");
     private static void IgnoreIfUnreferencedMethod() => Console.WriteLine("ignore-unreferenced");
 }
+
+public sealed class AssemblyFieldTarget
+{
+    [Preserve]
+    private static int InitializedField = Initialize();
+
+    private static int Initialize() => 41;
+}
+
+public sealed class CollidingAttributeTarget
+{
+    [PreserveCollision.Duplicate]
+    private static void NonDerivedMethod() => Console.WriteLine("non-derived-drop");
+}

--- a/samples/dotnet/PreserveAssemblyLib/Library.cs
+++ b/samples/dotnet/PreserveAssemblyLib/Library.cs
@@ -1,0 +1,17 @@
+using System;
+using Dn2Cpp.Scripting;
+
+[assembly: Preserve]
+
+namespace PreserveAssemblyLib;
+
+public sealed class AssemblyOnlyTarget
+{
+    public AssemblyOnlyTarget()
+    {
+        Console.WriteLine("assembly-default-constructor");
+    }
+
+    private static void AssemblyMethodNotKept() => Console.WriteLine("assembly-method-drop");
+    private static void IgnoreIfUnreferencedMethod() => Console.WriteLine("ignore-unreferenced");
+}

--- a/samples/dotnet/PreserveAssemblyLib/PreserveAssemblyLib.csproj
+++ b/samples/dotnet/PreserveAssemblyLib/PreserveAssemblyLib.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>disable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Optimize>true</Optimize>
+    <DebugType>none</DebugType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../../src/Dn2Cpp.Runtime/Dn2Cpp.Runtime.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/dotnet/PreserveControl/Ignored/Link.XML
+++ b/samples/dotnet/PreserveControl/Ignored/Link.XML
@@ -1,0 +1,1 @@
+<this-file-name-is-deliberately-ignored />

--- a/samples/dotnet/PreserveControl/Nested/link.xml
+++ b/samples/dotnet/PreserveControl/Nested/link.xml
@@ -1,0 +1,5 @@
+<linker>
+  <assembly fullname="PreserveControlLib">
+    <type fullname="PreserveControlLib.Outer/Nested`1" preserve="methods" />
+  </assembly>
+</linker>

--- a/samples/dotnet/PreserveControl/PreserveControl.csproj
+++ b/samples/dotnet/PreserveControl/PreserveControl.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>disable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Optimize>true</Optimize>
+    <DebugType>none</DebugType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../PreserveControlLib/PreserveControlLib.csproj" />
+    <ProjectReference Include="../PreserveAssemblyLib/PreserveAssemblyLib.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/dotnet/PreserveControl/Program.cs
+++ b/samples/dotnet/PreserveControl/Program.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Globalization;
+using System.Reflection;
+
+namespace PreserveControl;
+
+internal static class Program
+{
+    private static void Main()
+    {
+        CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+        CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+        Console.WriteLine(PreserveControlLib.Live.Value());
+        Console.WriteLine(typeof(PreserveControlLib.Outer.Nested<int>).Name);
+        Console.WriteLine(typeof(PreserveControlLib.ConditionalUsed).Name);
+        PreservedReflection();
+    }
+
+    private static void PreservedReflection()
+    {
+        const BindingFlags Flags = BindingFlags.NonPublic | BindingFlags.Static;
+        Type type = typeof(PreserveControlLib.AttributeMembers);
+        type.GetMethod("BuiltInMethod", Flags).Invoke(null, null);
+
+        FieldInfo field = type.GetField("PreservedField", Flags);
+        field.SetValue(null, 17);
+        Console.WriteLine("preserved-field=" + field.GetValue(null));
+
+        PropertyInfo property = type.GetProperty("PreservedProperty", Flags);
+        property.SetValue(null, 23);
+        Console.WriteLine("preserved-property=" + property.GetValue(null));
+
+        Console.WriteLine("dropped-method=" + (type.GetMethod("DroppedMethod", Flags) is null));
+        Console.WriteLine("delegate-invoke="
+            + (typeof(PreserveControlLib.PreservedDelegate).GetMethod("Invoke") is not null));
+    }
+}

--- a/samples/dotnet/PreserveControl/Program.cs
+++ b/samples/dotnet/PreserveControl/Program.cs
@@ -14,6 +14,7 @@ internal static class Program
         Console.WriteLine(typeof(PreserveControlLib.Outer.Nested<int>).Name);
         Console.WriteLine(typeof(PreserveControlLib.ConditionalUsed).Name);
         PreservedReflection();
+        ReferencedAssemblyReflection();
     }
 
     private static void PreservedReflection()
@@ -21,6 +22,7 @@ internal static class Program
         const BindingFlags Flags = BindingFlags.NonPublic | BindingFlags.Static;
         Type type = typeof(PreserveControlLib.AttributeMembers);
         type.GetMethod("BuiltInMethod", Flags).Invoke(null, null);
+        type.GetMethod("AssemblyAwareDerivedMethod", Flags).Invoke(null, null);
 
         FieldInfo field = type.GetField("PreservedField", Flags);
         field.SetValue(null, 17);
@@ -33,5 +35,18 @@ internal static class Program
         Console.WriteLine("dropped-method=" + (type.GetMethod("DroppedMethod", Flags) is null));
         Console.WriteLine("delegate-invoke="
             + (typeof(PreserveControlLib.PreservedDelegate).GetMethod("Invoke") is not null));
+    }
+
+    private static void ReferencedAssemblyReflection()
+    {
+        const BindingFlags Flags = BindingFlags.NonPublic | BindingFlags.Static;
+        Assembly assembly = Assembly.Load("PreserveAssemblyLib");
+        Type fieldType = assembly.GetType("PreserveAssemblyLib.AssemblyFieldTarget", true);
+        Console.WriteLine("initialized-field="
+            + fieldType.GetField("InitializedField", Flags).GetValue(null));
+
+        Type collisionType = assembly.GetType("PreserveAssemblyLib.CollidingAttributeTarget", true);
+        Console.WriteLine("non-derived-dropped="
+            + (collisionType.GetMethod("NonDerivedMethod", Flags) is null));
     }
 }

--- a/samples/dotnet/PreserveControl/link.xml
+++ b/samples/dotnet/PreserveControl/link.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<!-- Root descriptor: member selectors, preserve modes and feature gates. -->
+<linker>
+  <assembly fullname="PreserveControl&#76;ib">
+    <type fullname="PreserveControlLib.XmlMembers" preserve="nothing">
+      <method name="XmlMethod" />
+      <method signature="System.Void XmlOverload(System.Int32)" />
+      <method name="NoSuch&amp;Member" />
+      <property name="XmlProperty" accessors="get" />
+      <event name="XmlEvent" />
+    </type>
+    <type fullname="PreserveControlLib.FeatureMembers" preserve="nothing">
+      <method name="ComMethod" feature="com" />
+      <method name="SreMethod" feature="sre" />
+    </type>
+    <type fullname="PreserveControlLib.NoSuch&#84;ype" required="0" />
+    <type fullname="PreserveControlLib.ConditionalUsed" preserve="methods" required="0" />
+    <type fullname="PreserveControlLib.ConditionalUnused" preserve="methods" required="0" />
+    <type fullname="PreserveControlLib.SignatureMembers" preserve="nothing">
+      <field signature="PreserveControlLib.FieldSignatureType SignatureField" />
+      <property signature="System.Int32 SignatureProperty" accessors="get" />
+      <event signature="System.Action SignatureEvent" />
+    </type>
+    <type fullname="PreserveControlLib.Wildcard*" preserve="nothing">
+      <method name="Wildcard*" />
+    </type>
+    <type fullname="PreserveControlLib.FieldsMode" preserve="fields" />
+  </assembly>
+  <assembly fullname="PreserveControlLib" feature="remoting" />
+  <assembly fullname="PreserveAssemblyLib" preserve="all"
+            ignoreIfUnreferenced="1" windowsruntime="true" />
+  <assembly fullname="NoSuchAssembly" ignoreIfMissing="1" />
+</linker>

--- a/samples/dotnet/PreserveControlBadDeclaration/link.xml
+++ b/samples/dotnet/PreserveControlBadDeclaration/link.xml
@@ -1,0 +1,2 @@
+<?xml nonsense="accepted-before"?>
+<linker />

--- a/samples/dotnet/PreserveControlIgnoredInvalid/link.xml
+++ b/samples/dotnet/PreserveControlIgnoredInvalid/link.xml
@@ -1,0 +1,5 @@
+<linker>
+  <assembly fullname="Missing" ignoreIfMissing="1">
+    <unknown />
+  </assembly>
+</linker>

--- a/samples/dotnet/PreserveControlLib/CollisionAttribute.cs
+++ b/samples/dotnet/PreserveControlLib/CollisionAttribute.cs
@@ -1,0 +1,7 @@
+using PreserveControlLib;
+
+namespace PreserveCollision;
+
+public sealed class DuplicateAttribute : PreserveAttribute
+{
+}

--- a/samples/dotnet/PreserveControlLib/Library.cs
+++ b/samples/dotnet/PreserveControlLib/Library.cs
@@ -30,6 +30,9 @@ public sealed class AttributeMembers
     [DerivedPreserve]
     private static void DerivedMethod() => Console.WriteLine("derived");
 
+    [PreserveCollision.Duplicate]
+    private static void AssemblyAwareDerivedMethod() => Console.WriteLine("assembly-aware-derived");
+
     [Preserve]
     private static int PreservedField;
 

--- a/samples/dotnet/PreserveControlLib/Library.cs
+++ b/samples/dotnet/PreserveControlLib/Library.cs
@@ -1,0 +1,156 @@
+using System;
+using Dn2Cpp.Scripting;
+
+namespace PreserveControlLib;
+
+public static class Live
+{
+    public static string Value() => "preserve control";
+}
+
+public class PreserveAttribute : Attribute
+{
+}
+
+public sealed class DerivedPreserveAttribute : PreserveAttribute
+{
+}
+
+public sealed class AttributeMembers
+{
+    [Dn2Cpp.Scripting.Preserve]
+    private AttributeMembers(int ignored) => Console.WriteLine("attribute-constructor");
+
+    [Dn2Cpp.Scripting.Preserve]
+    private static void BuiltInMethod() => Console.WriteLine("built-in");
+
+    [PreserveControlLib.Preserve]
+    private static void SameNameMethod() => Console.WriteLine("same-name");
+
+    [DerivedPreserve]
+    private static void DerivedMethod() => Console.WriteLine("derived");
+
+    [Preserve]
+    private static int PreservedField;
+
+    [Preserve]
+    private static int PreservedProperty
+    {
+        get { Console.WriteLine("property-get"); return PreservedField; }
+        set { Console.WriteLine("property-set"); PreservedField = value; }
+    }
+
+    [Preserve]
+    private static event Action PreservedEvent
+    {
+        add { Console.WriteLine("event-add"); }
+        remove { Console.WriteLine("event-remove"); }
+    }
+
+    private static void DroppedMethod() => Console.WriteLine("drop");
+}
+
+[Dn2Cpp.Scripting.Preserve]
+public sealed class TypeTarget
+{
+    public TypeTarget()
+    {
+        Console.WriteLine("type-ctor");
+    }
+
+    private void NotKeptByTypeAttribute() => Console.WriteLine("type-method-drop");
+}
+
+[Dn2Cpp.Scripting.Preserve]
+public delegate void PreservedDelegate(int value);
+
+public sealed class XmlMembers
+{
+    private static void XmlMethod() => Console.WriteLine("xml-method");
+
+    private static void XmlOverload() => SignatureNoArgMarker();
+    private static void XmlOverload(int value) => SignatureIntMarker();
+    private static void SignatureNoArgMarker() => Console.WriteLine("signature-no-arg");
+    private static void SignatureIntMarker() => Console.WriteLine("signature-int");
+
+    private int XmlProperty
+    {
+        get { Console.WriteLine("xml-property-get"); return 0; }
+        set { Console.WriteLine("xml-property-set"); }
+    }
+
+    private event Action XmlEvent
+    {
+        add { Console.WriteLine("xml-event-add"); }
+        remove { Console.WriteLine("xml-event-remove"); }
+    }
+}
+
+public sealed class ConditionalUsed
+{
+    private static void ConditionalUsedMarker() => ConditionalChainLeaf();
+    private static void ConditionalChainLeaf() => Console.WriteLine("conditional-used-chain");
+}
+
+public sealed class ConditionalUnused
+{
+    private static void ConditionalUnusedMarker() => ConditionalUnusedChainLeaf();
+    private static void ConditionalUnusedChainLeaf() => Console.WriteLine("conditional-unused-chain");
+}
+
+public sealed class WildcardMembers
+{
+    private static void WildcardMethod() => SelectedChainLeaf();
+    private static void SelectedChainLeaf() => Console.WriteLine("wildcard-chain");
+    private static void NotSelected() => Console.WriteLine("wildcard-drop");
+}
+
+public sealed class FieldsModePayload
+{
+}
+
+public sealed class FieldsMode
+{
+    private FieldsModePayload Payload;
+    private static void FieldsModeMethodDrop() => Console.WriteLine("fields-mode-drop");
+}
+
+public sealed class FieldSignatureType
+{
+}
+
+public sealed class SignatureMembers
+{
+    private FieldSignatureType SignatureField;
+
+    private int SignatureProperty
+    {
+        get { SignaturePropertyGetMarker(); return 0; }
+        set { SignaturePropertySetMarker(); }
+    }
+
+    private event Action SignatureEvent
+    {
+        add { SignatureEventAddMarker(); }
+        remove { SignatureEventRemoveMarker(); }
+    }
+
+    private static void SignaturePropertyGetMarker() => Console.WriteLine("signature-property-get");
+    private static void SignaturePropertySetMarker() => Console.WriteLine("signature-property-set");
+    private static void SignatureEventAddMarker() => Console.WriteLine("signature-event-add");
+    private static void SignatureEventRemoveMarker() => Console.WriteLine("signature-event-remove");
+}
+
+public sealed class FeatureMembers
+{
+    private static void ComMethod() => Console.WriteLine("feature-com");
+    private static void SreMethod() => Console.WriteLine("feature-sre");
+}
+
+public static class Outer
+{
+    public sealed class Nested<T>
+    {
+        private static void GenericMethod() => Console.WriteLine("generic-method");
+    }
+}

--- a/samples/dotnet/PreserveControlLib/PreserveControlLib.csproj
+++ b/samples/dotnet/PreserveControlLib/PreserveControlLib.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>disable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Optimize>true</Optimize>
+    <DebugType>none</DebugType>
+    <NoWarn>$(NoWarn);CS0169</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../../src/Dn2Cpp.Runtime/Dn2Cpp.Runtime.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/dotnet/PreserveControlMalformed/link.xml
+++ b/samples/dotnet/PreserveControlMalformed/link.xml
@@ -1,0 +1,1 @@
+<linker><assembly fullname="PreserveControlLib"><type></assembly></linker>

--- a/samples/dotnet/PreserveControlUnknownElement/link.xml
+++ b/samples/dotnet/PreserveControlUnknownElement/link.xml
@@ -1,0 +1,1 @@
+<linker><assembly fullname="PreserveControlLib"><type fullname="PreserveControlLib.XmlMembers"><unknown name="Ignored" feature="sre" /></type></assembly></linker>

--- a/samples/dotnet/PreserveControlUnknownFeature/link.xml
+++ b/samples/dotnet/PreserveControlUnknownFeature/link.xml
@@ -1,0 +1,1 @@
+<linker><assembly fullname="PreserveControlLib" feature="unknown" /></linker>

--- a/samples/dotnet/PreserveControlUnknownPreserve/link.xml
+++ b/samples/dotnet/PreserveControlUnknownPreserve/link.xml
@@ -1,0 +1,1 @@
+<linker><assembly fullname="PreserveControlLib" preserve="sometimes" /></linker>

--- a/src/Dn2Cpp.Build/README.md
+++ b/src/Dn2Cpp.Build/README.md
@@ -27,6 +27,10 @@ and `ninja`.
 | `Dn2CppCMake` / `Dn2CppGenerator` | `cmake` / `Ninja` | Native build front end |
 | `Dn2CppCMakeArgs` | (empty) | Extra cmake configure args |
 
+The publish target always passes `$(MSBuildProjectDirectory)` as a
+`--project-root`, so Unity-format `link.xml` files below the project directory
+participate in stripping without extra configuration.
+
 Console apps only; the Godot lanes (GDExtension / mono-module drop-in) have
 their own export paths — see the
 [repository](https://github.com/takuma-komatsu/dn2cpp).

--- a/src/Dn2Cpp.Build/build/Dn2Cpp.Build.targets
+++ b/src/Dn2Cpp.Build/build/Dn2Cpp.Build.targets
@@ -24,7 +24,7 @@
       <_Dn2CppBuildDir>$([MSBuild]::NormalizeDirectory('$(_Dn2CppGenDir)', 'build'))</_Dn2CppBuildDir>
     </PropertyGroup>
 
-    <Exec Command="$(Dn2CppTool) &quot;$(PublishDir)$(TargetFileName)&quot; -o &quot;$(_Dn2CppGenDir)&quot; $(Dn2CppExtraArgs)" />
+    <Exec Command="$(Dn2CppTool) &quot;$(PublishDir)$(TargetFileName)&quot; -o &quot;$(_Dn2CppGenDir)&quot; --project-root &quot;$(MSBuildProjectDirectory)&quot; $(Dn2CppExtraArgs)" />
 
     <Exec Command="$(Dn2CppCMake) -S &quot;$(_Dn2CppRuntimeDir)&quot; -B &quot;$(_Dn2CppBuildDir)&quot; -G &quot;$(Dn2CppGenerator)&quot; -DDN2CPP_APP_DIR=&quot;$(_Dn2CppGenDir.TrimEnd('/'))&quot; -DDN2CPP_APP_NAME=&quot;$(AssemblyName)&quot; $(Dn2CppCMakeArgs)" />
     <Exec Command="$(Dn2CppCMake) --build &quot;$(_Dn2CppBuildDir)&quot;" />

--- a/src/Dn2Cpp.Cli.Console/Program.cs
+++ b/src/Dn2Cpp.Cli.Console/Program.cs
@@ -7,8 +7,8 @@ using Dn2Cpp;
 // BindingGenerator.Run subtree that the full CLI statically roots but never
 // executes on the console path (=, out of console-self-host scope).
 //
-// Supports only the console transpile arguments — input assembly, -o <dir>,
-// -r <ref.dll>, --measure. There is no --gdextension / --generate-bindings here;
+// Supports only the console transpile arguments, including the shared
+// preservation controls. There is no --gdextension / --generate-bindings here;
 // the GDExtension path lives in the full `dn2cpp` CLI. The transpile pipeline
 // itself is the shared backend-agnostic Dn2Cpp.TranspileDriver, so this CLI's
 // console output is byte-identical to the full CLI's ConsoleBackend path.
@@ -22,6 +22,8 @@ bool sharedGenerics = true;
 bool shadowStack = false;
 var references = new List<string>();
 var noDefaultRefs = new List<string>();
+var projectRoots = new List<string>();
+var linkFeatures = new List<string>();
 
 for (int i = 0; i < args.Length; i++)
 {
@@ -63,6 +65,20 @@ for (int i = 0; i < args.Length; i++)
         // transitive dependency. Opt-in while drift is being measured.
         autoRef = true;
     }
+    else if (args[i] == "--project-root" && i + 1 < args.Length)
+    {
+        projectRoots.Add(args[++i]);
+    }
+    else if (args[i] == "--link-feature" && i + 1 < args.Length)
+    {
+        string feature = args[++i];
+        if (feature != "com" && feature != "sre" && feature != "remoting")
+        {
+            Console.Error.WriteLine($"error: --link-feature expects com, sre, or remoting, got '{feature}'");
+            return 1;
+        }
+        linkFeatures.Add(feature);
+    }
     else if (args[i] == "--no-shared-generics")
     {
         // Escape hatch: compile every generic instantiation monomorphically
@@ -95,7 +111,7 @@ for (int i = 0; i < args.Length; i++)
 
 if (string.IsNullOrEmpty(input))
 {
-    Console.Error.WriteLine("Usage: dn2cpp-console <assembly.dll> [-o <output-dir>] [-r <ref.dll>] [--no-default-ref <DnZlib|DnBrotli|DnHttp>] [--auto-ref] [--no-shared-generics] [--shadow-stack] [--measure] [--verbose]");
+    Console.Error.WriteLine("Usage: dn2cpp-console <assembly.dll> [-o <output-dir>] [-r <ref.dll>] [--no-default-ref <DnZlib|DnBrotli|DnHttp>] [--auto-ref] [--project-root <dir>] [--link-feature <com|sre|remoting>] [--no-shared-generics] [--shadow-stack] [--measure] [--verbose]");
     return 1;
 }
 
@@ -110,4 +126,6 @@ return TranspileDriver.RunConsole(new TranspileOptions
     AutoRef = autoRef,
     SharedGenerics = sharedGenerics,
     ShadowStack = shadowStack,
+    ProjectRoots = projectRoots,
+    LinkFeatures = linkFeatures,
 });

--- a/src/Dn2Cpp.Cli/Program.cs
+++ b/src/Dn2Cpp.Cli/Program.cs
@@ -33,6 +33,8 @@ var reflectionRoots = new List<string>();
 var noManifestResources = new List<string>();
 var manifestResourceRoots = new List<string>();
 var pinvokeModules = new List<string>();
+var projectRoots = new List<string>();
+var linkFeatures = new List<string>();
 bool trimGodotClasses = false;
 var godotClassRoots = new List<string>();
 bool shadowStack = false;
@@ -204,6 +206,20 @@ for (int i = 0; i < args.Length; i++)
         // resolve, instead of requiring every transitive dependency via explicit -r.
         // Opt-in while drift vs. the explicit-ref output is being measured.
         autoRef = true;
+    }
+    else if (args[i] == "--project-root" && i + 1 < args.Length)
+    {
+        projectRoots.Add(args[++i]);
+    }
+    else if (args[i] == "--link-feature" && i + 1 < args.Length)
+    {
+        string feature = args[++i];
+        if (feature != "com" && feature != "sre" && feature != "remoting")
+        {
+            Console.Error.WriteLine($"error: --link-feature expects com, sre, or remoting, got '{feature}'");
+            return 1;
+        }
+        linkFeatures.Add(feature);
     }
     else if (args[i] == "--no-adopt-async" && i + 1 < args.Length)
     {
@@ -453,7 +469,7 @@ if (generateBindings)
 
 if (string.IsNullOrEmpty(input))
 {
-    Console.Error.WriteLine("Usage: dn2cpp <assembly.dll> [-o <output-dir>] [-r <ref.dll>] [--no-default-ref <DnZlib|DnBrotli|DnHttp>] [--pinvoke-module <name>] [--auto-ref] [--no-shared-generics] [--shadow-stack] [--trim-reflection] [--reflection-root <Type.Full.Name>] [--no-manifest-resources <Assembly>] [--manifest-resource-root <manifest.name>] [--trim-godot-classes] [--godot-class-root <Godot.Full.Name>] [--max-heap-mb <n>] [--verbose] [--gdextension [--godot-api <extension_api.json>]] [--dotnet-module] [--hotupdate-base] [--emit-patch <patch.dll> --base-abi <base-abi.json> [--patch-version <n>] [--patch-stackcode]] [--generate-bindings <extension_api.json>] [--check-wasm-imports <side.wasm> <main.wasm> [<main.js>] [--peer-module <peer.wasm>]...] [--print-runtime-dir]");
+    Console.Error.WriteLine("Usage: dn2cpp <assembly.dll> [-o <output-dir>] [-r <ref.dll>] [--no-default-ref <DnZlib|DnBrotli|DnHttp>] [--pinvoke-module <name>] [--auto-ref] [--project-root <dir>] [--link-feature <com|sre|remoting>] [--no-shared-generics] [--shadow-stack] [--trim-reflection] [--reflection-root <Type.Full.Name>] [--no-manifest-resources <Assembly>] [--manifest-resource-root <manifest.name>] [--trim-godot-classes] [--godot-class-root <Godot.Full.Name>] [--max-heap-mb <n>] [--verbose] [--gdextension [--godot-api <extension_api.json>]] [--dotnet-module] [--hotupdate-base] [--emit-patch <patch.dll> --base-abi <base-abi.json> [--patch-version <n>] [--patch-stackcode]] [--generate-bindings <extension_api.json>] [--check-wasm-imports <side.wasm> <main.wasm> [<main.js>] [--peer-module <peer.wasm>]...] [--print-runtime-dir]");
     return 1;
 }
 
@@ -532,5 +548,7 @@ return TranspileDriver.Run(new TranspileOptions
     NoManifestResources = noManifestResources,
     ManifestResourceRoots = manifestResourceRoots,
     PInvokeModules = pinvokeModules,
+    ProjectRoots = projectRoots,
+    LinkFeatures = linkFeatures,
     ShadowStack = shadowStack,
 });

--- a/src/Dn2Cpp.Runtime/Dn2Cpp.Runtime.csproj
+++ b/src/Dn2Cpp.Runtime/Dn2Cpp.Runtime.csproj
@@ -1,15 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <!--
-    dn2cpp's always-available managed support shim. Unlike the LINQ shim, this
-    is NOT a "fake BCL" the user compiles against — user code never references it. The
-    CLI auto-references the built Dn2Cpp.Runtime.dll (it sits next to the CLI), and the
-    transpiler instantiates types from it on demand (e.g. SZArrayEnumerable<T> at a
-    T[] -> collection-interface boundary). Tree-shaking drops everything a given
-    program doesn't reach, so the cost when unused is nil.
+    dn2cpp's always-available managed support assembly. The CLI auto-references
+    the copy beside it so emitted helpers such as SZArrayEnumerable<T> are
+    available on demand. User projects may also compile against it for
+    Dn2Cpp.Scripting.PreserveAttribute; tree-shaking removes unused helpers.
   -->
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <AssemblyName>Dn2Cpp.Runtime</AssemblyName>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>

--- a/src/Dn2Cpp.Runtime/PreserveAttribute.cs
+++ b/src/Dn2Cpp.Runtime/PreserveAttribute.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace Dn2Cpp.Scripting;
+
+[AttributeUsage(
+    AttributeTargets.Assembly
+    | AttributeTargets.Class
+    | AttributeTargets.Struct
+    | AttributeTargets.Enum
+    | AttributeTargets.Interface
+    | AttributeTargets.Delegate
+    | AttributeTargets.Constructor
+    | AttributeTargets.Method
+    | AttributeTargets.Property
+    | AttributeTargets.Field
+    | AttributeTargets.Event,
+    AllowMultiple = false,
+    Inherited = false)]
+public class PreserveAttribute : Attribute
+{
+}

--- a/src/Dn2Cpp.Transpiler/Compilation.Preservation.cs
+++ b/src/Dn2Cpp.Transpiler/Compilation.Preservation.cs
@@ -34,7 +34,7 @@ internal sealed partial class Compilation
     private readonly Dictionary<(int Module, TypeDefinitionHandle Type), PreservePolicy> _preservePolicies = new();
     private readonly HashSet<ClassInfo> _explicitReflectionKeep = new();
     private readonly HashSet<ClassInfo> _activatedConditionalPolicies = new();
-    private readonly Dictionary<string, bool> _preserveAttributeTypes = new(StringComparer.Ordinal);
+    private readonly Dictionary<(int Module, TypeDefinitionHandle Type), bool> _preserveAttributeTypes = new();
     private bool _preservationSeedingActive;
 
     private PreservePolicy Policy(Module module, TypeDefinitionHandle type)
@@ -125,28 +125,25 @@ internal sealed partial class Compilation
     {
         foreach (var handle in attributes)
         {
-            string? name = AttributeTypeName(module.Reader, module.Reader.GetCustomAttribute(handle));
+            var attribute = module.Reader.GetCustomAttribute(handle);
+            string? name = AttributeTypeName(module.Reader, attribute);
             if (name is null)
                 continue;
             string simple = name.Substring(name.LastIndexOfAny(new[] { '.', '+' }) + 1);
             if (simple == "PreserveAttribute")
                 return true;
-            if (IsRawPreserveAttributeType(name)) return true;
+            if (RawAttributeTypeDefinition(module, attribute) is { } type
+                && IsRawPreserveAttributeType(type.Module, type.Handle)) return true;
         }
         return false;
     }
 
-    private bool IsRawPreserveAttributeType(string fullName)
+    private bool IsRawPreserveAttributeType(Module module, TypeDefinitionHandle handle)
     {
-        if (_preserveAttributeTypes.TryGetValue(fullName, out bool cached)) return cached;
+        var key = (module.Index, handle);
+        if (_preserveAttributeTypes.TryGetValue(key, out bool cached)) return cached;
         var seen = new HashSet<(int, TypeDefinitionHandle)>();
-        foreach (var module in Modules)
-            foreach (var handle in module.Reader.TypeDefinitions)
-                if (RawReflectionTypeName(module.Reader, handle) == fullName
-                    && RawBaseIsPreserve(module, handle, seen))
-                    return _preserveAttributeTypes[fullName] = true;
-        _preserveAttributeTypes[fullName] = false;
-        return false;
+        return _preserveAttributeTypes[key] = RawBaseIsPreserve(module, handle, seen);
     }
 
     private bool RawBaseIsPreserve(Module module, TypeDefinitionHandle handle,
@@ -163,11 +160,64 @@ internal sealed partial class Compilation
             (TypeReferenceHandle)td.BaseType);
         if (baseName.Substring(baseName.LastIndexOfAny(new[] { '.', '+' }) + 1) == "PreserveAttribute")
             return true;
-        foreach (var candidateModule in Modules)
-            foreach (var candidate in candidateModule.Reader.TypeDefinitions)
-                if (RawReflectionTypeName(candidateModule.Reader, candidate) == baseName
-                    && RawBaseIsPreserve(candidateModule, candidate, seen)) return true;
-        return false;
+        return RawTypeReferenceDefinition(module, (TypeReferenceHandle)td.BaseType) is { } type
+            && RawBaseIsPreserve(type.Module, type.Handle, seen);
+    }
+
+    private (Module Module, TypeDefinitionHandle Handle)? RawAttributeTypeDefinition(
+        Module module, CustomAttribute attribute)
+    {
+        EntityHandle parent = attribute.Constructor.Kind switch
+        {
+            HandleKind.MethodDefinition => module.Reader.GetMethodDefinition(
+                (MethodDefinitionHandle)attribute.Constructor).GetDeclaringType(),
+            HandleKind.MemberReference => module.Reader.GetMemberReference(
+                (MemberReferenceHandle)attribute.Constructor).Parent,
+            _ => default,
+        };
+        return parent.Kind switch
+        {
+            HandleKind.TypeDefinition => (module, (TypeDefinitionHandle)parent),
+            HandleKind.TypeReference => RawTypeReferenceDefinition(module, (TypeReferenceHandle)parent),
+            _ => null,
+        };
+    }
+
+    private (Module Module, TypeDefinitionHandle Handle)? RawTypeReferenceDefinition(
+        Module module, TypeReferenceHandle handle)
+    {
+        var tr = module.Reader.GetTypeReference(handle);
+        string name = module.Reader.GetString(tr.Name);
+        string ns = module.Reader.GetString(tr.Namespace);
+        if (!TypeIndex().TryGetValue((ns, name), out var candidates))
+            return null;
+        if (tr.ResolutionScope.Kind == HandleKind.TypeReference)
+        {
+            if (RawTypeReferenceDefinition(module, (TypeReferenceHandle)tr.ResolutionScope)
+                is not { } declaring)
+                return null;
+            foreach (var (candidateModule, candidate) in candidates)
+                if (candidateModule == declaring.Module
+                    && candidateModule.Reader.GetTypeDefinition(candidate).GetDeclaringType() == declaring.Handle)
+                    return (candidateModule, candidate);
+            return null;
+        }
+
+        Module? target = tr.ResolutionScope.Kind switch
+        {
+            HandleKind.AssemblyReference => Modules.FirstOrDefault(m => m.AssemblyName
+                == module.Reader.GetString(module.Reader.GetAssemblyReference(
+                    (AssemblyReferenceHandle)tr.ResolutionScope).Name)),
+            HandleKind.ModuleDefinition => module,
+            _ => null,
+        };
+        if (target is null)
+            return null;
+        foreach (var (candidateModule, candidate) in candidates)
+            if (candidateModule == target
+                && target.Reader.GetTypeDefinition(candidate).GetDeclaringType().IsNil)
+                return (target, candidate);
+        return null;
     }
 
     private IReadOnlyList<string> FindLinkFiles()
@@ -178,10 +228,8 @@ internal sealed partial class Compilation
             string root = Path.GetFullPath(rootValue);
             if (!Directory.Exists(root))
                 throw new NotSupportedException($"--project-root {rootValue}: directory does not exist");
-            foreach (string path in Directory.EnumerateFiles(root, "*", SearchOption.AllDirectories))
+            foreach (string path in EnumerateLinkFiles(root))
             {
-                if (!string.Equals(Path.GetFileName(path), "link.xml", StringComparison.Ordinal))
-                    continue;
                 string full = Path.GetFullPath(path);
                 string relative = Path.GetRelativePath(root, full).Replace(Path.DirectorySeparatorChar, '/');
                 if (!paths.TryGetValue(full, out var have)
@@ -198,6 +246,26 @@ internal sealed partial class Compilation
         var result = new List<string>(rows.Count);
         foreach (var row in rows) result.Add(row.Full);
         return result;
+    }
+
+    private static IEnumerable<string> EnumerateLinkFiles(string root)
+    {
+        var pending = new Stack<string>();
+        pending.Push(root);
+        while (pending.Count > 0)
+        {
+            string directory = pending.Pop();
+            foreach (string path in Directory.EnumerateFiles(directory))
+                if (string.Equals(Path.GetFileName(path), "link.xml", StringComparison.Ordinal))
+                    yield return path;
+            foreach (string child in Directory.EnumerateDirectories(directory))
+            {
+                string name = Path.GetFileName(child);
+                if (name is "bin" or "obj" or ".godot" or ".git")
+                    continue;
+                pending.Push(child);
+            }
+        }
     }
 
     private void ApplyLinkDocument(string path, LinkNode root)
@@ -793,6 +861,7 @@ internal sealed partial class Compilation
     {
         NoteForceEmit(field.DeclaringClass);
         NotePreservedType(field.Type);
+        ReachCctor(field.DeclaringClass);
     }
 
     private void PreserveMethod(MethodInfo method)

--- a/src/Dn2Cpp.Transpiler/Compilation.Preservation.cs
+++ b/src/Dn2Cpp.Transpiler/Compilation.Preservation.cs
@@ -1,0 +1,1135 @@
+using System.Reflection.Metadata;
+
+namespace Dn2Cpp;
+
+internal sealed partial class Compilation
+{
+    [Flags]
+    private enum PreserveKind
+    {
+        None = 0,
+        Type = 1,
+        DefaultConstructor = 2,
+        Fields = 4,
+        Methods = 8,
+        All = Type | Fields | Methods,
+    }
+
+    private sealed class PreservePolicy
+    {
+        public PreserveKind Kind;
+        public readonly HashSet<FieldDefinitionHandle> Fields = new();
+        public readonly HashSet<MethodDefinitionHandle> Methods = new();
+        public readonly HashSet<PropertyDefinitionHandle> Properties = new();
+        public readonly HashSet<EventDefinitionHandle> Events = new();
+        public PreserveKind ConditionalKind;
+        public readonly HashSet<FieldDefinitionHandle> ConditionalFields = new();
+        public readonly HashSet<MethodDefinitionHandle> ConditionalMethods = new();
+        public readonly HashSet<PropertyDefinitionHandle> ConditionalProperties = new();
+        public readonly HashSet<EventDefinitionHandle> ConditionalEvents = new();
+    }
+
+    private readonly IReadOnlyList<string> _projectRoots;
+    private readonly HashSet<string> _linkFeatures;
+    private readonly Dictionary<(int Module, TypeDefinitionHandle Type), PreservePolicy> _preservePolicies = new();
+    private readonly HashSet<ClassInfo> _explicitReflectionKeep = new();
+    private readonly HashSet<ClassInfo> _activatedConditionalPolicies = new();
+    private readonly Dictionary<string, bool> _preserveAttributeTypes = new(StringComparer.Ordinal);
+    private bool _preservationSeedingActive;
+
+    private PreservePolicy Policy(Module module, TypeDefinitionHandle type)
+    {
+        var key = (module.Index, type);
+        if (!_preservePolicies.TryGetValue(key, out var policy))
+            _preservePolicies.Add(key, policy = new PreservePolicy());
+        return policy;
+    }
+
+    private void DiscoverPreservationPolicies()
+    {
+        foreach (var module in Modules)
+        {
+            bool assemblyPreserved = HasPreserveAttribute(module,
+                module.Reader.GetAssemblyDefinition().GetCustomAttributes());
+            foreach (var tdh in module.Reader.TypeDefinitions)
+            {
+                var td = module.Reader.GetTypeDefinition(tdh);
+                if (module.Reader.GetString(td.Name) == "<Module>")
+                    continue;
+                PreservePolicy? policy = null;
+                if (assemblyPreserved || HasPreserveAttribute(module, td.GetCustomAttributes()))
+                    (policy ??= Policy(module, tdh)).Kind |= PreserveKind.Type | PreserveKind.DefaultConstructor;
+                foreach (var fdh in td.GetFields())
+                    if (HasPreserveAttribute(module,
+                        module.Reader.GetFieldDefinition(fdh).GetCustomAttributes()))
+                        (policy ??= Policy(module, tdh)).Fields.Add(fdh);
+                foreach (var mdh in td.GetMethods())
+                    if (HasPreserveAttribute(module,
+                        module.Reader.GetMethodDefinition(mdh).GetCustomAttributes()))
+                        (policy ??= Policy(module, tdh)).Methods.Add(mdh);
+                foreach (var ph in td.GetProperties())
+                {
+                    var pd = module.Reader.GetPropertyDefinition(ph);
+                    if (!HasPreserveAttribute(module, pd.GetCustomAttributes()))
+                        continue;
+                    policy ??= Policy(module, tdh);
+                    policy.Properties.Add(ph);
+                    AddAccessors(policy, pd.GetAccessors());
+                    AddBackingField(module, td, policy, module.Reader.GetString(pd.Name));
+                }
+                foreach (var eh in td.GetEvents())
+                {
+                    var ed = module.Reader.GetEventDefinition(eh);
+                    if (!HasPreserveAttribute(module, ed.GetCustomAttributes()))
+                        continue;
+                    policy ??= Policy(module, tdh);
+                    policy.Events.Add(eh);
+                    AddAccessors(policy, ed.GetAccessors());
+                    AddBackingField(module, td, policy, module.Reader.GetString(ed.Name));
+                }
+            }
+        }
+        foreach (string path in FindLinkFiles())
+            ApplyLinkDocument(path, LinkXml.Parse(path));
+    }
+
+    private static void AddAccessors(PreservePolicy policy, PropertyAccessors accessors)
+    {
+        if (!accessors.Getter.IsNil) policy.Methods.Add(accessors.Getter);
+        if (!accessors.Setter.IsNil) policy.Methods.Add(accessors.Setter);
+    }
+
+    private static void AddAccessors(PreservePolicy policy, EventAccessors accessors)
+    {
+        if (!accessors.Adder.IsNil) policy.Methods.Add(accessors.Adder);
+        if (!accessors.Remover.IsNil) policy.Methods.Add(accessors.Remover);
+    }
+
+    private static void AddBackingField(Module module, TypeDefinition td,
+        PreservePolicy policy, string name)
+        => AddBackingField(module, td, policy.Fields, name);
+
+    private static void AddBackingField(Module module, TypeDefinition td,
+        HashSet<FieldDefinitionHandle> fields, string name)
+    {
+        string compilerName = "<" + name + ">k__BackingField";
+        foreach (var fdh in td.GetFields())
+        {
+            string fieldName = module.Reader.GetString(module.Reader.GetFieldDefinition(fdh).Name);
+            if (fieldName == name || fieldName == compilerName)
+                fields.Add(fdh);
+        }
+    }
+
+    private bool HasPreserveAttribute(Module module, CustomAttributeHandleCollection attributes)
+    {
+        foreach (var handle in attributes)
+        {
+            string? name = AttributeTypeName(module.Reader, module.Reader.GetCustomAttribute(handle));
+            if (name is null)
+                continue;
+            string simple = name.Substring(name.LastIndexOfAny(new[] { '.', '+' }) + 1);
+            if (simple == "PreserveAttribute")
+                return true;
+            if (IsRawPreserveAttributeType(name)) return true;
+        }
+        return false;
+    }
+
+    private bool IsRawPreserveAttributeType(string fullName)
+    {
+        if (_preserveAttributeTypes.TryGetValue(fullName, out bool cached)) return cached;
+        var seen = new HashSet<(int, TypeDefinitionHandle)>();
+        foreach (var module in Modules)
+            foreach (var handle in module.Reader.TypeDefinitions)
+                if (RawReflectionTypeName(module.Reader, handle) == fullName
+                    && RawBaseIsPreserve(module, handle, seen))
+                    return _preserveAttributeTypes[fullName] = true;
+        _preserveAttributeTypes[fullName] = false;
+        return false;
+    }
+
+    private bool RawBaseIsPreserve(Module module, TypeDefinitionHandle handle,
+        HashSet<(int, TypeDefinitionHandle)> seen)
+    {
+        if (!seen.Add((module.Index, handle))) return false;
+        var td = module.Reader.GetTypeDefinition(handle);
+        if (module.Reader.GetString(td.Name) == "PreserveAttribute") return true;
+        if (td.BaseType.IsNil) return false;
+        if (td.BaseType.Kind == HandleKind.TypeDefinition)
+            return RawBaseIsPreserve(module, (TypeDefinitionHandle)td.BaseType, seen);
+        if (td.BaseType.Kind != HandleKind.TypeReference) return false;
+        string baseName = RawSignatureProvider.TypeReferenceName(module.Reader,
+            (TypeReferenceHandle)td.BaseType);
+        if (baseName.Substring(baseName.LastIndexOfAny(new[] { '.', '+' }) + 1) == "PreserveAttribute")
+            return true;
+        foreach (var candidateModule in Modules)
+            foreach (var candidate in candidateModule.Reader.TypeDefinitions)
+                if (RawReflectionTypeName(candidateModule.Reader, candidate) == baseName
+                    && RawBaseIsPreserve(candidateModule, candidate, seen)) return true;
+        return false;
+    }
+
+    private IReadOnlyList<string> FindLinkFiles()
+    {
+        var paths = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (string rootValue in _projectRoots)
+        {
+            string root = Path.GetFullPath(rootValue);
+            if (!Directory.Exists(root))
+                throw new NotSupportedException($"--project-root {rootValue}: directory does not exist");
+            foreach (string path in Directory.EnumerateFiles(root, "*", SearchOption.AllDirectories))
+            {
+                if (!string.Equals(Path.GetFileName(path), "link.xml", StringComparison.Ordinal))
+                    continue;
+                string full = Path.GetFullPath(path);
+                string relative = Path.GetRelativePath(root, full).Replace(Path.DirectorySeparatorChar, '/');
+                if (!paths.TryGetValue(full, out var have)
+                    || string.CompareOrdinal(relative, have) < 0)
+                    paths[full] = relative;
+            }
+        }
+        var rows = paths.Select(p => (Full: p.Key, Relative: p.Value)).ToList();
+        rows.Sort((a, b) =>
+        {
+            int c = string.CompareOrdinal(a.Relative, b.Relative);
+            return c != 0 ? c : string.CompareOrdinal(a.Full, b.Full);
+        });
+        var result = new List<string>(rows.Count);
+        foreach (var row in rows) result.Add(row.Full);
+        return result;
+    }
+
+    private void ApplyLinkDocument(string path, LinkNode root)
+    {
+        if (root.Name != "linker")
+            throw LinkError(path, "root element must be <linker>");
+        ValidateLinkSchema(root, path);
+        RequireOnly(root, path, Array.Empty<string>());
+        foreach (var assembly in root.Children)
+        {
+            if (assembly.Name != "assembly")
+                throw LinkError(path, $"unknown <{assembly.Name}> under <linker>");
+            RequireOnly(assembly, path, new[] { "fullname", "preserve", "ignoreIfMissing",
+                "ignoreIfUnreferenced", "windowsruntime", "feature" });
+            ValidateFeature(assembly, path);
+            _ = BoolAttr(assembly, path, "ignoreIfMissing", false);
+            _ = BoolAttr(assembly, path, "ignoreIfUnreferenced", false);
+            _ = BoolAttr(assembly, path, "windowsruntime", false);
+            if (!FeatureEnabled(assembly))
+                continue;
+            string assemblyName = Required(assembly, path, "fullname");
+            int comma = assemblyName.IndexOf(',');
+            string assemblyPattern = comma < 0 ? assemblyName : assemblyName.Substring(0, comma).Trim();
+            var modules = Modules.Where(m => Wildcard(assemblyPattern, m.AssemblyName)).ToList();
+            if (modules.Count == 0)
+            {
+                if (!BoolAttr(assembly, path, "ignoreIfMissing", false))
+                    Warn(path, $"assembly '{assemblyName}' was not loaded");
+                continue;
+            }
+            PreserveKind assemblyKind = ParsePreserve(assembly, path,
+                assembly.Children.Count == 0 ? PreserveKind.All : PreserveKind.None,
+                PreserveKind.None);
+            foreach (var module in modules)
+            {
+                if (BoolAttr(assembly, path, "ignoreIfUnreferenced", false)
+                    && !IsLinkAssemblyReferenced(module))
+                    continue;
+                if (assemblyKind != PreserveKind.None)
+                    foreach (var tdh in module.Reader.TypeDefinitions)
+                        Policy(module, tdh).Kind |= assemblyKind;
+                foreach (var type in assembly.Children)
+                    ApplyLinkType(path, module, type);
+            }
+        }
+    }
+
+    private static void ValidateLinkSchema(LinkNode root, string path)
+    {
+        RequireOnly(root, path, Array.Empty<string>());
+        foreach (var assembly in root.Children)
+        {
+            if (assembly.Name != "assembly")
+                throw LinkError(path, $"unknown <{assembly.Name}> under <linker>");
+            RequireOnly(assembly, path, new[] { "fullname", "preserve", "ignoreIfMissing",
+                "ignoreIfUnreferenced", "windowsruntime", "feature" });
+            _ = Required(assembly, path, "fullname");
+            _ = ParsePreserve(assembly, path, PreserveKind.None, PreserveKind.None);
+            _ = BoolAttr(assembly, path, "ignoreIfMissing", false);
+            _ = BoolAttr(assembly, path, "ignoreIfUnreferenced", false);
+            _ = BoolAttr(assembly, path, "windowsruntime", false);
+            ValidateFeature(assembly, path);
+            foreach (var type in assembly.Children)
+            {
+                if (type.Name != "type")
+                    throw LinkError(path, $"unknown <{type.Name}> under <assembly>");
+                RequireOnly(type, path, new[] { "fullname", "name", "preserve", "required", "feature" });
+                int typeSelectors = (type.Attr("fullname") is null ? 0 : 1)
+                    + (type.Attr("name") is null ? 0 : 1);
+                if (typeSelectors != 1)
+                    throw LinkError(path, "<type> requires exactly one of fullname or name");
+                _ = ParsePreserve(type, path, PreserveKind.Type, PreserveKind.Type);
+                _ = BoolAttr(type, path, "required", true);
+                ValidateFeature(type, path);
+                foreach (var member in type.Children)
+                {
+                    if (member.Name is not ("field" or "method" or "property" or "event"))
+                        throw LinkError(path, $"unknown <{member.Name}> under <type>");
+                    RequireOnly(member, path,
+                        new[] { "name", "fullname", "signature", "accessors", "feature" });
+                    int selectors = (member.Attr("name") is null ? 0 : 1)
+                        + (member.Attr("fullname") is null ? 0 : 1)
+                        + (member.Attr("signature") is null ? 0 : 1);
+                    if (selectors != 1)
+                        throw LinkError(path,
+                            $"<{member.Name}> requires exactly one of name, fullname, or signature");
+                    string? accessors = member.Attr("accessors");
+                    if (member.Name != "property" && accessors is not null)
+                        throw LinkError(path, $"accessors is not valid on <{member.Name}>");
+                    if (member.Name == "property" && accessors is not null
+                        && accessors is not ("all" or "get" or "set"))
+                        throw LinkError(path, $"invalid accessors='{accessors}'");
+                    ValidateFeature(member, path);
+                }
+            }
+        }
+    }
+
+    private bool IsLinkAssemblyReferenced(Module target)
+    {
+        if (target == AppModule)
+            return true;
+        foreach (var module in Modules)
+            foreach (var handle in module.Reader.TypeReferences)
+            {
+                var tr = module.Reader.GetTypeReference(handle);
+                EntityHandle scope = tr.ResolutionScope;
+                while (scope.Kind == HandleKind.TypeReference)
+                    scope = module.Reader.GetTypeReference((TypeReferenceHandle)scope).ResolutionScope;
+                if (scope.Kind == HandleKind.AssemblyReference
+                    && module.Reader.GetString(module.Reader.GetAssemblyReference(
+                        (AssemblyReferenceHandle)scope).Name) == target.AssemblyName)
+                    return true;
+            }
+        return false;
+    }
+
+    private void ApplyLinkType(string path, Module module, LinkNode type)
+    {
+        if (type.Name != "type")
+            throw LinkError(path, $"unknown <{type.Name}> under <assembly>");
+        RequireOnly(type, path, new[] { "fullname", "name", "preserve", "required", "feature" });
+        ValidateFeature(type, path);
+        _ = BoolAttr(type, path, "required", true);
+        if (!FeatureEnabled(type))
+            return;
+        int typeSelectors = (type.Attr("fullname") is null ? 0 : 1) + (type.Attr("name") is null ? 0 : 1);
+        if (typeSelectors != 1) throw LinkError(path, "<type> requires exactly one of fullname or name");
+        string pattern = type.Attr("fullname") ?? type.Attr("name")!;
+        pattern = pattern.Replace('/', '+');
+        var matches = new List<TypeDefinitionHandle>();
+        foreach (var tdh in module.Reader.TypeDefinitions)
+        {
+            string name = RawReflectionTypeName(module.Reader, tdh);
+            if (Wildcard(pattern, name) || Wildcard(pattern, module.Reader.GetString(module.Reader.GetTypeDefinition(tdh).Name)))
+                matches.Add(tdh);
+        }
+        if (matches.Count == 0)
+        {
+            Warn(path, $"type '{pattern}' was not found in assembly '{module.AssemblyName}'");
+            return;
+        }
+        foreach (var tdh in matches)
+        {
+            var policy = Policy(module, tdh);
+            bool conditional = !BoolAttr(type, path, "required", true);
+            PreserveKind kind = ParsePreserve(type, path,
+                type.Children.Count == 0 ? PreserveKind.All : PreserveKind.Type,
+                PreserveKind.Type);
+            if (conditional) policy.ConditionalKind |= kind;
+            else policy.Kind |= kind;
+            foreach (var member in type.Children)
+                ApplyLinkMember(path, module, tdh, policy, member, conditional);
+        }
+    }
+
+    private void ApplyLinkMember(string path, Module module, TypeDefinitionHandle tdh,
+        PreservePolicy policy, LinkNode member, bool conditional)
+    {
+        if (member.Name is not ("field" or "method" or "property" or "event"))
+            throw LinkError(path, $"unknown <{member.Name}> under <type>");
+        RequireOnly(member, path, new[] { "name", "fullname", "signature", "accessors", "feature" });
+        ValidateFeature(member, path);
+        if (member.Name != "property" && member.Attr("accessors") is not null)
+            throw LinkError(path, $"accessors is not valid on <{member.Name}>");
+        int selectors = (member.Attr("name") is null ? 0 : 1)
+            + (member.Attr("fullname") is null ? 0 : 1) + (member.Attr("signature") is null ? 0 : 1);
+        if (selectors != 1)
+            throw LinkError(path, $"<{member.Name}> requires exactly one of name, fullname, or signature");
+        if (!FeatureEnabled(member))
+            return;
+        var td = module.Reader.GetTypeDefinition(tdh);
+        string selector = member.Attr("name") ?? member.Attr("fullname") ?? member.Attr("signature")!;
+        string simpleSelector = MemberSelectorName(selector);
+        string declaringName = RawReflectionTypeName(module.Reader, tdh);
+        bool bySignature = member.Attr("signature") is not null;
+        var fields = conditional ? policy.ConditionalFields : policy.Fields;
+        var methods = conditional ? policy.ConditionalMethods : policy.Methods;
+        var properties = conditional ? policy.ConditionalProperties : policy.Properties;
+        var events = conditional ? policy.ConditionalEvents : policy.Events;
+        int hit = 0;
+        if (member.Name == "field")
+        {
+            foreach (var h in td.GetFields())
+            {
+                string name = module.Reader.GetString(module.Reader.GetFieldDefinition(h).Name);
+                if (bySignature ? FieldSignatureMatches(module, h, selector)
+                    : Wildcard(simpleSelector, name) || Wildcard(selector, declaringName + "::" + name))
+                { fields.Add(h); hit++; }
+            }
+        }
+        else if (member.Name == "method")
+        {
+            foreach (var h in td.GetMethods())
+            {
+                var md = module.Reader.GetMethodDefinition(h);
+                string name = module.Reader.GetString(md.Name);
+                if (bySignature ? MethodSignatureMatches(module, h, selector)
+                    : Wildcard(simpleSelector, name) || Wildcard(selector, declaringName + "::" + name))
+                { methods.Add(h); hit++; }
+            }
+        }
+        else if (member.Name is "property" or "event")
+        {
+            bool property = member.Name == "property";
+            if (property)
+                foreach (var h in td.GetProperties())
+                {
+                    var def = module.Reader.GetPropertyDefinition(h);
+                    string name = module.Reader.GetString(def.Name);
+                    if (bySignature ? !PropertySignatureMatches(module, tdh, h, selector)
+                        : !Wildcard(simpleSelector, name) && !Wildcard(selector, declaringName + "::" + name)) continue;
+                    AddSelectedAccessors(methods, def.GetAccessors(), member.Attr("accessors"), path);
+                    properties.Add(h);
+                    AddBackingField(module, td, fields, module.Reader.GetString(def.Name)); hit++;
+                }
+            else
+                foreach (var h in td.GetEvents())
+                {
+                    var def = module.Reader.GetEventDefinition(h);
+                    string name = module.Reader.GetString(def.Name);
+                    if (bySignature ? !EventSignatureMatches(module, tdh, h, selector)
+                        : !Wildcard(simpleSelector, name) && !Wildcard(selector, declaringName + "::" + name)) continue;
+                    AddSelectedAccessors(methods, def.GetAccessors(), member.Attr("accessors"), path);
+                    events.Add(h);
+                    AddBackingField(module, td, fields, module.Reader.GetString(def.Name)); hit++;
+                }
+        }
+        else
+            throw LinkError(path, $"unknown <{member.Name}> under <type>");
+        if (hit == 0)
+            Warn(path, $"{member.Name} '{selector}' was not found on '{RawReflectionTypeName(module.Reader, tdh)}'");
+    }
+
+    private static string MemberSelectorName(string selector)
+    {
+        int scope = selector.LastIndexOf("::", StringComparison.Ordinal);
+        if (scope >= 0)
+            return selector.Substring(scope + 2);
+        int space = selector.LastIndexOf(' ');
+        return space < 0 ? selector : selector.Substring(space + 1);
+    }
+
+    private bool MethodSignatureMatches(Module module, MethodDefinitionHandle handle, string selector)
+    {
+        int paren = selector.IndexOf('(');
+        int close = selector.LastIndexOf(')');
+        if (paren < 0 || close < paren)
+            return false;
+        string head = selector.Substring(0, paren).Trim();
+        int space = head.LastIndexOf(' ');
+        string wantedName = space < 0 ? head : head.Substring(space + 1);
+        int scope = wantedName.LastIndexOf("::", StringComparison.Ordinal);
+        if (scope >= 0) wantedName = wantedName.Substring(scope + 2);
+        var md = module.Reader.GetMethodDefinition(handle);
+        if (module.Reader.GetString(md.Name) != wantedName)
+            return false;
+        MethodSignature<string> sig;
+        try { sig = md.DecodeSignature(RawSignatureProvider.Instance, null); }
+        catch (Exception e) when (!IsMustEscape(e)) { return false; }
+        string args = selector.Substring(paren + 1, close - paren - 1).Trim();
+        var wanted = SplitSignatureArguments(args);
+        if (wanted.Length != sig.ParameterTypes.Length)
+            return false;
+        for (int i = 0; i < wanted.Length; i++)
+            if (!TypeNameMatches(NamedGenericParameters(module.Reader, md.GetDeclaringType(), handle,
+                sig.ParameterTypes[i]), wanted[i]))
+                return false;
+        if (space >= 0 && !TypeNameMatches(NamedGenericParameters(module.Reader,
+            md.GetDeclaringType(), handle, sig.ReturnType), head.Substring(0, space).Trim()))
+            return false;
+        return true;
+    }
+
+    private static string[] SplitSignatureArguments(string value)
+    {
+        if (value.Length == 0) return Array.Empty<string>();
+        var parts = new List<string>();
+        int start = 0, angle = 0, square = 0;
+        for (int i = 0; i < value.Length; i++)
+        {
+            if (value[i] == '<') angle++;
+            else if (value[i] == '>') angle--;
+            else if (value[i] == '[') square++;
+            else if (value[i] == ']') square--;
+            else if (value[i] == ',' && angle == 0 && square == 0)
+            {
+                parts.Add(value.Substring(start, i - start).Trim());
+                start = i + 1;
+            }
+        }
+        parts.Add(value.Substring(start).Trim());
+        return parts.ToArray();
+    }
+
+    private bool FieldSignatureMatches(Module module, FieldDefinitionHandle handle, string selector)
+    {
+        var (type, name) = SignatureMember(selector);
+        var fd = module.Reader.GetFieldDefinition(handle);
+        if (module.Reader.GetString(fd.Name) != name) return false;
+        try { return TypeNameMatches(NamedGenericParameters(module.Reader, fd.GetDeclaringType(), null,
+            fd.DecodeSignature(RawSignatureProvider.Instance, null)), type); }
+        catch (Exception e) when (!IsMustEscape(e)) { return false; }
+    }
+
+    private bool PropertySignatureMatches(Module module, TypeDefinitionHandle declaring,
+        PropertyDefinitionHandle handle, string selector)
+    {
+        var (type, name) = SignatureMember(selector);
+        var pd = module.Reader.GetPropertyDefinition(handle);
+        if (module.Reader.GetString(pd.Name) != name) return false;
+        try { return TypeNameMatches(NamedGenericParameters(module.Reader, declaring, null,
+            pd.DecodeSignature(RawSignatureProvider.Instance, null).ReturnType), type); }
+        catch (Exception e) when (!IsMustEscape(e)) { return false; }
+    }
+
+    private bool EventSignatureMatches(Module module, TypeDefinitionHandle declaring,
+        EventDefinitionHandle handle, string selector)
+    {
+        var (type, name) = SignatureMember(selector);
+        var ed = module.Reader.GetEventDefinition(handle);
+        if (module.Reader.GetString(ed.Name) != name) return false;
+        try
+        {
+            string eventType = ed.Type.Kind switch
+            {
+                HandleKind.TypeDefinition => RawSignatureProvider.TypeDefinitionName(module.Reader, (TypeDefinitionHandle)ed.Type),
+                HandleKind.TypeReference => RawSignatureProvider.TypeReferenceName(module.Reader, (TypeReferenceHandle)ed.Type),
+                HandleKind.TypeSpecification => module.Reader.GetTypeSpecification((TypeSpecificationHandle)ed.Type)
+                    .DecodeSignature(RawSignatureProvider.Instance, null),
+                _ => "?",
+            };
+            return TypeNameMatches(NamedGenericParameters(module.Reader, declaring, null, eventType), type);
+        }
+        catch (Exception e) when (!IsMustEscape(e)) { return false; }
+    }
+
+    private static (string Type, string Name) SignatureMember(string selector)
+    {
+        int paren = selector.IndexOf('(');
+        string head = (paren < 0 ? selector : selector.Substring(0, paren)).Trim();
+        int space = head.LastIndexOf(' ');
+        if (space < 0) return ("", head);
+        string name = head.Substring(space + 1);
+        int scope = name.LastIndexOf("::", StringComparison.Ordinal);
+        if (scope >= 0) name = name.Substring(scope + 2);
+        return (head.Substring(0, space).Trim(), name);
+    }
+
+    private static bool TypeNameMatches(string actual, string wanted) =>
+        string.Equals(actual, wanted.Replace('/', '+'), StringComparison.Ordinal);
+
+    private static string NamedGenericParameters(MetadataReader reader,
+        TypeDefinitionHandle declaring, MethodDefinitionHandle? method, string value)
+    {
+        if (method is { } mh)
+        {
+            var parameters = reader.GetMethodDefinition(mh).GetGenericParameters().ToArray();
+            for (int i = parameters.Length - 1; i >= 0; i--)
+                value = value.Replace("!!" + i,
+                    reader.GetString(reader.GetGenericParameter(parameters[i]).Name), StringComparison.Ordinal);
+        }
+        var typeParameters = reader.GetTypeDefinition(declaring).GetGenericParameters().ToArray();
+        for (int i = typeParameters.Length - 1; i >= 0; i--)
+            value = value.Replace("!" + i,
+                reader.GetString(reader.GetGenericParameter(typeParameters[i]).Name), StringComparison.Ordinal);
+        return value;
+    }
+
+    private static void AddSelectedAccessors(HashSet<MethodDefinitionHandle> methods, PropertyAccessors a,
+        string? value, string path)
+    {
+        string selected = value ?? "all";
+        if (selected is not ("all" or "get" or "set")) throw LinkError(path, $"invalid accessors='{selected}'");
+        if (selected is "all" or "get" && !a.Getter.IsNil) methods.Add(a.Getter);
+        if (selected is "all" or "set" && !a.Setter.IsNil) methods.Add(a.Setter);
+    }
+
+    private static void AddSelectedAccessors(HashSet<MethodDefinitionHandle> methods, EventAccessors a,
+        string? value, string path)
+    {
+        string selected = value ?? "all";
+        if (selected is not ("all" or "add" or "remove")) throw LinkError(path, $"invalid accessors='{selected}'");
+        if (selected is "all" or "add" && !a.Adder.IsNil) methods.Add(a.Adder);
+        if (selected is "all" or "remove" && !a.Remover.IsNil) methods.Add(a.Remover);
+    }
+
+    private bool FeatureEnabled(LinkNode node) =>
+        node.Attr("feature") is not { } feature || _linkFeatures.Contains(feature);
+
+    private static void ValidateFeature(LinkNode node, string path)
+    {
+        if (node.Attr("feature") is { } feature && feature is not ("com" or "sre" or "remoting"))
+            throw LinkError(path, $"unknown feature='{feature}'");
+    }
+
+    private static PreserveKind ParsePreserve(LinkNode node, string path, PreserveKind fallback,
+        PreserveKind nothing) =>
+        node.Attr("preserve") switch
+        {
+            null => fallback,
+            "all" => PreserveKind.All,
+            "fields" => PreserveKind.Type | PreserveKind.Fields,
+            "methods" => PreserveKind.Type | PreserveKind.Methods,
+            "nothing" => nothing,
+            var value => throw LinkError(path, $"invalid preserve='{value}'"),
+        };
+
+    private static bool BoolAttr(LinkNode node, string path, string name, bool fallback) =>
+        node.Attr(name) switch
+        {
+            null => fallback,
+            "0" or "false" => false,
+            "1" or "true" => true,
+            var value => throw LinkError(path, $"invalid {name}='{value}'"),
+        };
+
+    private static string Required(LinkNode node, string path, string name) =>
+        node.Attr(name) ?? throw LinkError(path, $"<{node.Name}> requires {name}");
+
+    private static void RequireOnly(LinkNode node, string path, IReadOnlyList<string> allowed)
+    {
+        foreach (var pair in node.Attributes)
+            if (!allowed.Contains(pair.Key))
+                throw LinkError(path, $"unknown attribute '{pair.Key}' on <{node.Name}>");
+    }
+
+    private static bool Wildcard(string pattern, string value)
+    {
+        int p = 0, v = 0, star = -1, retry = -1;
+        while (v < value.Length)
+        {
+            if (p < pattern.Length && pattern[p] == value[v]) { p++; v++; continue; }
+            if (p < pattern.Length && pattern[p] == '*') { star = p++; retry = v; continue; }
+            if (star >= 0) { p = star + 1; v = ++retry; continue; }
+            return false;
+        }
+        while (p < pattern.Length && pattern[p] == '*') p++;
+        return p == pattern.Length;
+    }
+
+    private static string RawReflectionTypeName(MetadataReader reader, TypeDefinitionHandle h)
+    {
+        var td = reader.GetTypeDefinition(h);
+        string name = reader.GetString(td.Name);
+        var decl = td.GetDeclaringType();
+        while (!decl.IsNil)
+        {
+            td = reader.GetTypeDefinition(decl);
+            name = reader.GetString(td.Name) + "+" + name;
+            decl = td.GetDeclaringType();
+        }
+        string ns = reader.GetString(td.Namespace);
+        return string.IsNullOrEmpty(ns) ? name : ns + "." + name;
+    }
+
+    private static NotSupportedException LinkError(string path, string message) =>
+        new($"{path}: link.xml: {message}");
+
+    private static void Warn(string path, string message) =>
+        Console.Error.WriteLine($"warning: {path}: link.xml: {message}");
+
+    private void SeedPreservedMembers()
+    {
+        _preservationSeedingActive = true;
+        foreach (var cls in Classes.ToList())
+            if (cls.MembersReady)
+                ApplyPreservation(cls);
+            else if (cls.ShapeReady)
+                ApplyPreservationAfterShape(cls);
+    }
+
+    private void ApplyPreservation(ClassInfo cls)
+    {
+        if (!_preservePolicies.TryGetValue((cls.Module.Index, cls.Handle), out var policy))
+            return;
+        bool conditional = _activatedConditionalPolicies.Contains(cls);
+        PreserveKind kind = policy.Kind | (conditional ? policy.ConditionalKind : PreserveKind.None);
+        bool delegateAll = cls.IsDelegate && kind != PreserveKind.None;
+        if (kind != PreserveKind.None || policy.Fields.Count > 0 || policy.Methods.Count > 0
+            || policy.Properties.Count > 0 || policy.Events.Count > 0
+            || conditional && (policy.ConditionalFields.Count > 0 || policy.ConditionalMethods.Count > 0
+                || policy.ConditionalProperties.Count > 0 || policy.ConditionalEvents.Count > 0))
+        {
+            NoteForceEmit(cls);
+            _explicitReflectionKeep.Add(cls);
+        }
+        if ((kind & PreserveKind.Fields) != 0)
+            foreach (var field in cls.Fields) PreserveField(field);
+        else
+            foreach (var field in cls.Fields)
+                if (policy.Fields.Contains(field.Handle)
+                    || conditional && policy.ConditionalFields.Contains(field.Handle)) PreserveField(field);
+        foreach (var method in cls.Methods)
+        {
+            bool keep = delegateAll || (kind & PreserveKind.Methods) != 0
+                || policy.Methods.Contains(method.Handle)
+                || conditional && policy.ConditionalMethods.Contains(method.Handle)
+                || (kind & PreserveKind.DefaultConstructor) != 0
+                    && method.Name == ".ctor" && method.Signature.ParameterTypes.Length == 0;
+            if (keep) PreserveMethod(method);
+        }
+        foreach (var ph in policy.Properties)
+            PreservePropertyType(cls, ph);
+        foreach (var eh in policy.Events)
+            PreserveEventType(cls, eh);
+        if (conditional)
+        {
+            foreach (var ph in policy.ConditionalProperties) PreservePropertyType(cls, ph);
+            foreach (var eh in policy.ConditionalEvents) PreserveEventType(cls, eh);
+        }
+    }
+
+    private void PreservePropertyType(ClassInfo cls, PropertyDefinitionHandle handle)
+    {
+        var sig = cls.Module.Reader.GetPropertyDefinition(handle).DecodeSignature(SigProvider, cls.Context);
+        NotePreservedType(sig.ReturnType);
+        foreach (var type in sig.ParameterTypes) NotePreservedType(type);
+    }
+
+    private void PreserveEventType(ClassInfo cls, EventDefinitionHandle handle)
+    {
+        var ed = cls.Module.Reader.GetEventDefinition(handle);
+        TypeDesc type = ed.Type.Kind switch
+        {
+            HandleKind.TypeDefinition => GetTypeDescForDefinition(cls.Module, (TypeDefinitionHandle)ed.Type),
+            HandleKind.TypeReference => ResolveTypeRef(cls.Module, (TypeReferenceHandle)ed.Type) ?? TypeDesc.MakeExternal("?"),
+            HandleKind.TypeSpecification => cls.Module.Reader.GetTypeSpecification((TypeSpecificationHandle)ed.Type)
+                .DecodeSignature(SigProvider, cls.Context),
+            _ => TypeDesc.MakeExternal("?"),
+        };
+        NotePreservedType(type);
+    }
+
+    private void ApplyPreservationAfterShape(ClassInfo cls)
+    {
+        if (!_preservationSeedingActive
+            || !_preservePolicies.TryGetValue((cls.Module.Index, cls.Handle), out var policy))
+            return;
+        if (cls.MembersReady)
+        {
+            ApplyPreservation(cls);
+            return;
+        }
+        bool conditional = PreservedTypeWasOtherwiseUsed(cls);
+        PreserveKind kind = policy.Kind | (conditional ? policy.ConditionalKind : PreserveKind.None);
+        if ((kind & (PreserveKind.Methods | PreserveKind.DefaultConstructor)) != 0
+            || policy.Methods.Count > 0 || conditional && policy.ConditionalMethods.Count > 0
+            || cls.IsDelegate && kind != PreserveKind.None)
+            CompleteMembers(cls);
+        else
+            ApplyPreservation(cls);
+    }
+
+    private bool PreservedTypeWasOtherwiseUsed(ClassInfo cls) =>
+        ReferencedTypes.Contains(cls) || ForceEmittedClasses.Contains(cls)
+        || IsAllocated(cls) || Reachable.Any(m => m.DeclaringClass == cls)
+        || _reflectionRoots.Count > 0 && ReflectionRootMatching(cls) is not null;
+
+    private bool ActivateConditionalPreservationPolicies()
+    {
+        if (!_preservationSeedingActive) return false;
+        bool activated = false;
+        foreach (var cls in Classes.ToList())
+            if (!_activatedConditionalPolicies.Contains(cls)
+                && _preservePolicies.TryGetValue((cls.Module.Index, cls.Handle), out var policy)
+                && (policy.ConditionalKind != PreserveKind.None
+                    || policy.ConditionalFields.Count > 0 || policy.ConditionalMethods.Count > 0
+                    || policy.ConditionalProperties.Count > 0 || policy.ConditionalEvents.Count > 0)
+                && PreservedTypeWasOtherwiseUsed(cls))
+            {
+                _activatedConditionalPolicies.Add(cls);
+                if (cls.ShapeReady) ApplyPreservationAfterShape(cls);
+                activated = true;
+            }
+        return activated;
+    }
+
+    private void ApplyPreservationToInstantiatedMethod(MethodInfo method)
+    {
+        if (!_preservationSeedingActive
+            || !_preservePolicies.TryGetValue((method.DeclaringClass.Module.Index,
+                method.DeclaringClass.Handle), out var policy))
+            return;
+        bool conditional = _activatedConditionalPolicies.Contains(method.DeclaringClass);
+        PreserveKind kind = policy.Kind | (conditional ? policy.ConditionalKind : PreserveKind.None);
+        if ((kind & PreserveKind.Methods) != 0 || policy.Methods.Contains(method.Handle)
+            || conditional && policy.ConditionalMethods.Contains(method.Handle))
+            PreserveMethod(method);
+    }
+
+    private void PreserveField(FieldInfo field)
+    {
+        NoteForceEmit(field.DeclaringClass);
+        NotePreservedType(field.Type);
+    }
+
+    private void PreserveMethod(MethodInfo method)
+    {
+        NoteForceEmit(method.DeclaringClass);
+        var sig = method.Signature;
+        NotePreservedType(sig.ReturnType);
+        foreach (var type in sig.ParameterTypes) NotePreservedType(type);
+        Reach(method);
+    }
+
+    private void NotePreservedType(TypeDesc type)
+    {
+        switch (type.Kind)
+        {
+            case TypeKind.Class:
+                NoteForceEmit(type.Class);
+                if (type.Class is not null) _explicitReflectionKeep.Add(type.Class);
+                break;
+            case TypeKind.SZArray:
+            case TypeKind.MDArray:
+            case TypeKind.ByRef:
+                if (type.Element is not null) NotePreservedType(type.Element);
+                break;
+            case TypeKind.ExternalGeneric:
+                if (type.GenericArgs is not null)
+                    foreach (var arg in type.GenericArgs) NotePreservedType(arg);
+                break;
+        }
+        if (type.Kind == TypeKind.Class && type.Class is { } cls)
+            foreach (var arg in cls.Context.TypeArgs) NotePreservedType(arg);
+    }
+}
+
+internal sealed class LinkNode
+{
+    public required string Name;
+    public readonly Dictionary<string, string> Attributes = new(StringComparer.Ordinal);
+    public readonly List<LinkNode> Children = new();
+    public string? Attr(string name) => Attributes.TryGetValue(name, out var value) ? value : null;
+}
+
+internal sealed class RawSignatureProvider : ISignatureTypeProvider<string, object?>
+{
+    public static readonly RawSignatureProvider Instance = new();
+
+    public string GetPrimitiveType(PrimitiveTypeCode typeCode) => "System." + typeCode;
+    public string GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind) =>
+        TypeDefinitionName(reader, handle);
+    public string GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind) =>
+        TypeReferenceName(reader, handle);
+    public string GetSZArrayType(string elementType) => elementType + "[]";
+    public string GetArrayType(string elementType, ArrayShape shape) =>
+        elementType + "[" + new string(',', shape.Rank - 1) + "]";
+    public string GetByReferenceType(string elementType) => elementType + "&";
+    public string GetPointerType(string elementType) => elementType + "*";
+    public string GetFunctionPointerType(MethodSignature<string> signature) => "method*";
+    public string GetGenericInstantiation(string genericType,
+        System.Collections.Immutable.ImmutableArray<string> typeArguments)
+    {
+        string result = genericType + "<";
+        for (int i = 0; i < typeArguments.Length; i++)
+        {
+            if (i != 0) result += ",";
+            result += typeArguments[i];
+        }
+        return result + ">";
+    }
+    public string GetGenericMethodParameter(object? genericContext, int index) => "!!" + index;
+    public string GetGenericTypeParameter(object? genericContext, int index) => "!" + index;
+    public string GetModifiedType(string modifier, string unmodifiedType, bool isRequired) => unmodifiedType;
+    public string GetPinnedType(string elementType) => elementType;
+    public string GetTypeFromSpecification(MetadataReader reader, object? genericContext,
+        TypeSpecificationHandle handle, byte rawTypeKind) =>
+        reader.GetTypeSpecification(handle).DecodeSignature(this, genericContext);
+
+    public static string TypeDefinitionName(MetadataReader reader, TypeDefinitionHandle handle)
+    {
+        var td = reader.GetTypeDefinition(handle);
+        string name = reader.GetString(td.Name);
+        var declaring = td.GetDeclaringType();
+        while (!declaring.IsNil)
+        {
+            td = reader.GetTypeDefinition(declaring);
+            name = reader.GetString(td.Name) + "+" + name;
+            declaring = td.GetDeclaringType();
+        }
+        string ns = reader.GetString(td.Namespace);
+        return string.IsNullOrEmpty(ns) ? name : ns + "." + name;
+    }
+
+    public static string TypeReferenceName(MetadataReader reader, TypeReferenceHandle handle)
+    {
+        var tr = reader.GetTypeReference(handle);
+        string name = reader.GetString(tr.Name);
+        if (tr.ResolutionScope.Kind == HandleKind.TypeReference)
+            return TypeReferenceName(reader, (TypeReferenceHandle)tr.ResolutionScope) + "+" + name;
+        string ns = reader.GetString(tr.Namespace);
+        return string.IsNullOrEmpty(ns) ? name : ns + "." + name;
+    }
+
+}
+
+internal static class LinkXml
+{
+    public static LinkNode Parse(string path)
+    {
+        using var reader = File.OpenText(path);
+        var parser = new Parser(path, reader);
+        return parser.Parse();
+    }
+
+    private sealed class Parser
+    {
+        private readonly string _path;
+        private readonly TextReader _reader;
+        private readonly List<int> _look = new();
+        private int _offset;
+
+        public Parser(string path, TextReader reader) { _path = path; _reader = reader; }
+
+        public LinkNode Parse()
+        {
+            SkipSpace();
+            if (Take("<?xml"))
+            {
+                if (!End && !char.IsWhiteSpace((char)Peek())) Fail("malformed XML declaration");
+                Declaration();
+            }
+            SkipMisc();
+            var root = Element();
+            SkipMisc();
+            if (!End) Fail("content after root element");
+            return root;
+        }
+
+        private LinkNode Element()
+        {
+            Expect('<');
+            if (Peek('!')) Fail("DTD and declarations are not supported");
+            var node = new LinkNode { Name = Name() };
+            while (true)
+            {
+                SkipSpace();
+                if (Take("/>")) return node;
+                if (Take(">")) break;
+                string name = Name();
+                SkipSpace(); Expect('='); SkipSpace();
+                if (End || Peek() is not ('\'' or '"')) Fail("quoted attribute value expected");
+                char quote = (char)Read();
+                var valueText = new System.Text.StringBuilder();
+                while (!End && Peek() != quote)
+                {
+                    if (Peek() == '<') Fail("'<' must be escaped in an attribute value");
+                    valueText.Append((char)Read());
+                }
+                if (End) Fail("unterminated attribute value");
+                Read();
+                string value = Entities(valueText.ToString());
+                if (!node.Attributes.TryAdd(name, value)) Fail($"duplicate attribute '{name}'");
+            }
+            while (true)
+            {
+                if (Take("<!--")) { SkipComment(); continue; }
+                if (Take("</"))
+                {
+                    string close = Name(); SkipSpace(); Expect('>');
+                    if (close != node.Name) Fail($"closing </{close}> does not match <{node.Name}>");
+                    return node;
+                }
+                if (Peek('<')) { node.Children.Add(Element()); continue; }
+                var content = new System.Text.StringBuilder();
+                while (!End && Peek() != '<') content.Append((char)Read());
+                if (!string.IsNullOrWhiteSpace(Entities(content.ToString())))
+                    Fail("non-whitespace text is not allowed");
+                if (End) Fail($"unterminated <{node.Name}>");
+            }
+        }
+
+        private void SkipMisc()
+        {
+            while (true)
+            {
+                SkipSpace();
+                if (!Take("<!--")) return;
+                SkipComment();
+            }
+        }
+
+        private void Declaration()
+        {
+            int stage = 0;
+            while (true)
+            {
+                SkipSpace();
+                if (Take("?>"))
+                {
+                    if (stage == 0) Fail("XML declaration requires version");
+                    return;
+                }
+                string name = Name();
+                SkipSpace(); Expect('='); SkipSpace();
+                if (End || Peek() is not ('\'' or '"')) Fail("quoted XML declaration value expected");
+                char quote = (char)Read();
+                var text = new System.Text.StringBuilder();
+                while (!End && Peek() != quote) text.Append((char)Read());
+                if (End) Fail("unterminated XML declaration value");
+                Read();
+                string value = text.ToString();
+                if (stage == 0 && name == "version" && value == "1.0")
+                    stage = 1;
+                else if (stage == 1 && name == "encoding" && ValidEncodingName(value))
+                    stage = 2;
+                else if (stage is 1 or 2 && name == "standalone" && value is "yes" or "no")
+                    stage = 3;
+                else
+                    Fail($"invalid XML declaration attribute {name}='{value}'");
+                if (!End && !char.IsWhiteSpace((char)Peek()) && !StartsWith("?>"))
+                    Fail("whitespace expected in XML declaration");
+            }
+        }
+
+        private static bool ValidEncodingName(string value)
+        {
+            if (value.Length == 0 || !char.IsLetter(value[0])) return false;
+            for (int i = 1; i < value.Length; i++)
+                if (!(char.IsLetterOrDigit(value[i]) || value[i] is '.' or '_' or '-'))
+                    return false;
+            return true;
+        }
+
+        private string Name()
+        {
+            if (End || !(char.IsLetter((char)Peek()) || Peek() is '_' or ':'))
+                Fail("XML name expected");
+            var name = new System.Text.StringBuilder();
+            name.Append((char)Read());
+            while (!End && (char.IsLetterOrDigit((char)Peek()) || Peek() is '_' or '-' or ':' or '.'))
+                name.Append((char)Read());
+            return name.ToString();
+        }
+
+        private string Entities(string value)
+        {
+            var result = new System.Text.StringBuilder();
+            for (int i = 0; i < value.Length; i++)
+            {
+                if (value[i] != '&') { result.Append(value[i]); continue; }
+                int semi = value.IndexOf(';', i + 1);
+                if (semi < 0) Fail("unterminated entity");
+                string entity = value.Substring(i + 1, semi - i - 1);
+                if (entity == "amp") result.Append('&');
+                else if (entity == "lt") result.Append('<');
+                else if (entity == "gt") result.Append('>');
+                else if (entity == "quot") result.Append('"');
+                else if (entity == "apos") result.Append('\'');
+                else if (entity.StartsWith("#", StringComparison.Ordinal))
+                {
+                    try
+                    {
+                        int number = entity.StartsWith("#x", StringComparison.Ordinal)
+                            ? Convert.ToInt32(entity.Substring(2), 16)
+                            : Convert.ToInt32(entity.Substring(1), 10);
+                        if (!(number is 0x9 or 0xa or 0xd
+                            || number >= 0x20 && number <= 0xd7ff
+                            || number >= 0xe000 && number <= 0xfffd
+                            || number >= 0x10000 && number <= 0x10ffff))
+                            Fail($"numeric entity '&{entity};' is not a valid XML character");
+                        result.Append(char.ConvertFromUtf32(number));
+                    }
+                    catch (Exception e) when (e is FormatException or OverflowException or ArgumentOutOfRangeException)
+                    {
+                        Fail($"invalid numeric entity '&{entity};'");
+                    }
+                }
+                else Fail($"unknown entity '&{entity};'");
+                i = semi;
+            }
+            return result.ToString();
+        }
+
+        private void SkipSpace() { while (!End && char.IsWhiteSpace((char)Peek())) Read(); }
+        private bool Peek(char c) => !End && Peek() == c;
+        private bool Take(string value)
+        {
+            for (int i = 0; i < value.Length; i++)
+                if (Peek(i) != value[i]) return false;
+            for (int i = 0; i < value.Length; i++) Read();
+            return true;
+        }
+        private bool StartsWith(string value)
+        {
+            for (int i = 0; i < value.Length; i++)
+                if (Peek(i) != value[i]) return false;
+            return true;
+        }
+        private void Expect(char c) { if (!Peek(c)) Fail($"expected '{c}'"); Read(); }
+        private void SkipUntil(string value)
+        {
+            while (!End)
+            {
+                if (Take(value)) return;
+                Read();
+            }
+            Fail($"unterminated '{value}'");
+        }
+        private void SkipComment()
+        {
+            while (!End)
+            {
+                if (Take("-->")) return;
+                if (Take("--")) Fail("'--' is not allowed inside an XML comment");
+                Read();
+            }
+            Fail("unterminated XML comment");
+        }
+
+        private bool End => Peek() < 0;
+        private int Peek(int index = 0)
+        {
+            while (_look.Count <= index)
+            {
+                int value = _reader.Read();
+                _look.Add(value);
+                if (value < 0) break;
+            }
+            return index < _look.Count ? _look[index] : -1;
+        }
+
+        private int Read()
+        {
+            int value = Peek();
+            _look.RemoveAt(0);
+            if (value >= 0) _offset++;
+            return value;
+        }
+
+        private void Fail(string message) => throw new NotSupportedException($"{_path}: link.xml: {message} at offset {_offset}");
+    }
+}

--- a/src/Dn2Cpp.Transpiler/Compilation.Reachability.cs
+++ b/src/Dn2Cpp.Transpiler/Compilation.Reachability.cs
@@ -3641,6 +3641,7 @@ internal sealed partial class Compilation
             if (it.Kind == TypeKind.Class)
                 spec.Interfaces.Add(it.Class!);
         }
+        ApplyPreservationAfterShape(spec);
     }
 
     /// <summary>Populates what a specialization can <em>do</em>: its methods, the vtable
@@ -3716,6 +3717,8 @@ internal sealed partial class Compilation
         // compare. This is the first moment it can be checked — so check it here rather
         // than force every specialization to decode just to be compared.
         VerifyCanonicalLink(spec);
+        if (_preservationSeedingActive)
+            ApplyPreservation(spec);
     }
 
     private void BuildVtableForSpecialization(ClassInfo spec)

--- a/src/Dn2Cpp.Transpiler/Compilation.Resolve.cs
+++ b/src/Dn2Cpp.Transpiler/Compilation.Resolve.cs
@@ -706,6 +706,7 @@ internal sealed partial class Compilation
         _methodInstanceCount++;
         _methodInstanceOrder.Add(mi);
         declClass.Methods.Add(mi); // emitted (and scanned) alongside the declaring class
+        ApplyPreservationToInstantiatedMethod(mi);
         return mi;
     }
 

--- a/src/Dn2Cpp.Transpiler/Compilation.cs
+++ b/src/Dn2Cpp.Transpiler/Compilation.cs
@@ -464,6 +464,8 @@ internal sealed partial class Compilation
         _cliCutMethods = (options.CutMethods ?? Array.Empty<string>()).Select(ParseCutSpec).ToHashSet();
         _trimReflection = options.TrimReflection;
         _reflectionRoots = new HashSet<string>(options.ReflectionRoots ?? Array.Empty<string>(), StringComparer.Ordinal);
+        _projectRoots = options.ProjectRoots;
+        _linkFeatures = new HashSet<string>(options.LinkFeatures, StringComparer.Ordinal);
         _noManifestResources = new HashSet<string>(
             options.NoManifestResources ?? Array.Empty<string>(), StringComparer.Ordinal);
         _manifestResourceRoots = new HashSet<string>(
@@ -1078,6 +1080,8 @@ internal sealed partial class Compilation
                 keep.Add(cls);
                 rootsHit.Add(hit);
             }
+            if (_explicitReflectionKeep.Contains(cls))
+                keep.Add(cls);
         }
         // A root matching no loaded type is a hard error: a typo silently becoming a no-op
         // root would surface as a PlatformNotSupportedException in a shipped game, which is
@@ -1824,6 +1828,8 @@ internal sealed partial class Compilation
         // to nothing is a hard error), before reachability — the first consumer
         // of the cut set — runs.
         ValidateCutMethods();
+
+        DiscoverPreservationPolicies();
 
         // Pass 2.5: populate MethodImpls for all non-generic classes
         foreach (var cls in Classes.ToList())
@@ -3597,6 +3603,8 @@ internal sealed partial class Compilation
     {
         _toScan = new Queue<MethodInfo>();
 
+        SeedPreservedMembers();
+
         // Seed with the program roots. Only the app module is rooted; reference
         // assemblies (e.g. a real CoreLib passed with -r) are pulled in solely
         // through reachability edges, so tree-shaking can keep all but the
@@ -3719,7 +3727,6 @@ internal sealed partial class Compilation
                 SeedGenericRoot(root);
 
         DrainReachability();
-
         // Reflection-invoke reachability route: if the program calls
         // MethodInfo.Invoke, make every app-module (non-ctor) method body invokable by
         // reaching it — its invoker thunk + arg/return box/unbox then emit. Bounded to
@@ -4801,6 +4808,8 @@ internal sealed partial class Compilation
                     { ReachabilityDiagnostics.Add((m, ex)); }
                 progress = true;
             }
+            if (ActivateConditionalPreservationPolicies())
+                progress = true;
         }
     }
 

--- a/src/Dn2Cpp.Transpiler/TranspileOptions.cs
+++ b/src/Dn2Cpp.Transpiler/TranspileOptions.cs
@@ -76,6 +76,14 @@ public sealed record TranspileOptions
     /// matching no loaded type is a hard error.</summary>
     public IReadOnlyList<string>? ReflectionRoots { get; init; }
 
+    /// <summary>Project directories recursively searched for files named exactly
+    /// <c>link.xml</c>. Direct CLI use performs no search unless a root is supplied.</summary>
+    public IReadOnlyList<string> ProjectRoots { get; init; } = Array.Empty<string>();
+
+    /// <summary>Unity linker feature names enabled for conditional
+    /// <c>feature=</c> directives in <c>link.xml</c>.</summary>
+    public IReadOnlyList<string> LinkFeatures { get; init; } = Array.Empty<string>();
+
     /// <summary>Assembly simple names (<c>--no-manifest-resources</c>, repeatable)
     /// whose embedded manifest resources are DROPPED from the image: the assembly's
     /// registry row carries the <c>resourcesDropped</c> bit instead of a resource


### PR DESCRIPTION
## 概要

- 公開 API として `PreserveAttribute` を追加し、互換性のある独自属性や派生属性も認識するようにしました
- 複数指定できるプロジェクトルートから Unity 形式の `link.xml` を検出・統合し、feature ガードにも対応しました
- 明示的な保持指定を、到達可能性解析、ジェネリックのインスタンス化、リフレクション用メタデータの保持に反映しました
- これらの制御を両 CLI と `Dn2Cpp.Build` から利用できるようにし、対象を絞ったネイティブ回帰テストを追加しました

エクスポーター側の対応 PR: https://github.com/takuma-komatsu/godot-dn2cpp/pull/4

## 検証

- Release / Debug の両構成でストリッピング制御ゲートを実行
- 両 CLI を Release / Debug でビルドし、Runtime を net8.0 / net10.0 でビルド
- `selfhost-emit` でネイティブ出力がバイト単位で一致する自己ホストの不動点を確認
- NuGet ツールと `Dn2Cpp.Build` の publish スモークテストを実行
- trim-reflection、P/Invoke（native / wasm）、HTTP、HTTP/2、gRPC の各ゲートを実行
- `SKIP_GODOT=1` のスイートでは、保持機能のゲートを含む 100 ゲートが成功しました。サンドボックスまたは共有アーティファクトに起因して失敗した 5 ゲートも、ループバックアクセスを有効にして直列で再実行したところ成功しました。iOS シミュレーターのゲートは、利用可能なデバイスがなかったためスキップしました

## 人手での引き継ぎ事項

- `gates/pre-merge.sh` は意図的に実行していません。マージ前に人手で実行する必要があります。
