### PR TITLE
Close layout field types of topo-only canonical owners

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -430,7 +430,8 @@ engine-side changes are in `docs/EDITOR-EXPORT-DESIGN.md`. Carve-outs:
 - **No HTTP transport** — a browser has no TCP socket layer, so
   `DN2CPP_USE_CURL` is forced off; `HttpClient` links and fails every call with
   an `HttpRequestException` naming the platform.
-- **`FileStream` does not link**; the intercepted `File.*` subset works on MEMFS.
+- **`FileStream` and the `File.*` surface work on MEMFS**, and the files are
+  ephemeral: they live in the page's memory and are gone when it unloads.
 - **The `libSystem.Native` surface is hand-picked per target**
   (`runtime/core/platform/wasm/`), and an omission here does NOT fail like the
   rows above: lowering a P/Invoke is target-neutral, so the call is still emitted

--- a/README.md
+++ b/README.md
@@ -768,9 +768,9 @@ it does not come back as a ticket.
   subclass overriding *neither* async overload takes that path). There is
   no IOCP implementation and none is planned. Results are unaffected; what
   is lost is the *reported* asynchrony.
-- **A real `FileStream` does not link on WASM** — deliberately and
-  loudly, at link time, naming the missing symbol. The intercepted
-  `File.*` subset still works against MEMFS.
+- **On WASM the filesystem is MEMFS, so files are ephemeral.**
+  `FileStream` and the `File.*` surface work, but what a page writes lives
+  in that page's memory and is gone when it unloads.
 - **A user `[DllImport]` whose native side fills an `[Out] byte[]` with a
   syscall** would be unsafe under a collector that write-protects heap pages
   to recover dirty bits — a kernel store into such a page returns `EFAULT`

--- a/docs/EDITOR-EXPORT-DESIGN.md
+++ b/docs/EDITOR-EXPORT-DESIGN.md
@@ -706,8 +706,10 @@ condition so an unstamped or differently stamped zip is relinked.
   platform, surfacing as a catchable `HttpRequestException`, so one feature
   degrades instead of the export being unbuildable. The thread carve-out is hit
   first for an async send, so a Web build uses the synchronous `Send`.
-- **`FileStream` does not link** (the pre-existing wasm carve-out). The
-  intercepted `File.*` subset works against MEMFS.
+- **The filesystem is MEMFS, so files are ephemeral.** `FileStream`,
+  `SafeFileHandle` and the `File.*` surface all work, but what a page writes
+  lives in that page's memory and is gone when it unloads. Persistence on the
+  Web is the engine's job (`user://` through `FileAccess`), not `System.IO`'s.
 - **The `libSystem.Native` surface this target defines is hand-picked**, and the
   omissions do not behave like the two above. Lowering a P/Invoke is
   target-neutral, so an omitted PAL symbol is still called; on a side module that

--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -131,27 +131,44 @@ user identity, and the low-level monitor.
   already-blittable shapes, so those calls direct-link once the modules are
   admitted to `Compilation.IsRuntimeProvidedPInvokeModule`. The port is a line in
   the transpiler and a `target_link_libraries` row.
-- **wasm defines nine.**
-  `runtime/core/platform/wasm/dn2cpp_system_native_wasm.cpp` supplies
+- **wasm defines 28.** They live in
+  `runtime/core/platform/wasm/dn2cpp_system_native_wasm.cpp`, in three groups.
+  The **non-file** entries are there each for their own reason:
   `SystemNative_GetCryptographicallySecureRandomBytes`, whose caller is not a
-  P/Invoke at all, `SystemNative_SysLog` and `SystemNative_Write` — the two sinks
-  of `DebugProvider.WriteCore`, hence reached by any game that logs —
+  P/Invoke at all; `SystemNative_SysLog` and `SystemNative_Write`, the two sinks
+  of `DebugProvider.WriteCore`, hence reached by any game that logs;
   `SystemNative_Malloc` and `SystemNative_Free`, which the intercepted
   `Marshal`/`NativeMemory` surface never reaches but the BSTR allocators and the
-  in-CoreLib marshaller stubs do, the `errno` accessors every managed retry loop
-  over a failing PAL call reads, plus the `pal_time.c` clocks behind
+  in-CoreLib marshaller stubs do; and the `pal_time.c` clocks behind
   `Stopwatch.GetTimestamp` and `Environment.TickCount64`. Both user calls resolve
   from MemberReferences to real CoreLib bodies and reach P/Invokes. An in-CoreLib
   MethodDefinition call to `TickCount64` can instead take the
-  `dn2cpp_tickcount64` intrinsic. Lowering a P/Invoke is
-  target-neutral, so excluding the POSIX file excludes the definition and leaves
-  its caller. The timestamp-resolution entry has no counterpart here because
-  `Stopwatch.Frequency` is a constant on this CoreLib. The rest is deliberately
-  absent: `FileStream` does not link on wasm, and the intercepted `File.*` subset
-  works against MEMFS. Absent means something weaker here than in an executable
-  link: on a side module an undefined symbol is a wasm IMPORT that throws only
-  when first called, which is why the export gates assert the drop-in's whole
-  import closure rather than trusting the link.
+  `dn2cpp_tickcount64` intrinsic. The timestamp-resolution entry has no
+  counterpart here because `Stopwatch.Frequency` is a constant on this CoreLib.
+
+  The **error** entries — the `errno` accessors and the two PAL/platform code
+  converters — ride in behind any of the others and behind every PAL failure the
+  BCL turns into an exception, with `SystemNative_StrErrorR` formatting it.
+
+  The **file-I/O closure** runs against Emscripten's MEMFS: `FileStream`,
+  `SafeFileHandle` and the `File.*` surface all work, and the files are ephemeral
+  — they live in the page's memory and are gone when it unloads. It is not
+  optional coverage, because a game does not opt into it: `Trace` with a
+  `DefaultTraceListener` log file goes `File.AppendAllText` → `SafeFileHandle` →
+  the whole closure. Two entries degrade rather than fail, both where .NET treats
+  the call as a hint: `SystemNative_PosixFAdvise` is advisory, and
+  `SystemNative_FAllocate` does nothing and reports success because MEMFS has no
+  size-preserving preallocation primitive — and a preallocation that changed the
+  file's LENGTH would make it read back as zeros nobody wrote.
+
+  What is still absent is absent for the ordinary reason — nothing here calls it.
+  Lowering a P/Invoke is target-neutral, so excluding the POSIX file excludes the
+  definition and leaves its caller; and absence means something weaker here than
+  in an executable link, because on a side module an undefined symbol is a wasm
+  IMPORT that throws only when first called. That is why the export gates assert
+  the drop-in's whole import closure rather than trusting the link, and why
+  `gates/build-and-run-wasm-console.sh`'s `PalSurface` bucket must keep REACHING
+  every entry this file defines.
 
 So the first question of a port is not "how do I write these functions" but
 **"which CoreLib flavour will this target's programs be transpiled from, and what

--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -131,12 +131,15 @@ user identity, and the low-level monitor.
   already-blittable shapes, so those calls direct-link once the modules are
   admitted to `Compilation.IsRuntimeProvidedPInvokeModule`. The port is a line in
   the transpiler and a `target_link_libraries` row.
-- **wasm defines four.**
+- **wasm defines nine.**
   `runtime/core/platform/wasm/dn2cpp_system_native_wasm.cpp` supplies
   `SystemNative_GetCryptographicallySecureRandomBytes`, whose caller is not a
-  P/Invoke at all, `SystemNative_SysLog` — the Trace/Debug sink `DebugProvider`
-  falls to once `Debugger.IsLogging` const-folds false, hence reached by any game
-  that logs — plus the `pal_time.c` clocks behind
+  P/Invoke at all, `SystemNative_SysLog` and `SystemNative_Write` — the two sinks
+  of `DebugProvider.WriteCore`, hence reached by any game that logs —
+  `SystemNative_Malloc` and `SystemNative_Free`, which the intercepted
+  `Marshal`/`NativeMemory` surface never reaches but the BSTR allocators and the
+  in-CoreLib marshaller stubs do, the `errno` accessors every managed retry loop
+  over a failing PAL call reads, plus the `pal_time.c` clocks behind
   `Stopwatch.GetTimestamp` and `Environment.TickCount64`. Both user calls resolve
   from MemberReferences to real CoreLib bodies and reach P/Invokes. An in-CoreLib
   MethodDefinition call to `TickCount64` can instead take the

--- a/gates/build-and-run-doc-claims.sh
+++ b/gates/build-and-run-doc-claims.sh
@@ -58,8 +58,13 @@ set_eq() {
 }
 
 # w2n WORD — the docs spell small counts as English words, which is good prose
-# and still a claim. Unknown word yields '?', which can never equal a number.
+# and still a claim. Past the words prose gives up and writes the digits, so those
+# pass through. Unknown word yields '?', which can never equal a number.
 w2n() {
+    case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
+        *[!0-9]* | '') ;;
+        *) echo "$1"; return ;;
+    esac
     case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
         one) echo 1 ;;      two) echo 2 ;;       three) echo 3 ;;
         four) echo 4 ;;     five) echo 5 ;;      six) echo 6 ;;
@@ -241,8 +246,8 @@ eq "docs/PORTING.md §2.1 'N of the M must answer truly'" \
 wasm_pal=runtime/core/platform/wasm/dn2cpp_system_native_wasm.cpp
 wasm_defs=$(grep -oE '^[a-z_0-9]+[a-z_0-9 *]* SystemNative_[A-Za-z_0-9]+\(' "$wasm_pal" \
             | grep -oE 'SystemNative_[A-Za-z_0-9]+' | sort -u | grep -c .)
-porting_wasm=$(w2n "$(sed -nE '1s/.*wasm defines ([a-z]+).*/\1/p' \
-    <<<"$(grep -oE '\*\*wasm defines [a-z]+\.\*\*' docs/PORTING.md)")")
+porting_wasm=$(w2n "$(sed -nE '1s/.*wasm defines ([a-z0-9]+).*/\1/p' \
+    <<<"$(grep -oE '\*\*wasm defines [a-z0-9]+\.\*\*' docs/PORTING.md)")")
 eq "docs/PORTING.md §2.2 'wasm defines N SystemNative_*'" "$porting_wasm" "$wasm_defs"
 
 # The editor guide tells a player what Stopwatch.Frequency reads on the Web, and that

