### PR TITLE
Lower IBinaryFloatParseAndFormatInfo statics for double/float

### DIFF
--- a/gates/build-and-run-float-parse-format-info.sh
+++ b/gates/build-and-run-float-parse-format-info.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Float parsing through IBinaryFloatParseAndFormatInfo<TSelf>: Utf8Parser.TryParse
+# (double/float) and the span Parse/TryParse family, diffed against real .NET.
+# Double/Single implement the interface's static abstract constants as explicit
+# impls the constrained resolver cannot see, so they are lowered from the interface
+# side (MethodCompiler.TryEmitBinaryFloatParseAndFormatInfoIntrinsic); a missing
+# row surfaces here as a transpile error, a wrong value as an output diff.
+source "$(dirname "$0")/_common.sh"
+
+corelib_diff_gate FloatParseFormatInfo

--- a/samples/dotnet/FloatParseFormatInfo/FloatParseFormatInfo.csproj
+++ b/samples/dotnet/FloatParseFormatInfo/FloatParseFormatInfo.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>disable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
+    <DebugType>none</DebugType>
+    <!-- Deliberately no InvariantGlobalization: it pins only the real-.NET oracle and
+         drops ICU, so it is not a second spelling of the driver's CurrentCulture pin.
+         gates/verify-culture-invariance.sh fails a bucket that reintroduces it. -->
+  </PropertyGroup>
+
+</Project>

--- a/samples/dotnet/FloatParseFormatInfo/Program.cs
+++ b/samples/dotnet/FloatParseFormatInfo/Program.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Buffers.Text;
+using System.Globalization;
+using System.Text;
+
+namespace FloatParseFormatInfo
+{
+    // Gate driver: the UTF-8 float parser (System.Buffers.Text.Utf8Parser) and the
+    // span-based double/float Parse family. Both reach Number.NumberToFloatingPointBits
+    // over TFloat : IBinaryFloatParseAndFormatInfo<TFloat>, whose static abstract
+    // constants are explicit impls on Double/Single. Every value is printed with the
+    // shortest round-trip format so the native side must agree bit-for-bit with real
+    // .NET, including subnormals, overflow to infinity and the slow (big-integer) path.
+    internal static class Program
+    {
+        private static readonly string[] Inputs =
+        {
+            "0", "-0", "1", "1.5", "3.141592653589793", "2.5e-3", "1e308", "1e309", "-1e309",
+            "4.9406564584124654E-324", "2.2250738585072014E-308", "1.7976931348623157E+308",
+            "123456789012345678901234567890", "0.1", "0.30000000000000004",
+            "9007199254740993", "1.00000000000000011102230246251565404236316680908203125",
+            "1.4e-45", "3.4028235E+38", "3.4028236E+38", "16777217", "0.1000000000000000055511151231257827",
+            "NaN", "Infinity", "-Infinity", "abc", "",
+        };
+
+        private static void Main()
+        {
+            CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+            foreach (string text in Inputs)
+            {
+                byte[] utf8 = Encoding.UTF8.GetBytes(text);
+                bool okD = Utf8Parser.TryParse(utf8, out double d, out int consumedD);
+                bool okF = Utf8Parser.TryParse(utf8, out float f, out int consumedF);
+                bool okSpanD = double.TryParse(text.AsSpan(), NumberStyles.Float, CultureInfo.InvariantCulture, out double sd);
+                bool okSpanF = float.TryParse(text.AsSpan(), NumberStyles.Float, CultureInfo.InvariantCulture, out float sf);
+                Console.WriteLine(
+                    $"{text}|utf8:{okD}:{consumedD}:{d.ToString("R", CultureInfo.InvariantCulture)}"
+                    + $"|utf8f:{okF}:{consumedF}:{f.ToString("R", CultureInfo.InvariantCulture)}"
+                    + $"|span:{okSpanD}:{sd.ToString("R", CultureInfo.InvariantCulture)}"
+                    + $"|spanf:{okSpanF}:{sf.ToString("R", CultureInfo.InvariantCulture)}");
+            }
+
+            // The bit-reinterpreting members (BitsToFloat / FloatToBits) are reached by
+            // the same parser on the slow path; pin them directly as well.
+            Console.WriteLine(BitConverter.DoubleToUInt64Bits(double.Parse("1e-320", CultureInfo.InvariantCulture)).ToString("X16"));
+            Console.WriteLine(BitConverter.SingleToUInt32Bits(float.Parse("1e-42", CultureInfo.InvariantCulture)).ToString("X8"));
+        }
+    }
+}

