### PR TITLE
Add Equals(object) intrinsic for the integer primitives

### DIFF
--- a/gates/build-and-run-primitive-equals-object.sh
+++ b/gates/build-and-run-primitive-equals-object.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Int32/Int64/Int16/Byte/Char/Boolean.Equals(object): the boxed-argument overload
+# the integer primitives share, reached by value-object wrappers whose
+# Equals(object) forwards to the wrapped primitive's. Real .NET is the oracle for
+# the same-type-box-only rule (no cross-type numeric equality, null is false).
+source "$(dirname "$0")/_common.sh"
+
+corelib_diff_gate PrimitiveEqualsObject

--- a/samples/dotnet/PrimitiveEqualsObject/PrimitiveEqualsObject.csproj
+++ b/samples/dotnet/PrimitiveEqualsObject/PrimitiveEqualsObject.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>disable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
+    <DebugType>none</DebugType>
+    <!-- Deliberately no InvariantGlobalization: it pins only the real-.NET oracle and
+         drops ICU, so it is not a second spelling of the driver's CurrentCulture pin.
+         gates/verify-culture-invariance.sh fails a bucket that reintroduces it. -->
+  </PropertyGroup>
+
+</Project>

--- a/samples/dotnet/PrimitiveEqualsObject/Program.cs
+++ b/samples/dotnet/PrimitiveEqualsObject/Program.cs
@@ -1,0 +1,61 @@
+using System;
+
+namespace PrimitiveEqualsObject
+{
+    // Gate driver: the Equals(object) overload of the integer primitives, reached
+    // through value-object wrappers of the shape source generators emit
+    // (`obj is Wrapper other && value.Equals(other.value)` lowers the inner call to
+    // Int32.Equals(object) once `other.value` is boxed by the generic path). Real .NET
+    // answers true only for a box of the very same primitive type with an equal
+    // payload: no cross-type numeric comparison, null is false.
+    internal readonly struct Agi
+    {
+        private readonly int value;
+        public Agi(int value) { this.value = value; }
+        public override bool Equals(object obj) => obj is Agi other && value.Equals((object)other.value);
+        public override int GetHashCode() => value.GetHashCode();
+    }
+
+    internal readonly struct Ticks
+    {
+        private readonly long value;
+        public Ticks(long value) { this.value = value; }
+        public override bool Equals(object obj) => obj is Ticks other && value.Equals((object)other.value);
+        public override int GetHashCode() => value.GetHashCode();
+    }
+
+    internal static class Program
+    {
+        private static void Main()
+        {
+            object boxedInt = 42;
+            object boxedLong = 42L;
+            object boxedShort = (short)42;
+            object boxedByte = (byte)42;
+            object boxedChar = 'x';
+            object boxedBool = true;
+
+            Console.WriteLine(42.Equals(boxedInt));
+            Console.WriteLine(42.Equals(boxedLong));
+            Console.WriteLine(42.Equals((object)43));
+            Console.WriteLine(42.Equals(null));
+            Console.WriteLine(42L.Equals(boxedLong));
+            Console.WriteLine(42L.Equals(boxedInt));
+            Console.WriteLine(((short)42).Equals(boxedShort));
+            Console.WriteLine(((short)42).Equals(boxedInt));
+            Console.WriteLine(((byte)42).Equals(boxedByte));
+            Console.WriteLine('x'.Equals(boxedChar));
+            Console.WriteLine('x'.Equals((object)'y'));
+            Console.WriteLine(true.Equals(boxedBool));
+            Console.WriteLine(true.Equals((object)false));
+            Console.WriteLine(int.MinValue.Equals((object)int.MinValue));
+            Console.WriteLine((-1).Equals((object)uint.MaxValue));
+
+            Console.WriteLine(new Agi(7).Equals(new Agi(7)));
+            Console.WriteLine(new Agi(7).Equals(new Agi(8)));
+            Console.WriteLine(new Agi(7).Equals(new Ticks(7)));
+            Console.WriteLine(new Ticks(long.MaxValue).Equals(new Ticks(long.MaxValue)));
+            Console.WriteLine(new Ticks(1).Equals(null));
+        }
+    }
+}

--- a/src/Dn2Cpp.Transpiler/MethodCompiler.EmitIntrinsic.Numbers.cs
+++ b/src/Dn2Cpp.Transpiler/MethodCompiler.EmitIntrinsic.Numbers.cs
@@ -10,6 +10,47 @@ internal sealed partial class MethodCompiler
     /// compares the value directly; the object form first implements IComparable's
     /// null / exact-box-type contract. Keeping both here makes the intrinsic-type and
     /// selectively intercepted primitive families answer from one shape table.</summary>
