### PR TITLE
Realize the span source of generic Enum.Parse/TryParse<T>

### DIFF
--- a/gates/build-and-run-enum-parse-span.sh
+++ b/gates/build-and-run-enum-parse-span.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Generic Enum.Parse<T> / Enum.TryParse<T> over ReadOnlySpan<char>: the span source
+# is realized as a string before the per-enum parse table, instead of being cast
+# to one (which the C++ compiler rejects). Names, numeric tokens, case folding,
+# [Flags] lists, a 64-bit underlying enum, misses and a sliced span, diffed
+# against real .NET.
+source "$(dirname "$0")/_common.sh"
+
+corelib_diff_gate EnumParseSpan

--- a/samples/dotnet/EnumParseSpan/EnumParseSpan.csproj
+++ b/samples/dotnet/EnumParseSpan/EnumParseSpan.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>disable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
+    <DebugType>none</DebugType>
+    <!-- Deliberately no InvariantGlobalization: it pins only the real-.NET oracle and
+         drops ICU, so it is not a second spelling of the driver's CurrentCulture pin.
+         gates/verify-culture-invariance.sh fails a bucket that reintroduces it. -->
+  </PropertyGroup>
+
+</Project>

--- a/samples/dotnet/EnumParseSpan/Program.cs
+++ b/samples/dotnet/EnumParseSpan/Program.cs
@@ -1,0 +1,65 @@
+using System;
+
+namespace EnumParseSpan
+{
+    // Gate driver: the ReadOnlySpan<char> overloads of the generic Enum.Parse<T> /
+    // Enum.TryParse<T>. The string overloads were lowered; the span ones fell into the
+    // same arm with a bare cast of the span struct to a string pointer, which the C++
+    // compiler rejects — the shape System.Text.Json's EnumConverter<T> reaches for
+    // every enum-typed member. Names, numbers, case folding, flags and misses are
+    // diffed against real .NET.
+    internal enum Color { Red = 1, Green = 2, Blue = 3 }
+
+    [Flags]
+    internal enum Perm : byte { None = 0, Read = 1, Write = 2, Exec = 4 }
+
+    internal enum Wide : long { Small = 1, Big = 1L << 40 }
+
+    internal static class Program
+    {
+        private static void Try<T>(string text, bool ignoreCase) where T : struct, Enum
+        {
+            ReadOnlySpan<char> span = text.AsSpan();
+            bool ok = Enum.TryParse<T>(span, ignoreCase, out T value);
+            Console.WriteLine($"TryParse<{typeof(T).Name}>(\"{text}\", {ignoreCase}) = {ok} {value}");
+        }
+
+        private static void Parse<T>(string text) where T : struct, Enum
+        {
+            try
+            {
+                Console.WriteLine($"Parse<{typeof(T).Name}>(\"{text}\") = {Enum.Parse<T>(text.AsSpan())}");
+            }
+            catch (ArgumentException)
+            {
+                Console.WriteLine($"Parse<{typeof(T).Name}>(\"{text}\") threw ArgumentException");
+            }
+        }
+
+        private static void Main()
+        {
+            Try<Color>("Green", false);
+            Try<Color>("green", false);
+            Try<Color>("green", true);
+            Try<Color>("2", false);
+            Try<Color>("7", false);
+            Try<Color>("Purple", true);
+            Try<Perm>("Read, Exec", false);
+            Try<Perm>("read,write", true);
+            Try<Perm>("6", false);
+            Try<Wide>("Big", false);
+            Try<Wide>("1099511627776", false);
+            Try<Color>("", false);
+            Parse<Color>("Blue");
+            Parse<Color>("blue");
+            Parse<Perm>("Write");
+            Parse<Wide>("Small");
+
+            // A span that is a slice of a larger buffer, the way a JSON reader hands
+            // the value out: length must be honored, not the backing string's.
+            ReadOnlySpan<char> sliced = "xxBluexx".AsSpan(2, 4);
+            Console.WriteLine(Enum.TryParse<Color>(sliced, false, out Color fromSlice) + " " + fromSlice);
+            Console.WriteLine(Enum.TryParse<Color>("Blue", out Color fromString) + " " + fromString);
+        }
+    }
+}

--- a/src/Dn2Cpp.Transpiler/MethodCompiler.EnumAsync.cs
+++ b/src/Dn2Cpp.Transpiler/MethodCompiler.EnumAsync.cs
@@ -52,6 +52,22 @@ internal sealed partial class MethodCompiler
     /// literals; no runtime metadata is read. The case-insensitive `Parse`/`TryParse`
     /// overloads (the trailing `bool ignoreCase`) fold case via the runtime flag through
     /// `dn2cpp_string_equals_ci`.</summary>