--- a/src/Dn2Cpp.Transpiler/MethodCompiler.Call.cs
+++ b/src/Dn2Cpp.Transpiler/MethodCompiler.Call.cs
@@ -1673,6 +1673,18 @@ internal sealed partial class MethodCompiler
                     && Compilation.ContainsCanonPlaceholder(_constrained))))
             ThrowSharedTaint("static-virtual", callee.DeclaringClass.FullName + "." + callee.Name);
 
+        // constrained. + call to System.IBinaryFloatParseAndFormatInfo<TSelf> with TSelf
+        // closed to double/float: the CoreLib-internal parse/format shape constants
+        // (namespace System, so the generic-math table never sees them). Double and
+        // Single implement every member as an explicit static property impl, invisible
+        // to the static-virtual resolver below, which then reports the interface
+        // declaration as a bodyless InternalCall. Reached from Number.NumberToFloat
+        // (Utf8Parser.TryParse(double/float) behind Utf8JsonReader.GetDouble/GetSingle).
+        if (!isCallvirt && callee.IsStatic && callee.DeclaringClass.IsInterface
+            && _constrained is { Kind: TypeKind.Primitive }
+            && TryEmitBinaryFloatParseAndFormatInfoIntrinsic(callee))
+            return;
+
         // The constrained type is the concrete TSelf; resolve to its implementing
         // static method and call it directly. This covers value-type structs — e.g.
         // Linq's IMinMaxCalc<T> Min/Max comparer structs, whose Compare devirtualizes
@@ -2116,6 +2128,77 @@ internal sealed partial class MethodCompiler
     /// guards (e.g. a collection capacity/index check). Emit the primitive op for a
     /// concrete numeric operand; the static-abstract dispatch already closed T to the
     /// primitive.</summary>