+    /// <summary>
+    /// <c>Int32.Equals(object)</c> and its primitive siblings: true only when the argument is
+    /// a box of the very same primitive type whose payload equals the receiver (the real
+    /// <c>Equals(object)</c> semantics — no cross-type numeric comparison). Reached by
+    /// UnitGenerator-style value-object wrappers whose <c>Equals(object)</c> forwards
+    /// to the wrapped primitive's.
+    /// </summary>
+    private bool TryEmitPrimitiveEqualsObject(string declType, MethodSignature<TypeDesc> sig)
+    {
+        if (Compilation.WellKnownPrimitive(declType) is not
+                { Kind: TypeKind.Primitive, Primitive: var code } prim
+            || code is PrimitiveTypeCode.String or PrimitiveTypeCode.Object
+                or PrimitiveTypeCode.Single or PrimitiveTypeCode.Double
+            || !sig.Header.IsInstance
+            || sig.ParameterTypes.Length != 1
+            || !sig.ParameterTypes[0].IsObject)
+            return false;
+
+        string compareCt = code switch
+        {
+            PrimitiveTypeCode.UIntPtr => "uintptr_t",
+            PrimitiveTypeCode.IntPtr => "intptr_t",
+            PrimitiveTypeCode.Boolean or PrimitiveTypeCode.Char => "int32_t",
+            _ => CppTypes.Of(prim),
+        };
+        string receiverCt = CppTypes.StorageOf(prim);
+        string boxed = NewTemp("Dn2CppObject*");
+        Emit($"{boxed} = {Cast(Pop(), "Dn2CppObject*")};");
+        string selfObj = NewTemp(compareCt);
+        Emit($"{selfObj} = ({compareCt})({DerefReceiver(receiverCt)});");
+        string result = NewTemp("int32_t");
+        Emit($"{result} = 0;");
+        string ti = TypeInfoExpr(prim)!;
+        string payloadCt = CppTypes.Of(prim);
+        Emit($"if ({boxed} != nullptr && {boxed}->type == {ti}) {{");
+        Emit($"    {result} = (({compareCt})(*({payloadCt}*)({boxed} + 1)) == {selfObj}) ? 1 : 0;");
+        Emit("}");
+        Push(StackKind.I4, "int32_t", result);
+        return true;
+    }
+
     private bool TryEmitPrimitiveCompareTo(string declType, MethodSignature<TypeDesc> sig)
     {
         if (Compilation.WellKnownPrimitive(declType) is not
@@ -85,6 +126,8 @@ internal sealed partial class MethodCompiler
     private bool TryEmitNumbersIntrinsic(string declType, string name, MethodSignature<TypeDesc> sig)
     {
         if (name == "CompareTo" && TryEmitPrimitiveCompareTo(declType, sig))
+            return true;
+        if (name == "Equals" && TryEmitPrimitiveEqualsObject(declType, sig))
             return true;
 
         switch (declType, name)


### PR DESCRIPTION
## Problem

A value-object struct whose `Equals(object)` forwards to the wrapped primitive — the shape source generators such as UnitGenerator emit — fails to transpile:

```
error: <Struct>.Equals: call to System.Int32::Equals(Object) has no intrinsic mapping yet
```

(and `System.Int64::Equals(Object)` for a `long`-backed struct). One row per wrapper type; a project with a couple of dozen strongly-typed ids reports them all.

## Change

- `MethodCompiler.EmitIntrinsic.Numbers.cs`: `TryEmitPrimitiveEqualsObject`, dispatched from `TryEmitNumbersIntrinsic` next to the existing `CompareTo(object)` intercept. Real `.NET` semantics: true only when the argument is a box of the very same primitive type whose payload equals the receiver; null and every other type answer false. `Single`/`Double` are excluded on purpose so the NaN / signed-zero rules stay on their own path.
- Gate `build-and-run-primitive-equals-object.sh` / sample `PrimitiveEqualsObject`: direct calls over int, long, short, byte, char and bool (same-type box, other-type box, null, extreme values) and two wrapper structs — diffed against real .NET.

## Verified

`SKIP_GODOT=1 ./gates/build-and-run-primitive-equals-object.sh` passes locally (macOS arm64, .NET SDK 10.0.102).