+    /// <summary>The Dn2CppString* expression for a generic Enum.Parse/TryParse source
+    /// argument: the string overloads pass it through, the ReadOnlySpan&lt;char&gt; overloads
+    /// (Enum.TryParse&lt;T&gt;(ReadOnlySpan&lt;char&gt;, bool, out T) — reached from
+    /// System.Text.Json's EnumConverter.TryParseEnumFromString) realize the span as a
+    /// string so the same dn2cpp_enum_parse worker serves both.</summary>
+    private string EnumParseSourceString(StackEntry s, TypeDesc paramType)
+    {
+        if (IsSpanOf(paramType, PrimitiveTypeCode.Char))
+        {
+            string sv = SpanValue(s, CppTypes.Of(paramType));
+            return $"dn2cpp_string_from_chars((const char16_t*){sv}.f__reference, {sv}.f__length)";
+        }
+
+        return Cast(s, "Dn2CppString*");
+    }
+
     private void TranslateEnumReflection(string name, MethodSpecificationHandle msh, TypeDesc[] methodArgs)
     {
         var t = methodArgs[0];
@@ -161,7 +177,7 @@ internal sealed partial class MethodCompiler
                 var s = Pop();
                 string st = NewTemp("Dn2CppString*");
                 string r = NewTemp(cty);
-                Emit($"{st} = {Cast(s, "Dn2CppString*")};");
+                Emit($"{st} = {EnumParseSourceString(s, sig.ParameterTypes[0])};");
                 EmitEnumParse(enumClass, members, wide, st, r, ic, onFail:
                     $"dn2cpp_throw_sr1(&dn2cpp_argument_exception_type, DN2CPP_SR_ENUM_VALUE_NOT_FOUND, {st});");
                 Push(wide ? StackKind.I8 : StackKind.I4, cty, r);
@@ -177,7 +193,7 @@ internal sealed partial class MethodCompiler
                 string st = NewTemp("Dn2CppString*");
                 string r = NewTemp(cty);            // the parsed value
                 string ok = NewTemp("int32_t");     // the bool result
-                Emit($"{st} = {Cast(s, "Dn2CppString*")};");
+                Emit($"{st} = {EnumParseSourceString(s, sig.ParameterTypes[0])};");
                 EmitEnumParse(enumClass, members, wide, st, r, ic, okVar: ok);
                 // Store through the `out T` ref at the enum's REAL underlying width:
                 // the ref can target a narrowed sub-word-underlying enum field (or a


### PR DESCRIPTION
## Problem

The transpile succeeds but the C++ build fails for every enum-typed member System.Text.Json deserializes — `EnumConverter<T>.TryParseEnumFromString` calls `Enum.TryParse<T>(ReadOnlySpan<char>, bool, out T)`:

```
generated_b53.cpp:1121:12: error: cannot cast from type 't_System_ReadOnlySpan_Char' to pointer type 'Dn2CppString *'
    t46 = ((Dn2CppString*)t44);
    ...
    t48 = dn2cpp_enum_parse(t46, t49, t50, 5, 0, 4, 0, &t47, nullptr);
```

`TranslateEnumReflection` lowers the generic `Parse<T>` / `TryParse<T>` and casts the first argument to `Dn2CppString*` unconditionally; only the non-generic `Enum.TryParse(Type, ReadOnlySpan<char>, …)` arm knew about spans. Because the emitter does not fail, the error only surfaces from clang, one translation unit per enum.

## Change

- `MethodCompiler.EnumAsync.cs`: `EnumParseSourceString` materializes a `ReadOnlySpan<char>` source through `dn2cpp_string_from_chars` (as the non-generic arm does) and keeps the string overloads on the direct cast; used by both `Parse` and `TryParse`.
- Gate `build-and-run-enum-parse-span.sh` / sample `EnumParseSpan`: names, numeric tokens, case folding, `[Flags]` lists, a `long`-underlying enum, misses, `Parse` throwing, and a span that is a slice of a larger buffer (so the length, not the backing string, is honored) — diffed against real .NET.

## Verified

`SKIP_GODOT=1 ./gates/build-and-run-enum-parse-span.sh` passes locally (macOS arm64, .NET SDK 10.0.102). With this and three sibling PRs, a source-generated `JsonSerializerContext` with enum members compiles and runs inside a Godot Web export.