+    /// <summary>
+    /// Lowers <c>System.IBinaryFloatParseAndFormatInfo&lt;TSelf&gt;</c> members for TSelf = double/float
+    /// to the .NET 10 CoreLib values of the explicit impls on <c>Double</c>/<c>Single</c>.
+    /// </summary>
+    private bool TryEmitBinaryFloatParseAndFormatInfoIntrinsic(MethodInfo callee)
+    {
+        if (_c.GenericDefFullName(callee.DeclaringClass) != "System.IBinaryFloatParseAndFormatInfo")
+            return false;
+        if (callee.DeclaringClass.Context.TypeArgs is not [{ Kind: TypeKind.Primitive } self])
+            return false;
+        bool isDouble = self.Primitive == PrimitiveTypeCode.Double;
+        if (!isDouble && self.Primitive != PrimitiveTypeCode.Single)
+            return false;
+
+        var ps = callee.Signature.ParameterTypes;
+        var rt = callee.Signature.ReturnType;
+        string ct = CppTypes.Of(rt);
+        if (ps.Length == 1 && callee.Name == "BitsToFloat")
+        {
+            var bits = Pop();
+            Push(CppTypes.KindOf(rt), ct, isDouble
+                ? $"dn2cpp_bits_r8((uint64_t)({bits.Expr}))"
+                : $"(({ct})dn2cpp_bits_r4((uint32_t)({bits.Expr})))");
+            return true;
+        }
+
+        if (ps.Length == 1 && callee.Name == "FloatToBits")
+        {
+            var value = Pop();
+            Push(CppTypes.KindOf(rt), ct, isDouble
+                ? $"dn2cpp_r8_bits((double)({value.Expr}))"
+                : $"((uint64_t)dn2cpp_r4_bits((float)({value.Expr})))");
+            return true;
+        }
+
+        if (ps.Length != 0)
+            return false;
+
+        string? konst = callee.Name switch
+        {
+            "get_NumberBufferLength" => isDouble ? "769" : "114",
+            "get_ZeroBits" => "UINT64_C(0)",
+            "get_InfinityBits" => isDouble ? "UINT64_C(0x7FF0000000000000)" : "UINT64_C(0x7F800000)",
+            "get_NormalMantissaMask" => isDouble ? "UINT64_C(0x001FFFFFFFFFFFFF)" : "UINT64_C(0x00FFFFFF)",
+            "get_DenormalMantissaMask" => isDouble ? "UINT64_C(0x000FFFFFFFFFFFFF)" : "UINT64_C(0x007FFFFF)",
+            "get_MinBinaryExponent" => isDouble ? "-1022" : "-126",
+            "get_MaxBinaryExponent" => isDouble ? "1023" : "127",
+            "get_MinDecimalExponent" => isDouble ? "-324" : "-45",
+            "get_MaxDecimalExponent" => isDouble ? "309" : "39",
+            "get_ExponentBias" => isDouble ? "1023" : "127",
+            "get_ExponentBits" => isDouble ? "11" : "8",
+            "get_OverflowDecimalExponent" => isDouble ? "376" : "58",
+            "get_InfinityExponent" => isDouble ? "0x7FF" : "0xFF",
+            "get_NormalMantissaBits" => isDouble ? "53" : "24",
+            "get_DenormalMantissaBits" => isDouble ? "52" : "23",
+            "get_MinFastFloatDecimalExponent" => isDouble ? "-342" : "-65",
+            "get_MaxFastFloatDecimalExponent" => isDouble ? "308" : "38",
+            "get_MinExponentRoundToEven" => isDouble ? "-4" : "-17",
+            "get_MaxExponentRoundToEven" => isDouble ? "23" : "10",
+            "get_MaxExponentFastPath" => isDouble ? "22" : "10",
+            "get_MaxMantissaFastPath" => isDouble ? "UINT64_C(0x0020000000000000)" : "UINT64_C(0x01000000)",
+            "get_MaxRoundTripDigits" => isDouble ? "17" : "9",
+            "get_MaxPrecisionCustomFormat" => isDouble ? "15" : "7",
+            _ => null,
+        };
+        if (konst is null)
+            return false;
+        Push(CppTypes.KindOf(rt), ct, $"(({ct})({konst}))");
+        return true;
+    }
+
     private bool TryEmitGenericMathIntrinsic(MethodInfo callee)
     {
         if (!callee.DeclaringClass.Namespace.StartsWith("System.Numerics"))


### PR DESCRIPTION
## Problem

Web (and any) export fails at transpile time as soon as the closure reaches `Utf8Parser.TryParse(double/float)` — e.g. through `Utf8JsonReader.GetDouble` / `GetSingle` from a source-generated `JsonSerializerContext` with a `double` or `float` member:

```
error: System.Number.AssembleFloatingPointBits: System.IBinaryFloatParseAndFormatInfo_Double::get_NormalMantissaBits
is an InternalCall/extern method with no IL body and no intrinsic mapping
[chain: System.Number.AssembleFloatingPointBits <- NumberToFloatingPointBitsSlow <- NumberToFloatingPointBits
 <- NumberToFloat <- System.Buffers.Text.Utf8Parser.TryParse <- System.Text.Json.Utf8JsonReader.TryGetDouble <- ...]
```

This is #63. The interface lives in namespace `System`, so `TryEmitGenericMathIntrinsic` (gated on `System.Numerics`) never sees it, and `Double`/`Single` implement every member as an explicit static property impl that the constrained static-virtual resolver cannot find; the call falls through to the bodyless-InternalCall diagnostic.

## Change

- `MethodCompiler.Call.cs`: `TryEmitBinaryFloatParseAndFormatInfoIntrinsic`, hooked ahead of the concrete-TSelf resolution. Lowers the 24 nullary constants with the .NET 10 CoreLib values of the explicit impls on `Double` / `Single`, and `BitsToFloat` / `FloatToBits` through `dn2cpp_bits_r8` / `dn2cpp_r8_bits` (`_r4` for float).
- Gate `build-and-run-float-parse-format-info.sh` / sample `FloatParseFormatInfo`: `Utf8Parser.TryParse` and the span `TryParse` for double and float over normal, subnormal, overflow, slow-path (big-integer) and invalid inputs, printed with `R`, plus the bit patterns of two subnormals — diffed against real .NET.

## Verified

- `SKIP_GODOT=1 ./gates/build-and-run-float-parse-format-info.sh` passes locally (macOS arm64, .NET SDK 10.0.102).
- With this change (and three sibling PRs) a real Godot .NET game that deserializes a 260 KB JSON document with float members exports to Web and runs in Chrome; its 100-seed deterministic simulation produces the same hash as the .NET 9 JIT run.

Draft: the constants are transcribed from `Double.cs` / `Single.cs` in dotnet/runtime `release/10.0` (`NumberBufferLength` = 767+1+1 / 112+1+1). Happy to move them next to the `IFloatingPointIeee754` rows in `TryEmitGenericMathIntrinsic` if a single table is preferred.

Fixes #63