--- a/gates/build-and-run-multiassembly.sh
+++ b/gates/build-and-run-multiassembly.sh
@@ -9,9 +9,31 @@
 # explicit cross-module root the library's initializer would silently never run. The
 # app's Main asserts it did and exits non-zero if not: this gate has no stdout oracle,
 # so the assertion has to live in the program.
+#
+# Also pins the layout closure of a canonical shared-generics owner reachable ONLY
+# through a referenced-only type's base chain: MiniBcl.LayoutMid is named as a type
+# token and nothing else, so it and its base LayoutBase<LayoutCtx> are emitted
+# opaquely while the struct ordering still pulls the group's canonical owner
+# LayoutBase<__Canon> in — and that owner gets a FULL field layout. Its field types
+# pass no other closure, so they must be declared here or generated.h spells
+# undeclared t_ names and the C++ compile fails on them.
 source "$(dirname "$0")/_common.sh"
 
 xasm_gate MultiAssembly MiniCorlib.dll artifacts/multiasm
+
+echo "== canonical owner's full layout declares its field types =="
+hdr=artifacts/multiasm/generated.h
+if ! grep -qw "struct t_MiniBcl_LayoutBase__CnRef : Dn2CppObject" "$hdr"; then
+    echo "FAIL: the repro shape no longer materializes — no full layout for" >&2
+    echo "t_MiniBcl_LayoutBase__CnRef in $hdr (the assertions below assert nothing)" >&2
+    exit 1
+fi
+for t in t_MiniBcl_LayoutBeh__CnRef t_MiniBcl_LayoutLeaf; do
+    if ! grep -qw "struct $t" "$hdr"; then
+        echo "FAIL: $hdr spells $t in a layout but never declares it" >&2
+        exit 1
+    fi
+done
 
 # The Dn2Cpp.Runtime.dll auto-reference dedupes by FILE NAME, not full
 # path — so `-r` pointing at a COPY of the shim under a different path must not

--- a/gates/build-and-run-multiassembly.sh
+++ b/gates/build-and-run-multiassembly.sh
@@ -10,13 +10,8 @@
 # app's Main asserts it did and exits non-zero if not: this gate has no stdout oracle,
 # so the assertion has to live in the program.
 #
-# Also pins the layout closure of a canonical shared-generics owner reachable ONLY
-# through a referenced-only type's base chain: MiniBcl.LayoutMid is named as a type
-# token and nothing else, so it and its base LayoutBase<LayoutCtx> are emitted
-# opaquely while the struct ordering still pulls the group's canonical owner
-# LayoutBase<__Canon> in — and that owner gets a FULL field layout. Its field types
-# pass no other closure, so they must be declared here or generated.h spells
-# undeclared t_ names and the C++ compile fails on them.
+# Also pins field closure for the full canonical-owner layout floated by an opaque
+# referenced-only base chain. Its by-value field requires both size and alignment.
 source "$(dirname "$0")/_common.sh"
 
 xasm_gate MultiAssembly MiniCorlib.dll artifacts/multiasm
@@ -28,12 +23,16 @@ if ! grep -qw "struct t_MiniBcl_LayoutBase__CnRef : Dn2CppObject" "$hdr"; then
     echo "t_MiniBcl_LayoutBase__CnRef in $hdr (the assertions below assert nothing)" >&2
     exit 1
 fi
-for t in t_MiniBcl_LayoutBeh__CnRef t_MiniBcl_LayoutLeaf; do
+for t in t_MiniBcl_LayoutBeh__CnRef t_MiniBcl_LayoutLeaf t_MiniBcl_LayoutAligned; do
     if ! grep -qw "struct $t" "$hdr"; then
         echo "FAIL: $hdr spells $t in a layout but never declares it" >&2
         exit 1
     fi
 done
+grep -qw "t_MiniBcl_LayoutAligned f__aligned" "$hdr" \
+    || { echo "FAIL: canonical owner does not carry the aligned field by value" >&2; exit 1; }
+grep -qw "struct alignas(8) t_MiniBcl_LayoutAligned" "$hdr" \
+    || { echo "FAIL: opaque aligned field shell lost its 8-byte alignment" >&2; exit 1; }
 
 # The Dn2Cpp.Runtime.dll auto-reference dedupes by FILE NAME, not full
 # path — so `-r` pointing at a COPY of the shim under a different path must not

--- a/gates/build-and-run-wasm-console.sh
+++ b/gates/build-and-run-wasm-console.sh
@@ -53,7 +53,10 @@
 # paths the intercepts leave alone: Marshal.StringToBSTR/FreeBSTR run the real CoreLib
 # bodies down to Interop.Sys.{Malloc,Free}, and a Debug write reaches
 # DebugProvider.WriteCore's stderr arm, Interop.Sys.Write, beside the SysLog arm — with
-# the errno accessors behind the stderr arm's retry loop.
+# the errno accessors behind the stderr arm's retry loop. Its third section is the
+# MEMFS file-I/O closure (FileStream, File.*, the error trio), which a game reaches
+# without asking for it: Trace with a DefaultTraceListener log file goes
+# File.AppendAllText -> SafeFileHandle -> all of it.
 #
 # Machines without the Emscripten toolchain (or node) skip: the suite stays
 # usable without emscripten, but the runner reports the gate as SKIPPED rather
@@ -99,13 +102,34 @@ echo "PAL reach OK: MonotonicClock still lowers both clocks to libSystem.Native"
 wasm_corelib_diff_gate PalSurface
 
 # Same reason as the clock assert above: the section's output is identical whether or
-# not it still reaches these three, so only the emitted call set can say it does.
+# not it still reaches these, so only the emitted call set can say it does. The
+# file-I/O half is the whole MEMFS closure — a BCL refactor that routed one operation
+# through a different PAL entry would leave the section green with the entry unlinked.
 for thunk in \
     dn2cpp_pinvoke_SystemNative_Malloc \
     dn2cpp_pinvoke_SystemNative_Free \
     dn2cpp_pinvoke_SystemNative_Write \
     dn2cpp_pinvoke_SystemNative_GetErrNo \
-    dn2cpp_pinvoke_SystemNative_SetErrNo; do
+    dn2cpp_pinvoke_SystemNative_SetErrNo \
+    dn2cpp_pinvoke_SystemNative_Open \
+    dn2cpp_pinvoke_SystemNative_Close \
+    dn2cpp_pinvoke_SystemNative_Read \
+    dn2cpp_pinvoke_SystemNative_PRead \
+    dn2cpp_pinvoke_SystemNative_PWrite \
+    dn2cpp_pinvoke_SystemNative_LSeek \
+    dn2cpp_pinvoke_SystemNative_FSync \
+    dn2cpp_pinvoke_SystemNative_FStat \
+    dn2cpp_pinvoke_SystemNative_Stat \
+    dn2cpp_pinvoke_SystemNative_Unlink \
+    dn2cpp_pinvoke_SystemNative_FLock \
+    dn2cpp_pinvoke_SystemNative_FTruncate \
+    dn2cpp_pinvoke_SystemNative_FAllocate \
+    dn2cpp_pinvoke_SystemNative_PosixFAdvise \
+    dn2cpp_pinvoke_SystemNative_GetCwd \
+    dn2cpp_pinvoke_SystemNative_GetFileSystemType \
+    dn2cpp_pinvoke_SystemNative_ConvertErrorPalToPlatform \
+    dn2cpp_pinvoke_SystemNative_ConvertErrorPlatformToPal \
+    dn2cpp_pinvoke_SystemNative_StrErrorR; do
     if ! grep -qF "$thunk" "$_CG_OUT"/generated*; then
         echo "FAIL: PalSurface no longer emits $thunk" >&2
         echo "      The section still passes, but it stopped reaching this wasm PAL" >&2
@@ -114,7 +138,7 @@ for thunk in \
         exit 1
     fi
 done
-echo "PAL reach OK: PalSurface still lowers the C heap and the stderr write to libSystem.Native"
+echo "PAL reach OK: PalSurface still lowers the C heap, the stderr write and the MEMFS file closure to libSystem.Native"
 
 # ── 6th section: the Web lane's HTTP carve-out ────────────────────────────────
 # The one section here that is NOT a diff against real .NET, and it cannot be:

--- a/gates/build-and-run-wasm-console.sh
+++ b/gates/build-and-run-wasm-console.sh
@@ -9,7 +9,7 @@
 # static roots registered via the dn2cpp_roots section. Emscripten's MEMFS
 # backs the filesystem.
 #
-# Six sections, five of them diffed against real .NET. StringCore covers the
+# Seven sections, six of them diffed against real .NET. StringCore covers the
 # string/formatting core, and
 # NestedFinallySubset proves the -fwasm-exceptions EH pipeline — a throw
 # (dn2cpp_throw -> C++ `throw Dn2CppException`) unwinding through nested
@@ -48,6 +48,12 @@
 # `TypeError: resolved is not a function` at the first call, naming a function index.
 # So this section is the cheap oracle for platform/wasm/dn2cpp_system_native_wasm.cpp,
 # and the export gates' import-closure assert is the backstop for the shipped drop-in.
+#
+# PalSurface is the rest of that oracle, for the entries a real game reaches through
+# paths the intercepts leave alone: Marshal.StringToBSTR/FreeBSTR run the real CoreLib
+# bodies down to Interop.Sys.{Malloc,Free}, and a Debug write reaches
+# DebugProvider.WriteCore's stderr arm, Interop.Sys.Write, beside the SysLog arm — with
+# the errno accessors behind the stderr arm's retry loop.
 #
 # Machines without the Emscripten toolchain (or node) skip: the suite stays
 # usable without emscripten, but the runner reports the gate as SKIPPED rather
@@ -89,6 +95,26 @@ for thunk in \
     fi
 done
 echo "PAL reach OK: MonotonicClock still lowers both clocks to libSystem.Native"
