### PR TITLE
Map ValueTask.IsFaulted and IsCanceled to the vtask status

### DIFF
--- a/gates/build-and-run-valuetask-status.sh
+++ b/gates/build-and-run-valuetask-status.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# ValueTask / ValueTask<T> status properties over the terminal states: IsCompleted,
+# IsCompletedSuccessfully, IsFaulted and IsCanceled read off the vtask status word.
+# IsFaulted/IsCanceled are the ones a WhenAll-style combinator inspects before
+# awaiting; they were unmapped. Diffed against real .NET.
+source "$(dirname "$0")/_common.sh"
+
+corelib_diff_gate ValueTaskStatus

--- a/samples/dotnet/ValueTaskStatus/Program.cs
+++ b/samples/dotnet/ValueTaskStatus/Program.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ValueTaskStatus
+{
+    // Gate driver: the status properties of a completed ValueTask / ValueTask<T> —
+    // IsCompleted, IsCompletedSuccessfully, IsFaulted, IsCanceled — over the three
+    // terminal states. IsFaulted/IsCanceled are what a WhenAll-style combinator reads
+    // before deciding whether to await, so a missing intrinsic blocks any library that
+    // fans out ValueTasks (a message router publishing to several subscribers).
+    internal static class Program
+    {
+        private static void Print(string label, ValueTask task)
+        {
+            Console.WriteLine($"{label}: completed={task.IsCompleted} ok={task.IsCompletedSuccessfully} faulted={task.IsFaulted} canceled={task.IsCanceled}");
+        }
+
+        private static void Print<T>(string label, ValueTask<T> task)
+        {
+            Console.WriteLine($"{label}: completed={task.IsCompleted} ok={task.IsCompletedSuccessfully} faulted={task.IsFaulted} canceled={task.IsCanceled}");
+        }
+
+        private static async ValueTask Throws()
+        {
+            await Task.CompletedTask;
+            throw new InvalidOperationException("boom");
+        }
+
+        private static void Main()
+        {
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            Print("default", default(ValueTask));
+            Print("completed", ValueTask.CompletedTask);
+            Print("fromResult", ValueTask.FromResult(3));
+            Print("faulted", ValueTask.FromException(new InvalidOperationException("x")));
+            Print("faultedT", ValueTask.FromException<int>(new InvalidOperationException("x")));
+            Print("canceled", ValueTask.FromCanceled(cts.Token));
+            Print("canceledT", ValueTask.FromCanceled<int>(cts.Token));
+            Print("wrappedFaultedTask", new ValueTask(Task.FromException(new InvalidOperationException("y"))));
+            Print("wrappedCanceledTask", new ValueTask<int>(Task.FromCanceled<int>(cts.Token)));
+
+            ValueTask thrown = Throws();
+            Print("asyncThrows", thrown);
+            try
+            {
+                thrown.GetAwaiter().GetResult();
+            }
+            catch (InvalidOperationException ex)
+            {
+                Console.WriteLine($"observed: {ex.Message}");
+            }
+        }
+    }
+}

--- a/samples/dotnet/ValueTaskStatus/ValueTaskStatus.csproj
+++ b/samples/dotnet/ValueTaskStatus/ValueTaskStatus.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>disable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
+    <DebugType>none</DebugType>
+    <!-- Deliberately no InvariantGlobalization: it pins only the real-.NET oracle and
+         drops ICU, so it is not a second spelling of the driver's CurrentCulture pin.
+         gates/verify-culture-invariance.sh fails a bucket that reintroduces it. -->
+  </PropertyGroup>
+
+</Project>

--- a/src/Dn2Cpp.Transpiler/MethodCompiler.EmitIntrinsic.AwaitersTasks.cs
+++ b/src/Dn2Cpp.Transpiler/MethodCompiler.EmitIntrinsic.AwaitersTasks.cs
@@ -425,6 +425,20 @@ internal sealed partial class MethodCompiler
                 Push(StackKind.Struct, "Dn2CppTaskAwaiter", $"Dn2CppTaskAwaiter{{ {task} }}");
                 return true;
             }
+            case ("System.Threading.Tasks.ValueTask", "get_IsFaulted"):
+            {
+                var v = Pop();
+                Push(StackKind.I4, "int32_t",
+                    $"(dn2cpp_vtask(((Dn2CppTaskAwaiter*)({v.Expr}))->task)->status == DN2CPP_TASK_FAULTED ? 1 : 0)");
+                return true;
+            }
+            case ("System.Threading.Tasks.ValueTask", "get_IsCanceled"):
+            {
+                var v = Pop();
+                Push(StackKind.I4, "int32_t",
+                    $"(dn2cpp_vtask(((Dn2CppTaskAwaiter*)({v.Expr}))->task)->status == DN2CPP_TASK_CANCELED ? 1 : 0)");
+                return true;
+            }
             case ("System.Threading.Tasks.ValueTask", "get_IsCompletedSuccessfully"):
             {
                 var v = Pop();


### PR DESCRIPTION
## Problem

Any library that fans out `ValueTask`s and inspects their outcome before awaiting — VitalRouter's `PublishAsync` with two or more subscribers goes through `ReusableWhenAllSource.AddTask` — fails to transpile:

```
error: VitalRouter.Internal.ReusableWhenAllSource.AddTask:
call to System.Threading.Tasks.ValueTask::get_IsFaulted() has no intrinsic mapping yet
```

`IsCompleted` and `IsCompletedSuccessfully` were mapped; `IsFaulted` and `IsCanceled` were not.

## Change

- `MethodCompiler.EmitIntrinsic.AwaitersTasks.cs`: two cases reading the vtask status word (`DN2CPP_TASK_FAULTED` / `DN2CPP_TASK_CANCELED`), mirroring `get_IsCompletedSuccessfully`.
- Gate `build-and-run-valuetask-status.sh` / sample `ValueTaskStatus`: the four status properties over default, completed, `FromResult`, `FromException`, `FromCanceled`, wrapped faulted/canceled `Task`s and an async method that throws — diffed against real .NET.

## Verified

`SKIP_GODOT=1 ./gates/build-and-run-valuetask-status.sh` passes locally (macOS arm64, .NET SDK 10.0.102). With this and three sibling PRs, VitalRouter 2.1.0 publishes to a multi-subscriber router inside a Godot Web export.