+
+wasm_corelib_diff_gate PalSurface
+
+# Same reason as the clock assert above: the section's output is identical whether or
+# not it still reaches these three, so only the emitted call set can say it does.
+for thunk in \
+    dn2cpp_pinvoke_SystemNative_Malloc \
+    dn2cpp_pinvoke_SystemNative_Free \
+    dn2cpp_pinvoke_SystemNative_Write \
+    dn2cpp_pinvoke_SystemNative_GetErrNo \
+    dn2cpp_pinvoke_SystemNative_SetErrNo; do
+    if ! grep -qF "$thunk" "$_CG_OUT"/generated*; then
+        echo "FAIL: PalSurface no longer emits $thunk" >&2
+        echo "      The section still passes, but it stopped reaching this wasm PAL" >&2
+        echo "      entry, so a regression in it would be invisible. If the lowering" >&2
+        echo "      moved on purpose, move this assert with it." >&2
+        exit 1
+    fi
+done
+echo "PAL reach OK: PalSurface still lowers the C heap and the stderr write to libSystem.Native"
 
 # ── 6th section: the Web lane's HTTP carve-out ────────────────────────────────
 # The one section here that is NOT a diff against real .NET, and it cannot be:

--- a/runtime/core/platform/wasm/dn2cpp_system_native_wasm.cpp
+++ b/runtime/core/platform/wasm/dn2cpp_system_native_wasm.cpp
@@ -3,7 +3,7 @@
 //
 // The bulk of that surface (platform/posix/dn2cpp_system_native.cpp) is the
 // file-I/O P/Invoke closure, and it is deliberately NOT part of the wasm build.
-// Four things it also defines are not file I/O, and each is here for its own
+// Several things it also defines are not file I/O, and each is here for its own
 // reason — the exclusion was written for the closure and covers none of them.
 //
 //   * The CSPRNG has a caller that is not a P/Invoke at all and IS compiled on
@@ -13,8 +13,15 @@
 //     user MemberReference to Environment.TickCount64 reach through their real
 //     BCL bodies. In-CoreLib MethodDefinition calls to TickCount64 can instead
 //     lower to dn2cpp_tickcount64. The engine's Time API is a separate surface.
-//   * SysLog is the Trace/Debug sink DebugProvider falls to, reached by any game
-//     that logs; it is a console entry point, not a file one.
+//   * SysLog and Write are DebugProvider.WriteCore's two sinks — the debugger arm
+//     and the stderr arm — so any game that logs reaches both. Write takes an fd,
+//     not a path: it is not part of the file-I/O closure.
+//   * Malloc/Free are the C heap. Marshal.{AllocHGlobal,FreeHGlobal} and the
+//     NativeMemory family are intercepted and never reach them, but the BSTR
+//     allocators and every marshaller stub that calls NativeMemory as an
+//     in-CoreLib MethodDefinition run the real body down to these two.
+//   * The errno accessors ride in behind any of them: a managed retry loop over a
+//     failing PAL call reads errno, and that read is a P/Invoke of its own.
 //
 // Only what a call site actually reaches is defined here. Stopwatch.Frequency is
 // a constant on this CoreLib, so the POSIX twin's timestamp-resolution entry does
@@ -34,8 +41,10 @@
 
 #include <cstdint>
 #include <cstdio>   // fprintf — the SysLog stand-in
+#include <cstdlib>  // malloc / free
 #include <ctime>    // clock_gettime
-#include <unistd.h> // getentropy
+#include <cerrno>   // EINTR
+#include <unistd.h> // getentropy, write
 
 extern "C" {
 
@@ -114,6 +123,48 @@ void SystemNative_SysLog(int32_t priority, const char* message, const char* arg1
 #pragma clang diagnostic pop
 #endif
     ::fputc('\n', stderr);
+}
+
+// pal_io.c SystemNative_Write, the other half of DebugProvider.WriteCore. Takes an
+// already-open fd, so it needs nothing from the file-I/O closure: under Emscripten
+// 1 and 2 reach the JS console and any other fd is MEMFS. Contract is the POSIX
+// twin's — bytes written, or -1 with errno set.
+//
+// No GC bounce buffer here, for the same reason the CSPRNG needs none: nothing
+// mprotects the heap on this axis.
+int32_t SystemNative_Write(intptr_t fd, const void* buffer, int32_t bufferSize)
+{
+    ssize_t n;
+    while ((n = ::write((int)fd, buffer, (size_t)bufferSize)) < 0 && errno == EINTR)
+    {
+    }
+    return (int32_t)n;
+}
+
+// The PAL's C-heap pair, the POSIX twins verbatim. Emscripten's dlmalloc backs it.
+// This is not the GC heap: a block from here is invisible to the collector and must
+// be freed through Free.
+void* SystemNative_Malloc(uintptr_t size)
+{
+    return std::malloc(size == 0 ? 1 : size); // malloc(0) may return NULL; .NET expects a pointer
+}
+
+void SystemNative_Free(void* ptr)
+{
+    std::free(ptr);
+}
+
+// The errno slot, reached by every managed retry loop over a PAL call that can fail —
+// DebugProvider's stderr loop is the one here. Emscripten's musl gives each of them a
+// real errno; the managed side maps the value itself.
+int32_t SystemNative_GetErrNo(void)
+{
+    return errno;
+}
+
+void SystemNative_SetErrNo(int32_t error)
+{
+    errno = error;
 }
 
 } // extern "C"

--- a/runtime/core/platform/wasm/dn2cpp_system_native_wasm.cpp
+++ b/runtime/core/platform/wasm/dn2cpp_system_native_wasm.cpp
@@ -1,10 +1,21 @@
-// dn2cpp_system_native_wasm.cpp — the sliver of the .NET PAL (libSystem.Native)
+// dn2cpp_system_native_wasm.cpp — the slice of the .NET PAL (libSystem.Native)
 // surface that the Emscripten target needs.
 //
-// The bulk of that surface (platform/posix/dn2cpp_system_native.cpp) is the
-// file-I/O P/Invoke closure, and it is deliberately NOT part of the wasm build.
-// Several things it also defines are not file I/O, and each is here for its own
-// reason — the exclusion was written for the closure and covers none of them.
+// platform/posix/dn2cpp_system_native.cpp is not part of the wasm build: most of
+// what it carries (process identity, directory enumeration, the Darwin bridges,
+// the low-level monitor) has no caller here, and the parts that do are gathered
+// below. The ABI is the managed one either way — Interop.Sys in
+// System.Private.CoreLib — so every struct layout, PAL flag and PAL error code
+// here must equal its POSIX twin exactly, and the bodies are that file's verbatim
+// wherever Emscripten's musl answers the same call.
+//
+// The FILE-I/O closure is shipped, against MEMFS. FileStream, SafeFileHandle and
+// the whole File.* surface work; the files live in the page's memory and are gone
+// when it unloads. It is here because a game does not opt into it: Trace with a
+// DefaultTraceListener log file goes File.AppendAllText -> SafeFileHandle -> the
+// closure, and a Web export that omits it fails at the first log line.
+//
+// The rest is not file I/O, and each entry is here for its own reason:
 //
 //   * The CSPRNG has a caller that is not a P/Invoke at all and IS compiled on
 //     wasm: intrinsics/dn2cpp_openssl_crypto_digest.cpp's
@@ -20,12 +31,19 @@
 //     NativeMemory family are intercepted and never reach them, but the BSTR
 //     allocators and every marshaller stub that calls NativeMemory as an
 //     in-CoreLib MethodDefinition run the real body down to these two.
-//   * The errno accessors ride in behind any of them: a managed retry loop over a
-//     failing PAL call reads errno, and that read is a P/Invoke of its own.
+//   * The errno accessors and the two PAL/platform error converters ride in behind
+//     any of them: a managed retry loop over a failing PAL call reads errno, and
+//     every ErrorInfo the BCL builds converts through the tables.
 //
 // Only what a call site actually reaches is defined here. Stopwatch.Frequency is
 // a constant on this CoreLib, so the POSIX twin's timestamp-resolution entry does
 // not belong here.
+//
+// None of the read-like fills below bounce through scratch memory the way the
+// POSIX twin's do. That bounce exists because Boehm's incremental mode mprotects
+// heap pages, so a kernel store into a managed buffer returns EFAULT instead of
+// trapping into the collector. There is no page-protection VDB under Emscripten:
+// the collector is built GC_DISABLE_INCREMENTAL and nothing mprotects anything.
 //
 // It stayed invisible because of the shape of the two link models, not because
 // nothing reached it. In an EXECUTABLE link wasm-ld dead-strips the unreferenced
@@ -42,8 +60,13 @@
 #include <cstdint>
 #include <cstdio>   // fprintf — the SysLog stand-in
 #include <cstdlib>  // malloc / free
+#include <cstring>  // strerror_r
 #include <ctime>    // clock_gettime
 #include <cerrno>   // EINTR
+#include <fcntl.h>  // open, O_*, posix_fadvise
+#include <sys/file.h>   // flock
+#include <sys/stat.h>   // stat / fstat
+#include <sys/statfs.h> // fstatfs — GetFileSystemType
 #include <unistd.h> // getentropy, write
 
 extern "C" {
@@ -165,6 +188,445 @@ int32_t SystemNative_GetErrNo(void)
 void SystemNative_SetErrNo(int32_t error)
 {
     errno = error;
+}
+
+// ============================ PAL error codes ==============================
+// Interop.Error (managed) values: 0x1XXXX per errno, ENONSTANDARD for an errno
+// with no PAL equivalent. These two tables ARE the ABI, so they are the POSIX
+// twin's verbatim, host guards and all — musl defines every errno they name, and
+// a value that differs between the two files is a silently mis-mapped exception.
+
+#define DN2CPP_PAL_ENONSTANDARD 0x1FFFF
+
+int32_t SystemNative_ConvertErrorPlatformToPal(int32_t platformErrno)
+{
+    switch (platformErrno)
+    {
+        case 0: return 0x0;
+        case E2BIG: return 0x10001;
+        case EACCES: return 0x10002;
+        case EADDRINUSE: return 0x10003;
+        case EADDRNOTAVAIL: return 0x10004;
+        case EAFNOSUPPORT: return 0x10005;
+        case EWOULDBLOCK: return 0x10006; // == EAGAIN
+        case EALREADY: return 0x10007;
+        case EBADF: return 0x10008;
+        case EBADMSG: return 0x10009;
+        case EBUSY: return 0x1000A;
+        case ECANCELED: return 0x1000B;
+        case ECHILD: return 0x1000C;
+        case ECONNABORTED: return 0x1000D;
+        case ECONNREFUSED: return 0x1000E;
+        case ECONNRESET: return 0x1000F;
+        case EDEADLK: return 0x10010;
+        case EDESTADDRREQ: return 0x10011;
+        case EDOM: return 0x10012;
+        case EDQUOT: return 0x10013;
+        case EEXIST: return 0x10014;
+        case EFAULT: return 0x10015;
+        case EFBIG: return 0x10016;
+        case EHOSTUNREACH: return 0x10017;
+        case EIDRM: return 0x10018;
+        case EILSEQ: return 0x10019;
+        case EINPROGRESS: return 0x1001A;
+        case EINTR: return 0x1001B;
+        case EINVAL: return 0x1001C;
+        case EIO: return 0x1001D;
+        case EISCONN: return 0x1001E;
+        case EISDIR: return 0x1001F;
+        case ELOOP: return 0x10020;
+        case EMFILE: return 0x10021;
+        case EMLINK: return 0x10022;
+        case EMSGSIZE: return 0x10023;
+        case EMULTIHOP: return 0x10024;
+        case ENAMETOOLONG: return 0x10025;
+        case ENETDOWN: return 0x10026;
+        case ENETRESET: return 0x10027;
+        case ENETUNREACH: return 0x10028;
+        case ENFILE: return 0x10029;
+        case ENOBUFS: return 0x1002A;
+        case ENODEV: return 0x1002C;
+        case ENOENT: return 0x1002D;
+        case ENOEXEC: return 0x1002E;
+        case ENOLCK: return 0x1002F;
+        case ENOLINK: return 0x10030;
+        case ENOMEM: return 0x10031;
+        case ENOMSG: return 0x10032;
+        case ENOPROTOOPT: return 0x10033;
+        case ENOSPC: return 0x10034;
+        case ENOSYS: return 0x10037;
+        case ENOTCONN: return 0x10038;
+        case ENOTDIR: return 0x10039;
+#if ENOTEMPTY != EEXIST // identical on some SysV-descended platforms
+        case ENOTEMPTY: return 0x1003A;
+#endif
+#ifdef ENOTRECOVERABLE
+        case ENOTRECOVERABLE: return 0x1003B;
+#endif
+        case ENOTSOCK: return 0x1003C;
+        case ENOTSUP: return 0x1003D; // == EOPNOTSUPP
+        case ENOTTY: return 0x1003E;
+        case ENXIO: return 0x1003F;
+        case EOVERFLOW: return 0x10040;
+#ifdef EOWNERDEAD
+        case EOWNERDEAD: return 0x10041;
+#endif
+        case EPERM: return 0x10042;
+        case EPIPE: return 0x10043;
+        case EPROTO: return 0x10044;
+        case EPROTONOSUPPORT: return 0x10045;
+        case EPROTOTYPE: return 0x10046;
+        case ERANGE: return 0x10047;
+        case EROFS: return 0x10048;
+        case ESPIPE: return 0x10049;
+        case ESRCH: return 0x1004A;
+        case ESTALE: return 0x1004B;
+        case ETIMEDOUT: return 0x1004D;
+        case ETXTBSY: return 0x1004E;
+        case EXDEV: return 0x1004F;
+#ifdef ESOCKTNOSUPPORT
+        case ESOCKTNOSUPPORT: return 0x1005E;
+#endif
+        case EPFNOSUPPORT: return 0x10060;
+        case ESHUTDOWN: return 0x1006C;
+        case EHOSTDOWN: return 0x10070;
+#ifdef ENODATA
+        case ENODATA: return 0x10071;
+#endif
+        default: return DN2CPP_PAL_ENONSTANDARD;
+    }
+}
+
+int32_t SystemNative_ConvertErrorPalToPlatform(int32_t palError)
+{
+    switch (palError)
+    {
+        case 0x0: return 0;
+        case 0x10001: return E2BIG;
+        case 0x10002: return EACCES;
+        case 0x10003: return EADDRINUSE;
+        case 0x10004: return EADDRNOTAVAIL;
+        case 0x10005: return EAFNOSUPPORT;
+        case 0x10006: return EWOULDBLOCK;
+        case 0x10007: return EALREADY;
+        case 0x10008: return EBADF;
+        case 0x10009: return EBADMSG;
+        case 0x1000A: return EBUSY;
+        case 0x1000B: return ECANCELED;
+        case 0x1000C: return ECHILD;
+        case 0x1000D: return ECONNABORTED;
+        case 0x1000E: return ECONNREFUSED;
+        case 0x1000F: return ECONNRESET;
+        case 0x10010: return EDEADLK;
+        case 0x10011: return EDESTADDRREQ;
+        case 0x10012: return EDOM;
+        case 0x10013: return EDQUOT;
+        case 0x10014: return EEXIST;
+        case 0x10015: return EFAULT;
+        case 0x10016: return EFBIG;
+        case 0x10017: return EHOSTUNREACH;
+        case 0x10018: return EIDRM;
+        case 0x10019: return EILSEQ;
+        case 0x1001A: return EINPROGRESS;
+        case 0x1001B: return EINTR;
+        case 0x1001C: return EINVAL;
+        case 0x1001D: return EIO;
+        case 0x1001E: return EISCONN;
+        case 0x1001F: return EISDIR;
+        case 0x10020: return ELOOP;
+        case 0x10021: return EMFILE;
+        case 0x10022: return EMLINK;
+        case 0x10023: return EMSGSIZE;
+        case 0x10024: return EMULTIHOP;
+        case 0x10025: return ENAMETOOLONG;
+        case 0x10026: return ENETDOWN;
+        case 0x10027: return ENETRESET;
+        case 0x10028: return ENETUNREACH;
+        case 0x10029: return ENFILE;
+        case 0x1002A: return ENOBUFS;
+        case 0x1002C: return ENODEV;
+        case 0x1002D: return ENOENT;
+        case 0x1002E: return ENOEXEC;
+        case 0x1002F: return ENOLCK;
+        case 0x10030: return ENOLINK;
+        case 0x10031: return ENOMEM;
+        case 0x10032: return ENOMSG;
+        case 0x10033: return ENOPROTOOPT;
+        case 0x10034: return ENOSPC;
+        case 0x10037: return ENOSYS;
+        case 0x10038: return ENOTCONN;
+        case 0x10039: return ENOTDIR;
+        case 0x1003A: return ENOTEMPTY;
+#ifdef ENOTRECOVERABLE
+        case 0x1003B: return ENOTRECOVERABLE;
+#endif
+        case 0x1003C: return ENOTSOCK;
+        case 0x1003D: return ENOTSUP;
+        case 0x1003E: return ENOTTY;
+        case 0x1003F: return ENXIO;
+        case 0x10040: return EOVERFLOW;
+#ifdef EOWNERDEAD
+        case 0x10041: return EOWNERDEAD;
+#endif
+        case 0x10042: return EPERM;
+        case 0x10043: return EPIPE;
+        case 0x10044: return EPROTO;
+        case 0x10045: return EPROTONOSUPPORT;
+        case 0x10046: return EPROTOTYPE;
+        case 0x10047: return ERANGE;
+        case 0x10048: return EROFS;
+        case 0x10049: return ESPIPE;
+        case 0x1004A: return ESRCH;
+        case 0x1004B: return ESTALE;
+        case 0x1004D: return ETIMEDOUT;
+        case 0x1004E: return ETXTBSY;
+        case 0x1004F: return EXDEV;
+        default: return -1; // ENONSTANDARD / unknown: no platform equivalent
+    }
+}
+
+// StrErrorR(platform errno, buffer, size) → the message. The managed caller treats
+// a null return as "buffer too small" and retries with a larger one.
+//
+// Unconditionally the XSI form: musl has no GNU strerror_r, so unlike the POSIX
+// twin there is nothing here to select between.
+const char* SystemNative_StrErrorR(int32_t platformErrno, char* buffer, int32_t bufferSize)
+{
+    int r = ::strerror_r(platformErrno, buffer, (size_t)bufferSize);
+    if (r == 0 || r == ERANGE)
+        return buffer; // ERANGE = truncated, still NUL-terminated
+    std::snprintf(buffer, (size_t)bufferSize, "Unknown error %d", platformErrno);
+    return buffer;
+}
+
+// ======================= file I/O against MEMFS ============================
+
+// PAL OpenFlags (managed Interop.Sys.OpenFlags) → host O_* bits. The PAL side of
+// this mapping is platform-stable and the host side is musl's; the POSIX twin's
+// body verbatim.
+intptr_t SystemNative_Open(const char* path, int32_t flags, int32_t mode)
+{
+    int f;
+    switch (flags & 0x3)
+    {
+        case 0: f = O_RDONLY; break;
+        case 1: f = O_WRONLY; break;
+        default: f = O_RDWR; break;
+    }
+    if (flags & 0x10) f |= O_CLOEXEC;
+    if (flags & 0x20) f |= O_CREAT;
+    if (flags & 0x40) f |= O_EXCL;
+    if (flags & 0x80) f |= O_TRUNC;
+    if (flags & 0x100) f |= O_SYNC;
+    if (flags & 0x200) f |= O_NOFOLLOW;
+    int fd;
+    while ((fd = ::open(path, f, (mode_t)mode)) < 0 && errno == EINTR)
+    {
+    }
+    return fd;
+}
+
+int32_t SystemNative_Close(intptr_t fd)
+{
+    // No EINTR retry: POSIX leaves the fd state unspecified after EINTR and
+    // retrying can close a recycled descriptor (the real PAL doesn't retry either).
+    return ::close((int)fd);
+}
+
+int32_t SystemNative_Read(intptr_t fd, void* buffer, int32_t bufferSize)
+{
+    if (bufferSize < 0)
+        bufferSize = 0;
+    ssize_t n;
+    while ((n = ::read((int)fd, buffer, (size_t)bufferSize)) < 0 && errno == EINTR)
+    {
+    }
+    return (int32_t)n;
+}
+
+int32_t SystemNative_PRead(intptr_t fd, void* buffer, int32_t bufferSize, int64_t fileOffset)
+{
+    if (bufferSize < 0)
+        bufferSize = 0;
+    ssize_t n;
+    while ((n = ::pread((int)fd, buffer, (size_t)bufferSize, (off_t)fileOffset)) < 0
+           && errno == EINTR)
+    {
+    }
+    return (int32_t)n;
+}
+
+int32_t SystemNative_PWrite(intptr_t fd, const void* buffer, int32_t bufferSize, int64_t fileOffset)
+{
+    ssize_t n;
+    while ((n = ::pwrite((int)fd, buffer, (size_t)bufferSize, (off_t)fileOffset)) < 0
+           && errno == EINTR)
+    {
+    }
+    return (int32_t)n;
+}
+
+// PAL SeekWhence values equal the host SEEK_SET/SEEK_CUR/SEEK_END (0/1/2).
+int64_t SystemNative_LSeek(intptr_t fd, int64_t offset, int32_t whence)
+{
+    return (int64_t)::lseek((int)fd, (off_t)offset, whence);
+}
+
+int32_t SystemNative_FSync(intptr_t fd)
+{
+    int r;
+    while ((r = ::fsync((int)fd)) < 0 && errno == EINTR)
+    {
+    }
+    return r;
+}
+
+int32_t SystemNative_FTruncate(intptr_t fd, int64_t length)
+{
+    int r;
+    while ((r = ::ftruncate((int)fd, (off_t)length)) < 0 && errno == EINTR)
+    {
+    }
+    return r;
+}
+
+// PAL LockOperations values equal the host LOCK_SH/EX/NB/UN (1/2/4/8). Emscripten
+// answers flock(2) by succeeding: one page is one process, so no lock it could
+// hand out is ever contended. The call is kept rather than stubbed here, so a
+// future MEMFS that does arbitrate reports through it.
+int32_t SystemNative_FLock(intptr_t fd, int32_t operation)
+{
+    int r;
+    while ((r = ::flock((int)fd, operation)) < 0 && errno == EINTR)
+    {
+    }
+    return r;
+}
+
+// Advisory readahead hint; the managed caller only debug-asserts success. Returns
+// the error number directly (posix_fadvise convention).
+int32_t SystemNative_PosixFAdvise(intptr_t fd, int64_t offset, int64_t length, int32_t advice)
+{
+    int r;
+    while ((r = ::posix_fadvise((int)fd, (off_t)offset, (off_t)length, advice)) == EINTR)
+    {
+    }
+    return r;
+}
+
+// Preallocation for FileStream(preallocationSize:). **It reserves BLOCKS and must
+// not change the file's LENGTH** — an arm that extends the size makes the file read
+// back as zeros nobody wrote, which every length-driven reader then sees.
+//
+// MEMFS has no size-preserving primitive: posix_fallocate is specified to grow the
+// file to offset+len, and Emscripten has no fallocate(FALLOC_FL_KEEP_SIZE). So do
+// nothing and report success, like the POSIX twin's fallback arm — a hint that is
+// not honored is a hint; a hint that corrupts the length is a bug. The managed
+// caller only surfaces ENOSPC/EFBIG and ignores any other outcome.
+int32_t SystemNative_FAllocate(intptr_t fd, int64_t offset, int64_t length)
+{
+    (void)fd;
+    (void)offset;
+    (void)length;
+    return 0;
+}
+
+// Managed Interop.Sys.FileStatus, sequential layout (net10.0): 120 bytes with
+// trailing pad. Mode is the RAW st_mode — the managed FileTypes constants
+// (S_IFMT/S_IFREG/…) match the POSIX octal values.
+struct Dn2CppPalFileStatus
+{
+    int32_t Flags; // 1 = HasBirthTime
+    int32_t Mode;
+    uint32_t Uid;
+    uint32_t Gid;
+    int64_t Size;
+    int64_t ATime;
+    int64_t ATimeNsec;
+    int64_t MTime;
+    int64_t MTimeNsec;
+    int64_t CTime;
+    int64_t CTimeNsec;
+    int64_t BirthTime;
+    int64_t BirthTimeNsec;
+    int64_t Dev;
+    int64_t RDev;
+    int64_t Ino;
+    uint32_t UserFlags; // 0x8000 = hidden; MEMFS has no such attribute
+};
+
+static void dn2cpp_pal_fill_status(const struct stat& st, Dn2CppPalFileStatus* out)
+{
+    out->Mode = (int32_t)st.st_mode;
+    out->Uid = st.st_uid;
+    out->Gid = st.st_gid;
+    out->Size = (int64_t)st.st_size;
+    out->Dev = (int64_t)st.st_dev;
+    out->RDev = (int64_t)st.st_rdev;
+    out->Ino = (int64_t)st.st_ino;
+    out->ATime = st.st_atim.tv_sec;
+    out->ATimeNsec = st.st_atim.tv_nsec;
+    out->MTime = st.st_mtim.tv_sec;
+    out->MTimeNsec = st.st_mtim.tv_nsec;
+    out->CTime = st.st_ctim.tv_sec;
+    out->CTimeNsec = st.st_ctim.tv_nsec;
+    out->BirthTime = 0;
+    out->BirthTimeNsec = 0;
+    out->Flags = 0; // no birth time
+    out->UserFlags = 0;
+}
+
+int32_t SystemNative_Stat(const char* path, Dn2CppPalFileStatus* output)
+{
+    struct stat st;
+    int r;
+    while ((r = ::stat(path, &st)) < 0 && errno == EINTR)
+    {
+    }
+    if (r == 0)
+        dn2cpp_pal_fill_status(st, output);
+    return r;
+}
+
+int32_t SystemNative_FStat(intptr_t fd, Dn2CppPalFileStatus* output)
+{
+    struct stat st;
+    int r;
+    while ((r = ::fstat((int)fd, &st)) < 0 && errno == EINTR)
+    {
+    }
+    if (r == 0)
+        dn2cpp_pal_fill_status(st, output);
+    return r;
+}
+
+int32_t SystemNative_Unlink(const char* path)
+{
+    int r;
+    while ((r = ::unlink(path)) < 0 && errno == EINTR)
+    {
+    }
+    return r;
+}
+
+char* SystemNative_GetCwd(char* buffer, int32_t bufferSize)
+{
+    return ::getcwd(buffer, (size_t)bufferSize);
+}
+
+// The managed caller compares this against the NFS/CIFS magics to decide whether
+// file locking is trustworthy. MEMFS reports 0, which is none of them — the
+// ordinary local-filesystem behaviour, which is what MEMFS is.
+uint32_t SystemNative_GetFileSystemType(intptr_t fd)
+{
+    struct statfs fs;
+    int r;
+    while ((r = ::fstatfs((int)fd, &fs)) < 0 && errno == EINTR)
+    {
+    }
+    if (r != 0)
+        return 0;
+    return (uint32_t)fs.f_type;
 }
 
 } // extern "C"

--- a/samples/dotnet/MiniCorlib/SharedLayoutTypes.cs
+++ b/samples/dotnet/MiniCorlib/SharedLayoutTypes.cs
@@ -1,0 +1,37 @@
+namespace MiniBcl
+{
+    // A canonical shared-generics owner reachable ONLY through a referenced-only
+    // type's base chain: the app names LayoutMid as a type token and nothing else,
+    // so LayoutMid and its base LayoutBase<LayoutCtx> are emitted opaquely, while
+    // the group's canonical owner LayoutBase<__Canon> is pulled in by the struct
+    // ordering alone. That owner gets a FULL field layout, so every field type it
+    // spells must be declared too.
+    public class LayoutLeaf
+    {
+        public int Value;
+    }
+
+    public class LayoutBeh<T> where T : class
+    {
+        public T Owner;
+    }
+
+    public class LayoutCtx
+    {
+        public int Id;
+    }
+
+#pragma warning disable CS0169, CS0649 // instance fields exist for their LAYOUT, not to be read
+    public class LayoutBase<T> where T : class
+    {
+        private T _ctx;
+        private LayoutBeh<T> _beh;
+        private readonly LayoutLeaf _leaf = new LayoutLeaf();
+        private bool _flag;
+    }
+#pragma warning restore CS0169, CS0649
+
+    public abstract class LayoutMid : LayoutBase<LayoutCtx>
+    {
+    }
+}

--- a/samples/dotnet/MiniCorlib/SharedLayoutTypes.cs
+++ b/samples/dotnet/MiniCorlib/SharedLayoutTypes.cs
@@ -1,11 +1,8 @@
 namespace MiniBcl
 {
-    // A canonical shared-generics owner reachable ONLY through a referenced-only
-    // type's base chain: the app names LayoutMid as a type token and nothing else,
-    // so LayoutMid and its base LayoutBase<LayoutCtx> are emitted opaquely, while
-    // the group's canonical owner LayoutBase<__Canon> is pulled in by the struct
-    // ordering alone. That owner gets a FULL field layout, so every field type it
-    // spells must be declared too.
+    // LayoutMid is referenced only by a type token, so its grouped base's canonical
+    // owner reaches struct ordering without field-type closure. Its full layout must
+    // still name only declared field types.
     public class LayoutLeaf
     {
         public int Value;
@@ -21,12 +18,19 @@ namespace MiniBcl
         public int Id;
     }
 
+    public struct LayoutAligned
+    {
+        public long Wide;
+        public byte Tail;
+    }
+
 #pragma warning disable CS0169, CS0649 // instance fields exist for their LAYOUT, not to be read
     public class LayoutBase<T> where T : class
     {
         private T _ctx;
         private LayoutBeh<T> _beh;
         private readonly LayoutLeaf _leaf = new LayoutLeaf();
+        private LayoutAligned _aligned;
         private bool _flag;
     }
 #pragma warning restore CS0169, CS0649

--- a/samples/dotnet/MultiAssembly/Program.cs
+++ b/samples/dotnet/MultiAssembly/Program.cs
@@ -226,13 +226,9 @@ namespace MultiAssembly
                 + " target " + (string)targetProp.GetValue(oneRef)
                 + " version " + changelog.Version + "/" + changelog.RefCount);
 
-            // A library type named as a TYPE TOKEN and nothing else: never
-            // allocated, no member called. It is emitted opaquely, and so is its
-            // base LayoutBase<LayoutCtx> — but that base is a grouped
-            // specialization, so the struct ordering pulls its canonical owner
-            // LayoutBase<__Canon> in and emits its FULL field layout. The owner
-            // never passes the field-type closure, so its field types have to be
-            // closed for layout explicitly or the header spells undeclared t_ names.
+            // Keep LayoutMid reachable only as a type token: its grouped base's
+            // canonical owner enters struct ordering without passing through the
+            // ordinary field-type closure.
             Type lm = typeof(MiniBcl.LayoutMid);
             Console.WriteLine("lib layout token: " + lm.Name);
             return 0;

--- a/samples/dotnet/MultiAssembly/Program.cs
+++ b/samples/dotnet/MultiAssembly/Program.cs
@@ -225,6 +225,16 @@ namespace MultiAssembly
                 + " item " + refItem.Name
                 + " target " + (string)targetProp.GetValue(oneRef)
                 + " version " + changelog.Version + "/" + changelog.RefCount);
+
+            // A library type named as a TYPE TOKEN and nothing else: never
+            // allocated, no member called. It is emitted opaquely, and so is its
+            // base LayoutBase<LayoutCtx> — but that base is a grouped
+            // specialization, so the struct ordering pulls its canonical owner
+            // LayoutBase<__Canon> in and emits its FULL field layout. The owner
+            // never passes the field-type closure, so its field types have to be
+            // closed for layout explicitly or the header spells undeclared t_ names.
+            Type lm = typeof(MiniBcl.LayoutMid);
+            Console.WriteLine("lib layout token: " + lm.Name);
             return 0;
         }
 

--- a/samples/dotnet/PalSurface/FileStreamPalSubset.cs
+++ b/samples/dotnet/PalSurface/FileStreamPalSubset.cs
@@ -1,0 +1,107 @@
+using System;
+using System.IO;
+using System.Text;
+
+namespace FileStreamPalSubset
+{
+    // The PAL's file-I/O closure -- SafeFileHandle/FileStream/File.* bottoming out in
+    // Interop.Sys.{Open,Close,LSeek,Read,PRead,PWrite,FSync,FStat,Stat,Unlink,FLock,
+    // FTruncate,FAllocate,PosixFAdvise,GetCwd,GetFileSystemType}, and behind all of them
+    // the error trio (StrErrorR and the two PAL/platform converters), which no single
+    // line below reaches on its own. A game reaches the whole thing without asking:
+    // Trace with a DefaultTraceListener log file goes File.AppendAllText ->
+    // SafeFileHandle -> all of it.
+    //
+    // Nothing here may print a PATH or a CWD: the diff oracle is real .NET on the host,
+    // whose temp directory and working directory are not Emscripten's MEMFS ones. Only
+    // derived booleans and file CONTENT cross the diff.
+    internal static class Program
+    {
+        internal static void __GateEntry()
+        {
+            Console.WriteLine("-- FileStreamPalSubset --");
+
+            // getcwd(3). The value is host-specific; that it is rooted and non-empty is not.
+            string cwd = Directory.GetCurrentDirectory();
+            Console.WriteLine($"cwdRooted={cwd.Length > 0 && Path.IsPathRooted(cwd)}");
+
+            string path = Path.Combine(Path.GetTempPath(), "dn2cpp-palsurface.txt");
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+
+            File.WriteAllText(path, "alpha\n");
+            File.AppendAllText(path, "beta\n");
+            Console.WriteLine($"roundTrip={File.ReadAllText(path).Replace("\n", "|")}");
+            Console.WriteLine($"exists={File.Exists(path)}");
+
+            // FileShare arms flock(2) and FileOptions.SequentialScan arms posix_fadvise(2),
+            // on this open and on the plain one below alike. PreallocationSize arms the
+            // fallocate hint, which is accepted only on a CREATING mode -- and it reserves
+            // BLOCKS: the length stays what was written, or every length-driven reader sees
+            // zeros nobody wrote.
+            var options = new FileStreamOptions
+            {
+                Mode = FileMode.Create,
+                Access = FileAccess.ReadWrite,
+                Share = FileShare.Read,
+                Options = FileOptions.SequentialScan,
+                PreallocationSize = 4096,
+            };
+            string prealloc = Path.Combine(Path.GetTempPath(), "dn2cpp-palsurface-prealloc.bin");
+            using (var fs = new FileStream(prealloc, options))
+            {
+                Console.WriteLine($"preallocLength={fs.Length}"); // fstat(2): 0, not 4096
+                fs.Write(Encoding.UTF8.GetBytes("gamma\n"));
+                fs.Flush();
+                Console.WriteLine($"afterWrite={fs.Length}");
+            }
+            File.Delete(prealloc);
+
+            using (var fs = new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.Read))
+            {
+                Console.WriteLine($"fsLength={fs.Length}"); // fstat(2)
+                fs.Seek(0, SeekOrigin.End);                 // lseek(2)
+                fs.Write(Encoding.UTF8.GetBytes("gamma\n"));
+                fs.Flush();
+                Console.WriteLine($"afterAppend={fs.Length}");
+
+                fs.Seek(6, SeekOrigin.Begin);
+                byte[] buf = new byte[4];
+                int n = fs.Read(buf, 0, buf.Length);
+                Console.WriteLine($"read={n}:{Encoding.UTF8.GetString(buf, 0, n)}");
+
+                fs.SetLength(6); // ftruncate(2)
+                Console.WriteLine($"afterTruncate={fs.Length}");
+            }
+            Console.WriteLine($"truncatedContent={File.ReadAllText(path).Replace("\n", "|")}");
+
+            File.Delete(path); // unlink(2)
+            Console.WriteLine($"existsAfterDelete={File.Exists(path)}");
+
+            // Two failed opens, two errnos, one dedicated exception each. Only the
+            // exception TYPE crosses the diff: the message carries the path, and where the
+            // BCL falls back to strerror the wording is the host libc's.
+            try
+            {
+                File.ReadAllText(Path.Combine(cwd, "dn2cpp-palsurface-absent.txt"));
+                Console.WriteLine("openMissing=UNREACHABLE");
+            }
+            catch (FileNotFoundException)
+            {
+                Console.WriteLine("openMissing=FileNotFoundException");
+            }
+
+            try
+            {
+                using var dirStream = new FileStream(cwd, FileMode.Open, FileAccess.Read);
+                Console.WriteLine("openDirectory=UNREACHABLE");
+            }
+            catch (UnauthorizedAccessException)
+            {
+                Console.WriteLine("openDirectory=UnauthorizedAccessException");
+            }
+        }
+    }
+}

--- a/samples/dotnet/PalSurface/NativeHeapPalSubset.cs
+++ b/samples/dotnet/PalSurface/NativeHeapPalSubset.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace NativeHeapPalSubset
+{
+    // The PAL's C heap, reached the way a program reaches it once the intercepts do
+    // not apply. Marshal.{AllocHGlobal,FreeHGlobal} and the NativeMemory family are
+    // lowered inline to dn2cpp_native_*, but the BSTR allocators are not: their real
+    // CoreLib bodies call Interop.Sys.{Malloc,Free}, so this section is what puts
+    // SystemNative_Malloc / SystemNative_Free in the emitted call set.
+    internal static class Program
+    {
+        internal static void __GateEntry()
+        {
+            Console.WriteLine("-- NativeHeapPalSubset --");
+
+            IntPtr bstr = Marshal.StringToBSTR("wasm pal");
+            Console.WriteLine($"bstrNonNull={bstr != IntPtr.Zero}");
+            // The BSTR byte-length prefix sits immediately before the data; reading it
+            // proves the block the PAL allocator returned is the one that was written.
+            Console.WriteLine($"bstrByteLen={Marshal.ReadInt32(bstr, -4)}");
+            Console.WriteLine($"bstrRoundTrip={Marshal.PtrToStringBSTR(bstr)}");
+            Marshal.FreeBSTR(bstr);
+            Console.WriteLine("bstrFreed=True");
+
+            // Zero is a documented no-op on both allocators, and the free path must
+            // reach the PAL without a null check of its own.
+            Marshal.FreeBSTR(IntPtr.Zero);
+            Console.WriteLine("bstrFreeZeroOk=True");
+        }
+    }
+}

--- a/samples/dotnet/PalSurface/PalSurface.csproj
+++ b/samples/dotnet/PalSurface/PalSurface.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Optimize>true</Optimize>
+    <DebugType>none</DebugType>
+    <!-- Debug.Write is [Conditional("DEBUG")]; StderrWritePalSubset needs the call site to survive. -->
+    <DefineConstants>$(DefineConstants);DEBUG</DefineConstants>
+  </PropertyGroup>
+
+</Project>

--- a/samples/dotnet/PalSurface/Program.cs
+++ b/samples/dotnet/PalSurface/Program.cs
@@ -14,6 +14,7 @@ namespace PalSurface
 
             NativeHeapPalSubset.Program.__GateEntry();
             StderrWritePalSubset.Program.__GateEntry();
+            FileStreamPalSubset.Program.__GateEntry();
         }
     }
 }

--- a/samples/dotnet/PalSurface/Program.cs
+++ b/samples/dotnet/PalSurface/Program.cs
@@ -1,0 +1,19 @@
+using System.Globalization;
+
+namespace PalSurface
+{
+    // Gate driver: each section keeps its own namespace so namespace-sensitive output
+    // matches a standalone build.
+    internal static class Program
+    {
+        private static void Main()
+        {
+            // Pin both cultures first: gate output must not depend on the host locale (see AGENTS.md).
+            CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+            CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+
+            NativeHeapPalSubset.Program.__GateEntry();
+            StderrWritePalSubset.Program.__GateEntry();
+        }
+    }
+}

--- a/samples/dotnet/PalSurface/StderrWritePalSubset.cs
+++ b/samples/dotnet/PalSurface/StderrWritePalSubset.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Diagnostics;
+
+namespace StderrWritePalSubset
+{
+    // The PAL's raw fd write. A Debug write reaches DebugProvider.WriteCore, whose two
+    // sinks are Interop.Sys.SysLog (the debugger arm, once Debugger.IsLogging const-folds
+    // false) and Interop.Sys.Write (the stderr arm) -- so this section is what puts
+    // SystemNative_Write in the emitted call set beside SystemNative_SysLog. The bucket
+    // defines DEBUG for it: Debug.Write is [Conditional("DEBUG")], and without the define
+    // the call site is gone before the transpiler sees it.
+    //
+    // Debug, not Trace: DefaultTraceListener can log to a FILE, so a Trace write drags the
+    // whole file-I/O P/Invoke closure in behind it -- and that closure is exactly what the
+    // wasm build excludes.
+    //
+    // Neither sink may reach stdout on either side of the diff, so the section prints a
+    // marker: a section whose subject prints nothing cannot prove it ran.
+    internal static class Program
+    {
+        internal static void __GateEntry()
+        {
+            Console.WriteLine("-- StderrWritePalSubset --");
+            Debug.WriteLine("must not reach stdout");
+            Debug.Write("must not reach stdout");
+            Console.WriteLine("debugWritten=True");
+        }
+    }
+}

--- a/src/Dn2Cpp.Transpiler/CppEmitter.cs
+++ b/src/Dn2Cpp.Transpiler/CppEmitter.cs
@@ -49,6 +49,12 @@ internal sealed partial class CppEmitter
     /// question the stamp asks.</para></summary>
     private readonly HashSet<string> _layoutUnknown = new(StringComparer.Ordinal);
 
+    /// <summary>Every struct name the layout emission actually RENDERED — each field's
+    /// storage type and each struct header's base — checked at the end of
+    /// <see cref="EmitStructs"/> against the names it declared. A layout that spells an
+    /// undeclared <c>t_</c> name is otherwise a C++ error with no cause attached.</summary>
+    private readonly List<(ClassInfo Cls, string Member, string Cpp)> _renderedStructRefs = new();
+
     /// <summary>Whether <paramref name="cls"/>'s type-info must carry
     /// <c>DN2CPP_TF_LAYOUT_UNKNOWN</c> — see <see cref="_layoutUnknown"/>.</summary>
     internal bool HasUnknownLayoutExtent(ClassInfo cls) => _layoutUnknown.Contains(cls.CppStructName);
@@ -5127,6 +5133,7 @@ internal sealed partial class CppEmitter
     private void EmitStructs(StringBuilder sb)
     {
         sb.AppendLine("// ---- managed type layouts ----");
+        _renderedStructRefs.Clear();
         // A grouped specialization's layout IS its canonical owner's
         // (CppStructName redirects), so the alias defines no struct of its own —
         // the owner's single definition serves the whole group.
@@ -5226,9 +5233,30 @@ internal sealed partial class CppEmitter
                 baseName = "Dn2CppExceptionObject";
             else
                 baseName = "Dn2CppObject";
+            _renderedStructRefs.Add((cls, "<base>", baseName));
             EmitOneStruct(sb, cls, baseName);
         }
         sb.AppendLine();
+
+        // Every t_ name a layout spelled must be one this emission declared. The C++
+        // compiler catches the miss too, but only as "unknown type name" with nothing
+        // saying which class, which field, or why the type never reached the emit set.
+        var declared = new HashSet<string>(fwdDeclared, System.StringComparer.Ordinal);
+        declared.UnionWith(emitted);
+        foreach (var (cls, member, cpp) in _renderedStructRefs)
+            if (!StructDeclared(cpp, declared))
+                throw new InvalidOperationException(
+                    $"{cls.FullName}.{member} is laid out as {cpp}, which no emitted struct "
+                    + "declares — the type was never closed into the emit set");
+    }
+
+    /// <summary>A field's rendered storage type, recorded for the declared-name check at
+    /// the end of <see cref="EmitStructs"/>.</summary>
+    private string FieldStorage(ClassInfo cls, FieldInfo f)
+    {
+        string t = CppTypes.FieldOf(f);
+        _renderedStructRefs.Add((cls, f.Name, t));
+        return t;
     }
 
     private void EmitOneStruct(StringBuilder sb, ClassInfo cls, string? baseName)
@@ -5282,7 +5310,7 @@ internal sealed partial class CppEmitter
                 // Storage-width elements (FieldOf; InlineArray owners are
                 // exact-layout) — span windows over the buffer use the element's
                 // real stride.
-                sb.AppendLine($"    {CppTypes.FieldOf(instanceFields[0])} {instanceFields[0].CppName}[{cls.InlineArrayLength}];");
+                sb.AppendLine($"    {FieldStorage(cls, instanceFields[0])} {instanceFields[0].CppName}[{cls.InlineArrayLength}];");
             else if (cls.IsExplicitLayout
                      && (instanceFields.Count > 0 || cls.LayoutSize > 0))
                 // Both value types and reference types: a class's explicit region
@@ -5308,7 +5336,7 @@ internal sealed partial class CppEmitter
                     sb.AppendLine("        struct");
                     sb.AppendLine("        {");
                     foreach (var f in instanceFields)
-                        sb.AppendLine($"            {CppTypes.FieldOf(f)} {f.CppName};");
+                        sb.AppendLine($"            {FieldStorage(cls, f)} {f.CppName};");
                     sb.AppendLine("        };");
                     sb.AppendLine("    };");
                 }
@@ -5316,7 +5344,7 @@ internal sealed partial class CppEmitter
             else
             {
                 foreach (var f in instanceFields)
-                    sb.AppendLine($"    {CppTypes.FieldOf(f)} {f.CppName};");
+                    sb.AppendLine($"    {FieldStorage(cls, f)} {f.CppName};");
                 // A C# `fixed E buf[N]` lowers to a compiler-generated <buf>e__FixedBuffer
                 // value type with a single element field of type E and an explicit
                 // ClassLayout size of N*sizeof(E). The buffer is addressed as
@@ -5398,7 +5426,7 @@ internal sealed partial class CppEmitter
         sb.AppendLine($"        uint8_t __explicit_pad[{size.Text}];");
         foreach (var f in fields)
         {
-            string t = CppTypes.FieldOf(f);
+            string t = FieldStorage(cls, f);
             sb.AppendLine(f.ExplicitOffset == 0
                 ? $"        {t} {f.CppName};"
                 : $"        struct {{ uint8_t __pad_{f.CppName}[{f.ExplicitOffset}]; {t} {f.CppName}; }};");

--- a/src/Dn2Cpp.Transpiler/CppEmitter.cs
+++ b/src/Dn2Cpp.Transpiler/CppEmitter.cs
@@ -5261,6 +5261,8 @@ internal sealed partial class CppEmitter
 
     private void EmitOneStruct(StringBuilder sb, ClassInfo cls, string? baseName)
     {
+        (ModeledSize Size, ModeledSize Align)? opaqueLayout =
+            IsOpaque(cls) && cls.IsValueType ? TryModeledStructLayout(cls) : null;
         // [StructLayout(Pack = N)] caps every field's alignment at N bytes; the
         // pragma makes the C++ compiler apply the same cap so the layout matches the
         // CLR's packed layout (value types only — a class's Pack has no emitted
@@ -5268,9 +5270,12 @@ internal sealed partial class CppEmitter
         bool packed = !IsOpaque(cls) && cls.IsValueType && cls.LayoutPack > 0;
         if (packed)
             sb.AppendLine($"#pragma pack(push, {cls.LayoutPack})");
+        string align = "";
+        if (opaqueLayout is { } ol && ol.Align.Text != "1")
+            align = $" alignas({ol.Align.Text})";
         sb.AppendLine(baseName is null
-            ? $"struct {cls.CppStructName}"
-            : $"struct {cls.CppStructName} : {baseName}");
+            ? $"struct{align} {cls.CppStructName}"
+            : $"struct{align} {cls.CppStructName} : {baseName}");
         sb.AppendLine("{");
         ModeledSize? explicitSize = null;
         // An opaque VALUE type is field-less, but its type-info still stamps instanceSize
@@ -5288,11 +5293,10 @@ internal sealed partial class CppEmitter
         // it today. A one-byte extent cannot: it holds no pointer, so both readings exist.
         if (IsOpaque(cls) && cls.IsValueType)
         {
-            if (TryStructExtent(cls, PointerWidth.Bytes64) is { } osz
-                && PointerWidth.Model(osz.Size, TryStructExtent(cls, PointerWidth.Bytes32)?.Size) is { Guarded: false } m)
+            if (opaqueLayout is { } modeled)
             {
-                if (osz.Size > 1)
-                    sb.AppendLine($"    uint8_t __opaque_pad[{m.Text}];");
+                if (modeled.Size.Text != "1")
+                    sb.AppendLine($"    uint8_t __opaque_pad[{modeled.Size.Text}];");
             }
             else if (!cls.IsEnum)
                 _layoutUnknown.Add(cls.CppStructName);
@@ -5723,6 +5727,18 @@ internal sealed partial class CppEmitter
         }
         _structExtents[(cls, ptr)] = r;
         return r;
+    }
+
+    /// <summary>The target-independent size and alignment an opaque value shell can
+    /// preserve. A missing narrow reading cannot be baked into shared generated text.</summary>
+    private (ModeledSize Size, ModeledSize Align)? TryModeledStructLayout(ClassInfo cls)
+    {
+        if (TryStructExtent(cls, PointerWidth.Bytes64) is not { } wide)
+            return null;
+        var narrow = TryStructExtent(cls, PointerWidth.Bytes32);
+        var size = PointerWidth.Model(wide.Size, narrow?.Size);
+        var align = PointerWidth.Model(wide.Align, narrow?.Align);
+        return size.Guarded || align.Guarded ? null : (size, align);
     }
 
     private (int Size, int Align)? ComputeStructExtent(ClassInfo cls, int ptr)
@@ -6272,15 +6288,17 @@ internal sealed partial class CppEmitter
     {
         // An opaque shell for a by-value field type IS the owner's layout, so a shell of
         // unknown extent would silently shrink the owner rather than only itself.
-        bool Stub(ClassInfo owner, FieldInfo f, ClassInfo t)
+        bool Stub(ClassInfo owner, FieldInfo f, ClassInfo t, bool directByValue)
         {
-            if (!EmitAdd(t))
-                return false;
-            if (t.IsValueType && TryStructExtent(t, PointerWidth.Bytes64) is null)
-                throw new InvalidOperationException(
+            bool added = EmitAdd(t);
+            if (directByValue && (added || _opaque.Contains(t))
+                && TryModeledStructLayout(t) is null)
+                throw new NotSupportedException(
                     $"{owner.FullName}.{f.Name}: by-value field type {t.FullName} is reached "
-                    + "only by the struct ordering and its layout extent is unknown, so no "
-                    + "stub can carry its size");
+                    + "only by the struct ordering, and its size or alignment cannot be "
+                    + "modeled at both pointer widths, so no opaque stub can preserve its layout");
+            if (!added)
+                return false;
             _opaque.Add(t);
             return true;
         }
@@ -6296,17 +6314,21 @@ internal sealed partial class CppEmitter
                 if (_emit.Contains(c) || _opaque.Contains(c)
                     || c.IsEnum || c.IsDelegate || c.SharedOwner is not null)
                     continue;
-                _c.EnsureCompleted(c);
+                if (!c.ShapeReady)
+                    throw new InvalidOperationException(
+                        $"emit protocol: topo-only layout owner {c.FullName} has incomplete shape");
                 foreach (var f in c.Fields)
                 {
                     if (f.IsStatic)
                         continue;
                     var t = f.Type;
+                    bool directByValue = t is
+                        { Kind: TypeKind.Class, Class: { IsValueType: true } };
                     while (t is { Kind: TypeKind.ByRef or TypeKind.Pointer, Element: { } el })
                         t = el;
                     if (t is not { Kind: TypeKind.Class, Class: { IntrinsicCppName: null, IsEnum: false } ft })
                         continue;
-                    grew |= Stub(c, f, ft);
+                    grew |= Stub(c, f, ft, directByValue);
                     // Mirrors the referenced-only path: a stub's own struct name may
                     // redirect to a canonical owner, and its bases back isinst.
                     if (ft.SharedOwner is { } owner && EmitAdd(owner))

--- a/src/Dn2Cpp.Transpiler/CppEmitter.cs
+++ b/src/Dn2Cpp.Transpiler/CppEmitter.cs
@@ -587,6 +587,8 @@ internal sealed partial class CppEmitter
                     }
             _c.CompletePendingSpecializations();
         }
+        if (ClassInfo.ShareStructLayout)
+            CloseTopoOnlyLayouts();
 
         // A `static Main(string[] args)` entry point's epilogue builds the args
         // array tagged with the precise ti_arr_string handle. That per-element array
@@ -6227,6 +6229,75 @@ internal sealed partial class CppEmitter
         sb.AppendLine();
     }
 
+
+    /// <summary>Closes the field types of a class the STRUCT ORDERING reaches and
+    /// nothing else does. TopoOrder visits a SharedOwner unconditionally, so a canonical
+    /// owner pulled in through an opaque referenced-only type's base chain lands in
+    /// neither <see cref="_emit"/> nor <see cref="_opaque"/> — and EmitStructs still
+    /// writes its FULL layout, spelling every field type by name while the only field
+    /// closure (ComputeEmitted's walk) never saw it. Those names must be declared.
+    ///
+    /// <para>The owner itself stays non-opaque: a grouped alias's type-info stamps
+    /// <c>sizeof(t_owner)</c> as its instance size, so shelling the owner instead would
+    /// silently shrink every member of its group.</para></summary>
+    private void CloseTopoOnlyLayouts()
+    {
+        // An opaque shell for a by-value field type IS the owner's layout, so a shell of
+        // unknown extent would silently shrink the owner rather than only itself.
+        bool Stub(ClassInfo owner, FieldInfo f, ClassInfo t)
+        {
+            if (!EmitAdd(t))
+                return false;
+            if (t.IsValueType && TryStructExtent(t, PointerWidth.Bytes64) is null)
+                throw new InvalidOperationException(
+                    $"{owner.FullName}.{f.Name}: by-value field type {t.FullName} is reached "
+                    + "only by the struct ordering and its layout extent is unknown, so no "
+                    + "stub can carry its size");
+            _opaque.Add(t);
+            return true;
+        }
+
+        bool grew = true;
+        while (grew)
+        {
+            grew = false;
+            // A stub can float a further SharedOwner into the order, so this iterates
+            // to a fixpoint over fresh snapshots.
+            foreach (var c in TopoOrder().ToList())
+            {
+                if (_emit.Contains(c) || _opaque.Contains(c)
+                    || c.IsEnum || c.IsDelegate || c.SharedOwner is not null)
+                    continue;
+                _c.EnsureCompleted(c);
+                foreach (var f in c.Fields)
+                {
+                    if (f.IsStatic)
+                        continue;
+                    var t = f.Type;
+                    while (t is { Kind: TypeKind.ByRef or TypeKind.Pointer, Element: { } el })
+                        t = el;
+                    if (t is not { Kind: TypeKind.Class, Class: { IntrinsicCppName: null, IsEnum: false } ft })
+                        continue;
+                    grew |= Stub(c, f, ft);
+                    // Mirrors the referenced-only path: a stub's own struct name may
+                    // redirect to a canonical owner, and its bases back isinst.
+                    if (ft.SharedOwner is { } owner && EmitAdd(owner))
+                    {
+                        _opaque.Add(owner);
+                        grew = true;
+                    }
+                    for (var bc = ft.BaseClass; bc is { IntrinsicCppName: null, IsEnum: false }; bc = bc.BaseClass)
+                        if (EmitAdd(bc))
+                        {
+                            _opaque.Add(bc);
+                            grew = true;
+                        }
+                }
+            }
+        }
+        if (_c.SharedGenericsEnabled)
+            _c.CompletePendingSpecializations();
+    }
 
     private IEnumerable<ClassInfo> TopoOrder()
     {


### PR DESCRIPTION
## 問題

実プロジェクトの Godot Web export が、生成 C++ のコンパイルで `unknown type name 't_..._CnRef'` により失敗する。generated.h に canonical shared-generics owner の完全フィールドレイアウトが emit される一方、そのフィールド型が完全定義・空スタブ・前方宣言のいずれの形でも宣言されない。

修正後に同プロジェクトのエクスポートを最後まで通したところ、wasm PAL 表面の欠落が続けて露出したため、本 PR で併せて解消した(下記)。

## 原因(レイアウト閉包)

referenced-only 型(type token でのみ到達)の opaque 化パスは、基底連鎖を opaque で emit セットに追加するが、基底の `SharedOwner` を扱わない。一方 `TopoOrder()` は `SharedOwner` を無条件に Visit するため、opaque な alias 基底経由でしか到達しない canonical owner が「TopoOrder には現れるが `_emit` にも `_opaque` にもいない」状態になり、`EmitStructs` がその完全レイアウトを emit する。フィールド型の閉包は `ComputeEmitted` の BFS にしかなく、この owner はそこを通らないため、フィールド型が未宣言のまま名前だけ綴られる。

なお owner を opaque(空シェル)にする最小修正は採れない: grouped alias の type-info は `sizeof(t_owner)` を instanceSize に刻むため、group 全メンバーのサイズを黙って壊す。

## 変更内容

**レイアウト閉包(310e14a9 / d437e3b3 / e16994b0)**
- `CppEmitter.CloseTopoOnlyLayouts()`: TopoOrder スナップショットの fixpoint で gap owner を検出し、その非 static フィールドの綴られる型を opaque スタブとして emit セットへ閉包(各スタブの `SharedOwner` と基底連鎖もミラー)。owner 自体は非 opaque のまま。`--no-shared-generics` では構造的に no-op。
- バックストップ: `EmitStructs` がレンダリングした全 `t_` 名(フィールド storage + 基底名)を宣言済み集合と照合し、未宣言なら宣言クラス・フィールド・欠けた型名を名指しした `InvalidOperationException`。
- opaque value shell の size/alignment を両ポインタ幅でモデル化して保持(レビュー対応)。
- 回帰ゲート: `MiniCorlib`/`MultiAssembly` に最小再現セクションを追加し、`build-and-run-multiassembly.sh` が再現形の成立とスタブ宣言を `-w` grep で assert。

**wasm PAL(639955a1 / af8dd3f5)**
- `SystemNative_Write` / `Malloc` / `Free` / `GetErrNo` / `SetErrNo` を追加(`Marshal` の BSTR 経路と `Debug` の stderr 書き出しが到達)。
- FileStream PAL クラスタ 19 シンボルを MEMFS 実装で追加し、carve-out を「`FileStream` と `File.*` は MEMFS 上で動く(ファイルはページ寿命で揮発)」に改訂(AGENTS.md / PORTING.md / EDITOR-EXPORT-DESIGN.md / README 更新、doc-claims の数値クレームも追随)。ほぼ POSIX 実装の流用で、`FAllocate` のみ成功 no-op(MEMFS に size 保持プリミティブが無い)。
- `wasm-console` ゲートに `PalSurface` バケットを新設し、全シンボルの到達を assert。各追加は wasm-ld の undefined-symbol 赤 → 緑で証明済み。

## 検証

- `build-and-run-multiassembly.sh`: 修正前 赤(実障害と同型の `unknown type name`)→ 修正後 緑
- Release / Debug スイート `SKIP_GODOT=1`: 110/111 passed・0 failed(skip は CRI 1 件のみ)
- `shared-generics` / `emit-order-stability` / `uco-shared` / `transpiler-limits` / `selfhost-prim-subset` / `godot-dotnet-trim` / `godot-dotnet-wasm` / `pinvoke-wasm` / `wasm-console` / `doc-claims` / `verify-culture-invariance`: 緑
- `gates/selfhost-emit.sh`: byte-for-byte fixpoint 一致
- **実プロジェクトでの end-to-end 検証**: 本ブランチでバンドルを再パッケージ(`dist/package-toolchain.sh`)してエディタに組み込み、当該プロジェクトの Web export を headless で実行 — transpile → コンパイル → リンク → staged → `wasm import closure verified` まで成功し、ページ一式が出力された。

## 関連

- 検証中に発見した別件バグは #50 に起票(`Encoding.ASCII.GetString` が `NotSupportedException`)。本 PR のスコープ外。

## ハンドオフ

`./gates/pre-merge.sh` は human-only のため未実行です。手元の Web テンプレートが fork エンジンの現ソースに対して stale だったため、pre-merge 前に `FORCE=1 gates/setup-godot-fork-web.sh` の再ベイクが必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)