### PR TITLE
Keep Godot fork artifacts fresh before pre-merge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,10 @@ The merge gate — `./gates/pre-merge.sh` — does not run there and cannot. Its
 header states each structural reason (a scons-built dn2cpp fork of the Godot
 editor, Xcode plus an iOS simulator, an Android NDK, a proprietary CRI package);
 read it there rather than trusting a summary. A maintainer runs it on a
-provisioned machine.
+provisioned machine. The Emscripten SDK is the one prerequisite pre-merge
+provisions itself (`gates/setup-emsdk.sh`); a host missing any other one still
+runs to completion, and the surfaces it cannot cover are reported red at the
+verdict — never green, never skipped.
 
 So a green pull request is not permission to merge — and equally, a pull request
 never goes red over a toolchain you cannot install.

--- a/docs/EDITOR-EXPORT-DESIGN.md
+++ b/docs/EDITOR-EXPORT-DESIGN.md
@@ -504,7 +504,7 @@ from outside the `.app` and cmake, ninja and Emscripten's clang from inside it.
    | that clone's glue and assemblies + feed (steps 2, 3) | `clone_tree_hash` (pin plus working-tree dirt), stamped in the gitignored `…/Generated/GeneratedIncludes.props.clone-hash` and `bin/GodotSharp/.clone-hash` |
    | the fork's editor + release template (`gates/setup-godot-fork.sh` steps 1, 5) | `godot_fork_engine_hash`, stamped `<binary>.engine-hash` |
    | the fork's mono glue (step 2) | the same engine hash — the glue is the editor's output |
-   | the fork's assemblies + feed + toolchain (step 4) | `tools_tree_hash` over the managed trees `build_assemblies.py` compiles |
+   | the fork's assemblies + feed + toolchain (step 4) | `godot_fork_tools_hash` over the managed trees `build_assemblies.py` compiles |
    | the fork's desktop export template (step 5) | `<template>.provenance`, `godot_fork_engine_provenance` |
    | the fork's iOS simulator library (`gates/setup-godot-fork-ios.sh` step 3) | `<library>.provenance`, `godot_fork_engine_provenance` plus the complete SCons argument vector |
 
@@ -539,6 +539,25 @@ from outside the `.app` and cmake, ninja and Emscripten's clang from inside it.
    re-freeze.
 3. Bump the pin constant in the gates, rebase `dn2cpp/main`, rebuild the fork
    cache, update `gates/expected/godot-fork-pin.txt`, re-run all Godot gates.
+
+### Ordinary fork updates are not a procedure
+
+The list above is for moving the *base*. A GodotTools edit, or a rebase onto the
+same base with unchanged engine sources, needs no separate cache procedure:
+`gates/pre-merge.sh` asks `godot_fork_cache_fresh` (`gates/_godot_fork.sh`)
+before its suites and refreshes the desktop cache and the two Web templates when
+a stamp disagrees. An engine edit also makes the iOS template stale. That repair
+stays manual because it consumes Xcode and an official templates archive;
+pre-merge refuses before its suites and names `gates/setup-godot-fork-ios.sh`
+rather than discovering the stale template inside the iOS gate.
+
+That predicate is also what makes forgetting *impossible* rather than merely
+unnecessary. `godot_fork_preflight` runs it inside every export gate, live and
+upstream of `gate_cache_check`, so a stale cache fails there with the
+disagreeing stamp named. Without it the gates read `Tools/GodotTools.dll` as
+their subject *and* hash that same DLL into their key, so an uncompiled
+GodotTools edit moves no key and the suite replays a warm green over the old
+exporter.
 
 ## 8. Risks
 

--- a/docs/EDITOR-EXPORT-DESIGN.md
+++ b/docs/EDITOR-EXPORT-DESIGN.md
@@ -547,9 +547,11 @@ same base with unchanged engine sources, needs no separate cache procedure:
 `gates/pre-merge.sh` asks `godot_fork_cache_fresh` (`gates/_godot_fork.sh`)
 before its suites and refreshes the desktop cache and the two Web templates when
 a stamp disagrees. An engine edit also makes the iOS template stale. That repair
-stays manual because it consumes Xcode and an official templates archive;
-pre-merge refuses before its suites and names `gates/setup-godot-fork-ios.sh`
-rather than discovering the stale template inside the iOS gate.
+stays manual because it consumes Xcode and an official templates archive. On a
+host with Xcode, pre-merge refuses before its suites and names
+`gates/setup-godot-fork-ios.sh` rather than discovering the stale template
+inside the iOS gate; on a host without Xcode nothing can be repaired, so the
+suites run to completion and the iOS gates are reported red at the verdict.
 
 That predicate is also what makes forgetting *impossible* rather than merely
 unnecessary. `godot_fork_preflight` runs it inside every export gate, live and

--- a/gates/_common.sh
+++ b/gates/_common.sh
@@ -499,15 +499,18 @@ godot_editor_config_dir() {
 # off its single Godot.NET.Sdk.<version>.nupkg. A gate re-pins a THIRD-PARTY
 # sample's Sdk onto this rather than onto a literal nothing re-pins.
 godot_nuget_sdk_version() {
-    local pkg
-    for pkg in "$1"/Godot.NET.Sdk.*.nupkg; do
-        [ -f "$pkg" ] || continue
-        pkg="${pkg##*/Godot.NET.Sdk.}"
-        printf '%s\n' "${pkg%.nupkg}"
-        return 0
-    done
-    echo "error: no Godot.NET.Sdk.*.nupkg in $1" >&2
-    return 1
+    local pkgs pkg
+    pkgs=("$1"/Godot.NET.Sdk.*.nupkg)
+    if [ ! -f "${pkgs[0]}" ]; then
+        echo "error: no Godot.NET.Sdk.*.nupkg in $1" >&2
+        return 1
+    fi
+    if [ "${#pkgs[@]}" -ne 1 ]; then
+        echo "error: expected one Godot.NET.Sdk package in $1, found ${#pkgs[@]}" >&2
+        return 1
+    fi
+    pkg="${pkgs[0]##*/Godot.NET.Sdk.}"
+    printf '%s\n' "${pkg%.nupkg}"
 }
 
 godot_template_version_dir() {

--- a/gates/_godot_fork.sh
+++ b/gates/_godot_fork.sh
@@ -13,18 +13,22 @@
 # (gate_skip, file_sig, file_sig_deref, file_hash, file_text, src_tree_hash) are
 # only called by gates, which source _common.sh first. The repo-root-relative
 # paths (gates/expected/..., artifacts/...) rely on _common.sh's cd-to-repo-root;
-# the setup aids only call godot_fork_resolve, which reads nothing but $FORK_ROOT.
+# the setup aids call only the functions that need neither — godot_fork_resolve,
+# the two tree hashes and the two cache predicates, which read $FORK_ROOT and
+# the fork worktree and nothing else.
 #
 # CACHE-KEY CONSTRAINT: no function here may affect gate behavior past
 # gate_cache_check. This file's own CONTENT is in every key (_gate_helpers_hash
 # in gates/_common.sh folds the whole gates/_*.sh set in), but what these
-# functions INSPECT is not: the ARTIFACTS under $FORK_ROOT (engine sources,
-# export template zips, their .provenance stamps). A gate's `tmpl=` term
-# fingerprints the stale zip ITSELF, so it holds still precisely while the
-# artifact is wrong, and the engine sources a stamp is compared against are in no
-# key at all — a template can go stale with every key unmoved and a warm green
-# replayed over it. So everything here runs live BEFORE the check: the preflight
-# and the pin/ABI tripwire assert on the spot, and godot_fork_ctx's output lands
+# functions INSPECT is not: the ARTIFACTS under $FORK_ROOT and in the fork's own
+# bin/ (the engine binaries, the GodotSharp tree, the export template zips, and
+# every .engine-hash / .tools-hash / .provenance stamp beside them). A gate's
+# `tmpl=`, `editor=` and `tools=` terms fingerprint the stale ARTIFACT ITSELF, so
+# they hold still precisely while it is wrong, and the fork sources a stamp is
+# compared against are in no key at all — a template or a whole fork cache can go
+# stale with every key unmoved and a warm green replayed over it. So everything
+# here runs live BEFORE the check: the preflight, the pin/ABI tripwire and the
+# freshness predicates assert on the spot, and godot_fork_ctx's output lands
 # verbatim in the CONTEXT string.
 
 FORK_ROOT="${DN2CPP_GODOT_FORK_ROOT:-$HOME/.cache/dn2cpp-godot-fork}"
@@ -238,6 +242,123 @@ godot_fork_engine_provenance() {
     printf 'engine=%s base=%s\n' "$(godot_fork_engine_hash)" "$BASE_COMMIT"
 }
 
+# ── Tools provenance ─────────────────────────────────────────────────────────
+# The MANAGED half of the fork: what build_assemblies.py compiles. TOOLS_OWNED
+# and FORK_OWNED partition the fork, and that partition is what lets the
+# GodotTools edit-test loop rebuild the assemblies without triggering a scons run
+# and an engine edit do the reverse. Both halves are defined here, in one file,
+# for FORK_OWNED's reason: a second copy of "which sources are which" is what
+# drifts, and gates/setup-godot-fork.sh is no longer the only asker — the fork
+# cache's own freshness is a question a gate and gates/pre-merge.sh both put.
+#
+# The membership is derived from what build_assemblies.py's build_all actually
+# READS, not from FORK_OWNED's exclusion list: generate_sdk_package_versions
+# (version.py -> the gitignored SdkPackageVersions.props), build_godot_api (the
+# GodotSharp glue sources -> Api/Release/GodotSharp.dll), GodotTools.sln
+# (-> Tools/GodotTools.dll) and Godot.NET.Sdk (-> the nupkgs pushed to the feed).
+# So it is a SUPERSET of the complement: version.py and modules/mono/glue/GodotSharp
+# are FORK_OWNED too and feed BOTH hashes, because they feed both products.
+#
+# `modules/mono/editor` is deliberately NOT taken whole — that directory also
+# holds engine C++ (editor_internal_calls.cpp, bindings_generator.cpp), which is
+# the engine hash's and whose change already forces a scons build.
+TOOLS_OWNED=(
+    'version.py'
+    'modules/mono/build_scripts'
+    'modules/mono/editor/GodotTools'
+    'modules/mono/editor/Godot.NET.Sdk'
+    'modules/mono/glue/GodotSharp'
+)
+
+# godot_fork_tools_hash — godot_fork_engine_hash's twin over TOOLS_OWNED, same
+# rules and for the same reasons: content rather than git state (so staging or
+# committing a GodotTools edit is not a rebuild, and reaching the same sources
+# from another branch is not either), --binary so a modified binary file is
+# fingerprinted by content, and untracked files hashed in. Everything
+# build_assemblies.py *writes* is gitignored (bin/, obj/, SdkPackageVersions.props,
+# the generated glue and source-generator constants), so its own products cannot
+# feed the hash that keys them — which is what keeps the stamp from moving on
+# every build.
+#
+# Reads $FORK (godot_fork_resolve) and $BASE_COMMIT, like its twin.
+godot_fork_tools_hash() {
+    (
+        cd "$FORK"
+        printf 'base %s\n' "$BASE_COMMIT"
+        git diff --no-ext-diff --no-textconv --no-color --no-renames --binary \
+            "$BASE_COMMIT" -- "${TOOLS_OWNED[@]}"
+        # Not `xargs`, for godot_fork_engine_hash's reason: with no untracked
+        # file GNU xargs still runs shasum, which hashes its own stdin, and the
+        # same tree would then key a different cache entry per host flavour.
+        git ls-files --others --exclude-standard -z -- "${TOOLS_OWNED[@]}" \
+            | while IFS= read -r -d '' f; do shasum -a 256 "$f"; done
+    ) | shasum -a 256 | cut -c1-16
+}
+
+# godot_fork_tools_stamp — where godot_fork_tools_hash is recorded: beside the
+# tree it describes, under the fork's gitignored bin/, the same placement and the
+# same rule as an engine binary's .engine-hash stamp. A function rather than a
+# variable because it reads $FORK, which is resolved per caller.
+godot_fork_tools_stamp() {
+    printf '%s/bin/GodotSharp/.tools-hash\n' "$FORK"
+}
+
+# godot_fork_managed_package_version — the version build_assemblies.py gives all
+# four managed packages in the fork feed. Its generated
+# SdkPackageVersions.props assigns this same godotsharp_version_str to
+# Godot.NET.Sdk, Godot.SourceGenerators, GodotSharp and GodotSharpEditor (the
+# latter reads PackageVersion_GodotSharp). Read version.py rather than a sample:
+# the feed is a fork product, and a re-pin can move it before samples move.
+godot_fork_managed_package_version() {
+    local major minor patch status label digits
+    major="$(sed -n 's/^major = //p' "$FORK/version.py")"
+    minor="$(sed -n 's/^minor = //p' "$FORK/version.py")"
+    patch="$(sed -n 's/^patch = //p' "$FORK/version.py")"
+    status="$(sed -n 's/^status = "\([^"]*\)"/\1/p' "$FORK/version.py")"
+    [ -n "$major" ] && [ -n "$minor" ] && [ -n "$patch" ] && [ -n "$status" ] || return 1
+    if [ "$status" = stable ]; then
+        printf '%s.%s.%s\n' "$major" "$minor" "$patch"
+        return 0
+    fi
+    label="$status"
+    digits=""
+    if [[ "$status" =~ ^([^0-9]*)([0-9]+)$ ]]; then
+        label="${BASH_REMATCH[1]}"
+        digits=".${BASH_REMATCH[2]}"
+    fi
+    printf '%s.%s.%s-%s%s\n' "$major" "$minor" "$patch" "$label" "$digits"
+}
+
+# godot_fork_managed_feed_fresh — exactly one current nupkg for every package
+# build_assemblies.py pushes. Checking only the SDK package admits a feed whose
+# SourceGenerators or GodotSharp dependency comes from another pin.
+# Sets FORK_MANAGED_FEED_WHY for the two callers' diagnostics.
+godot_fork_managed_feed_fresh() {
+    FORK_MANAGED_FEED_WHY=""
+    local version id expected files
+    version="$(godot_fork_managed_package_version)" || {
+        FORK_MANAGED_FEED_WHY="the fork's managed package version could not be read from version.py"
+        return 1
+    }
+    for id in Godot.NET.Sdk Godot.SourceGenerators GodotSharp GodotSharpEditor; do
+        expected="$FORK_ROOT/nuget/$id.$version.nupkg"
+        files=("$FORK_ROOT"/nuget/"$id".*.nupkg)
+        if [ ! -f "${files[0]}" ]; then
+            FORK_MANAGED_FEED_WHY="the managed feed has no $id package (wanted $(basename "$expected"))"
+            return 1
+        fi
+        if [ "${#files[@]}" -ne 1 ]; then
+            FORK_MANAGED_FEED_WHY="the managed feed is ambiguous for $id (${#files[@]} packages; wanted only $(basename "$expected"))"
+            return 1
+        fi
+        if [ "${files[0]}" != "$expected" ]; then
+            FORK_MANAGED_FEED_WHY="the managed feed contains $(basename "${files[0]}"), wanted $(basename "$expected")"
+            return 1
+        fi
+    done
+    return 0
+}
+
 # godot_fork_template_check PATH WHAT REMEDY — refuse an export template that
 # was not baked from the engine sources now in the fork. Reads $FORK and
 # $BASE_COMMIT, so a gate calls it after godot_fork_pin_abi_check and BEFORE
@@ -353,6 +474,41 @@ godot_fork_web_template_flavor() {
     fi
 }
 
+# godot_fork_web_template_fresh ZIP FLAVOR EMCC_STAMP EMCC ENGINE — the exact
+# skip predicate shared by the Web builder and pre-merge. The published emcc
+# stamp has a different name from the built zip's, so its path is explicit.
+# Sets FORK_WEB_TEMPLATE_WHY instead of printing: a probe's stdout is its return
+# protocol, while the builder has its own progress language.
+godot_fork_web_template_fresh() {
+    local zip="$1" want_flavor="$2" emcc_stamp="$3" want_emcc="$4" want_engine="$5"
+    local got_flavor got_emcc got_engine
+    FORK_WEB_TEMPLATE_WHY=""
+    if [ ! -f "$zip" ]; then
+        FORK_WEB_TEMPLATE_WHY="$zip is missing"
+        return 1
+    fi
+    got_flavor="$(godot_fork_web_template_flavor "$zip")"
+    if [ "$got_flavor" != "$want_flavor" ]; then
+        FORK_WEB_TEMPLATE_WHY="$zip is flavor $got_flavor, wanted $want_flavor"
+        return 1
+    fi
+    got_emcc="$(head -1 "$emcc_stamp" 2>/dev/null || true)"
+    if [ "$got_emcc" != "$want_emcc" ]; then
+        FORK_WEB_TEMPLATE_WHY="$emcc_stamp is ${got_emcc:-<empty>}, wanted $want_emcc"
+        return 1
+    fi
+    got_engine="$(head -1 "$zip.provenance" 2>/dev/null || true)"
+    if [ "$got_engine" != "$want_engine" ]; then
+        FORK_WEB_TEMPLATE_WHY="$zip.provenance is ${got_engine:-<empty>}, wanted $want_engine"
+        return 1
+    fi
+    if ! godot_fork_web_template_structural_fresh "$zip"; then
+        FORK_WEB_TEMPLATE_WHY="$FORK_WEB_TEMPLATE_STRUCTURAL_WHY"
+        return 1
+    fi
+    return 0
+}
+
 # godot_fork_web_template_assert ZIP — refuse a Web template the mono drop-in
 # cannot load. Two structural properties, neither of which announces itself at
 # export time:
@@ -367,23 +523,100 @@ godot_fork_web_template_flavor() {
 #     would recognise.
 #
 # Exits 1 on either: the artifact is WRONG, not missing.
-godot_fork_web_template_assert() {
+godot_fork_web_template_structural_fresh() {
     local zip="$1" tmp
+    FORK_WEB_TEMPLATE_STRUCTURAL_WHY=""
     tmp="$(mktemp -d)"
-    unzip -q "$zip" -d "$tmp"
-    if [ ! -f "$tmp/godot.side.wasm" ]; then
-        echo "error: $zip carries no godot.side.wasm -- this is not a dlink build" >&2
+    if ! unzip -q "$zip" -d "$tmp"; then
+        FORK_WEB_TEMPLATE_STRUCTURAL_WHY="$zip is not a readable template zip"
         rm -rf "$tmp"
-        exit 1
+        return 1
+    fi
+    if [ ! -f "$tmp/godot.side.wasm" ]; then
+        FORK_WEB_TEMPLATE_STRUCTURAL_WHY="$zip carries no godot.side.wasm -- this is not a dlink build"
+        rm -rf "$tmp"
+        return 1
     fi
     if ! grep -aq '__cpp_exception' "$tmp/godot.wasm"; then
-        echo "error: $zip's main module does not export the C++ exception tag" >&2
-        echo "       (rebuild with disable_exceptions=no cxxflags/linkflags=-fwasm-exceptions)" >&2
+        FORK_WEB_TEMPLATE_STRUCTURAL_WHY="$zip's main module does not export the C++ exception tag"
         rm -rf "$tmp"
-        exit 1
+        return 1
     fi
     rm -rf "$tmp"
+    return 0
+}
+
+godot_fork_web_template_assert() {
+    local zip="$1"
+    if ! godot_fork_web_template_structural_fresh "$zip"; then
+        echo "error: $FORK_WEB_TEMPLATE_STRUCTURAL_WHY" >&2
+        case "$FORK_WEB_TEMPLATE_STRUCTURAL_WHY" in
+            *"C++ exception tag"*)
+                echo "       (rebuild with disable_exceptions=no cxxflags/linkflags=-fwasm-exceptions)" >&2
+                ;;
+        esac
+        exit 1
+    fi
     echo "ok: godot.side.wasm present (dlink), main module exports __cpp_exception"
+}
+
+# godot_fork_ios_ready ZIP — the complete readiness predicate shared by the iOS
+# gate and pre-merge: host tools, a readable template, current engine provenance,
+# an available iPhone simulator and the repaired arm64 debug simulator slice.
+# Nothing is built. Sets FORK_IOS_READY_WHY and FORK_IOS_READY_KIND
+# (`prerequisite` or `artifact`) instead of printing, so each caller can phrase
+# the same fact for its own verdict.
+godot_fork_ios_ready() {
+    local zip="$1" tool want stamped devices listing entries entry tmp archs
+    FORK_IOS_READY_WHY=""
+    FORK_IOS_READY_KIND=prerequisite
+    for tool in xcodebuild xcrun lipo unzip; do
+        if ! command -v "$tool" >/dev/null 2>&1; then
+            FORK_IOS_READY_WHY="$tool is required by the iOS editor-export gate"
+            return 1
+        fi
+    done
+    if [ ! -f "$zip" ]; then
+        FORK_IOS_READY_WHY="$zip is missing — run gates/setup-godot-fork-ios.sh"
+        return 1
+    fi
+    FORK_IOS_READY_KIND=artifact
+    if ! listing="$(unzip -l "$zip" 2>/dev/null)"; then
+        FORK_IOS_READY_WHY="$zip is not a readable template zip — re-run gates/setup-godot-fork-ios.sh"
+        return 1
+    fi
+    want="$(godot_fork_engine_provenance)"
+    stamped="$(head -1 "$zip.provenance" 2>/dev/null || true)"
+    if [ "$stamped" != "$want" ]; then
+        FORK_IOS_READY_WHY="$zip was built from ${stamped:-<no stamp>}, wanted $want — re-run FORCE=1 gates/setup-godot-fork-ios.sh"
+        return 1
+    fi
+    devices="$(xcrun simctl list devices available 2>/dev/null || true)"
+    if ! grep -q iPhone <<<"$devices"; then
+        FORK_IOS_READY_KIND=prerequisite
+        FORK_IOS_READY_WHY="no available iPhone simulator device"
+        return 1
+    fi
+    entries="$(printf '%s\n' "$listing" \
+        | grep -oE 'libgodot\.ios\.debug\.xcframework/ios-[a-z0-9_]*-simulator/libgodot\.a' || true)"
+    entry="${entries%%$'\n'*}"
+    if [ -z "$entry" ]; then
+        FORK_IOS_READY_WHY="$zip has no debug simulator slice — re-run gates/setup-godot-fork-ios.sh"
+        return 1
+    fi
+    tmp="$(mktemp -d)"
+    if ! unzip -q "$zip" "$entry" -d "$tmp" 2>/dev/null; then
+        FORK_IOS_READY_WHY="$zip's debug simulator slice is unreadable — re-run gates/setup-godot-fork-ios.sh"
+        rm -rf "$tmp"
+        return 1
+    fi
+    archs="$(lipo -info "$tmp/$entry" 2>/dev/null | LC_ALL=C sed 's/^.*: //')"
+    rm -rf "$tmp"
+    if ! grep -q arm64 <<<"$archs"; then
+        FORK_IOS_READY_WHY="$zip has no arm64 debug simulator slice — re-run gates/setup-godot-fork-ios.sh"
+        return 1
+    fi
+    return 0
 }
 
 # godot_fork_web_template_emcc_assert BUNDLE_EMCC OUT_DIR VERSION — refuse an
@@ -428,29 +661,154 @@ godot_fork_web_template_emcc_assert() {
     echo "web template:  emcc matches the bundled toolchain ($origin)"
 }
 
+# ── Is the fork cache current? ────────────────────────────────────────────────
+# The three products of gates/setup-godot-fork.sh that carry a stamp inside the
+# fork worktree, named here rather than only in that script because two readers
+# now exist: the script that WRITES the stamps and the predicate that decides
+# whether they still describe the tree. A second spelling of a stamp's path is a
+# predicate that silently answers about nothing.
+FORK_GLUE_MARKER=modules/mono/glue/GodotSharp/GodotSharp/Generated/GeneratedIncludes.props
+FORK_API_RELEASE_REL=bin/GodotSharp/Api/Release/GodotSharp.dll
+FORK_TOOLCHAIN_MARKER=bin/GodotSharp/Dn2Cpp/manifest.json
+
+# godot_fork_cache_complete — the artifact root holds the four things every
+# consumer needs at all: the editor, the pin, the GodotSharp tree beside it, and
+# a Godot.NET.Sdk nupkg in the feed. Says nothing about whether any of them is
+# CURRENT — that is godot_fork_cache_fresh. Split out because "absent" and
+# "wrong" are different answers with different remedies, and because the
+# preflight and gates/pre-merge.sh both have to put the first question.
+godot_fork_cache_complete() {
+    [ -x "$FORK_EDITOR" ] || return 1
+    [ -f "$FORK_ROOT/pin.txt" ] || return 1
+    [ -d "$FORK_GODOTSHARP" ] || return 1
+    compgen -G "$FORK_ROOT/nuget/Godot.NET.Sdk.*.nupkg" >/dev/null || return 1
+}
+
+# godot_fork_cache_fresh — 0 when the fork cache was built from the fork worktree
+# as it is NOW, 1 when gates/setup-godot-fork.sh has to run again. Reports
+# nothing and sets FORK_CACHE_WHY (one line naming which stamp disagrees) plus
+# the raw terms instead, for selfhost_bin_fresh's reason: the askers phrase the
+# same fact differently, and a rebuild one of them skips is a rebuild another
+# demands.
+#
+# WHY THIS PREDICATE HAS TO EXIST OUTSIDE THAT SCRIPT. Until it did, the only way
+# to ask was to run the script, and the failure shape of not asking is the worst
+# one available: godot_fork_ctx's `editor=` and `tools=` terms fingerprint the
+# STALE PRODUCTS THEMSELVES, so a GodotTools edit that never got compiled leaves
+# every key unmoved and the export gates replay a warm green over an editor that
+# does not contain it — the gates assert the old exporter's behavior against the
+# old exporter. Neither the pin nor the ABI tripwire can help: both fingerprint
+# the clone's SOURCES, which are correct.
+#
+# A MISSING stamp is unknown provenance, not a pass — selfhost_bin_fresh's rule,
+# and here it is also what catches an interrupted setup run: every stamp is
+# removed before its product is rebuilt and written after, so a half-written
+# product carries no stamp rather than an old one.
+#
+# The desktop export artifact IS checked here even though its consumer checks it
+# again. The two checks answer different questions: this predicate lets
+# pre-merge repair an interrupted assembly before the suites; the consumer's
+# live check keeps a stale artifact from passing on a warm gate cache.
+#
+# Sets FORK and BASE_COMMIT through godot_fork_resolve, so a caller that holds
+# them already gets the same values back.
+godot_fork_cache_fresh() {
+    FORK_CACHE_WHY=""
+    FORK_CACHE_HEAD=""
+    FORK_CACHE_ENGINE_NOW=""
+    FORK_CACHE_TOOLS_NOW=""
+
+    godot_fork_resolve || { FORK_CACHE_WHY="the fork worktree does not resolve"; return 1; }
+    BASE_COMMIT="$(cat "$FORK_PIN_EXPECTED")"
+    # One word, never '<no head>': the pre-merge probe prints this as a
+    # whitespace-separated field and a space here would shift every field after it.
+    FORK_CACHE_HEAD="$(git -C "$FORK" rev-parse --short HEAD 2>/dev/null || echo '<no-head>')"
+
+    local rootpin
+    rootpin="$(head -1 "$FORK_ROOT/pin.txt" 2>/dev/null || true)"
+    if [ "$rootpin" != "$BASE_COMMIT" ]; then
+        FORK_CACHE_WHY="$FORK_ROOT/pin.txt is ${rootpin:-<empty>}, the checked-in pin is $BASE_COMMIT"
+        return 1
+    fi
+
+    FORK_CACHE_ENGINE_NOW="$(godot_fork_engine_hash)"
+    FORK_CACHE_TOOLS_NOW="$(godot_fork_tools_hash)"
+
+    if ! godot_fork_managed_feed_fresh; then
+        FORK_CACHE_WHY="$FORK_MANAGED_FEED_WHY"
+        return 1
+    fi
+
+    # _fork_stamp_is FILE WANT WHAT — 0 when FILE's first line is WANT. Local to
+    # this predicate: every caller of it is right here, and the message it builds
+    # is FORK_CACHE_WHY's whole content.
+    _fork_stamp_is() {
+        local stamped
+        stamped="$(head -1 "$1" 2>/dev/null || true)"
+        [ -n "$stamped" ] || stamped='<no stamp>'
+        [ "$stamped" = "$2" ] && return 0
+        FORK_CACHE_WHY="the $3 was built from $stamped, the fork's sources are $2"
+        return 1
+    }
+
+    _fork_stamp_is "$FORK_EDITOR.engine-hash" "$FORK_CACHE_ENGINE_NOW" "editor binary" || return 1
+    _fork_stamp_is "$FORK_TEMPLATE.engine-hash" "$FORK_CACHE_ENGINE_NOW" "release template" || return 1
+    _fork_stamp_is "$FORK/$FORK_GLUE_MARKER.engine-hash" "$FORK_CACHE_ENGINE_NOW" "mono glue" || return 1
+    _fork_stamp_is "$(godot_fork_tools_stamp)" "$FORK_CACHE_TOOLS_NOW" "managed assemblies + feed" || return 1
+
+    local desktop want_provenance stamped_provenance
+    desktop="$(godot_fork_desktop_template "$FORK_ROOT")" || {
+        FORK_CACHE_WHY="the desktop export template path cannot be resolved for ${DN2CPP_OS:-unknown}"
+        return 1
+    }
+    want_provenance="engine=$FORK_CACHE_ENGINE_NOW base=$BASE_COMMIT"
+    if [ ! -f "$desktop" ]; then
+        FORK_CACHE_WHY="the desktop export template is missing at $desktop"
+        return 1
+    fi
+    stamped_provenance="$(head -1 "$desktop.provenance" 2>/dev/null || true)"
+    if [ "$stamped_provenance" != "$want_provenance" ]; then
+        FORK_CACHE_WHY="the desktop export template was built from ${stamped_provenance:-<no stamp>}, the fork's sources are $want_provenance"
+        return 1
+    fi
+
+    # The products the tools stamp vouches for, asserted separately: the stamp is
+    # written last, but a root reassembled by hand can hold the stamp without the
+    # tree it describes.
+    if [ ! -f "$FORK/$FORK_API_RELEASE_REL" ]; then
+        FORK_CACHE_WHY="the managed assemblies are stamped current but $FORK_API_RELEASE_REL is missing"
+        return 1
+    fi
+    if [ ! -f "$FORK/$FORK_TOOLCHAIN_MARKER" ]; then
+        FORK_CACHE_WHY="the managed assemblies are stamped current but the dn2cpp bundle marker $FORK_TOOLCHAIN_MARKER is missing"
+        return 1
+    fi
+    return 0
+}
+
 # godot_fork_preflight — the skip-or-proceed test every editor-export gate runs
 # first: the fork cache must be complete (editor, pin, GodotSharp, Sdk feed) and
 # the self-hosted native CLI must exist AND be built from the sources now in the
 # tree. Per-gate prerequisites (a platform template, Xcode, an NDK) stay in the
 # gate, each with its own gate_skip.
 #
-# The staleness test is a hard FAIL, and it lives HERE rather than in either
-# other candidate home. dist/package-toolchain.sh honours an explicit
-# --dn2cpp-bin as given, unchecked, by stated contract, and every gate reaches it
-# through stage_editor_toolchain naming $SELFHOST_BIN explicitly — so its own
-# stamp check protects hand-run packaging and never a gate. stage_editor_toolchain
-# runs AFTER gate_cache_check in every consumer, where godot_fork_ctx's keys
-# fingerprint the stale binary itself and a rerun reports "cached green" BECAUSE
-# nothing changed. The preflight is upstream of the cache check in all six
-# consumers, which is what lets a stale binary fail even on a warm cache, and is
-# what the CACHE-KEY CONSTRAINT in this file's header demands of any assert here.
+# There are TWO staleness tests here — the self-hosted CLI against src/, the fork
+# cache against the fork worktree — and both are a hard FAIL, and both live HERE
+# rather than in either other candidate home. dist/package-toolchain.sh honours an
+# explicit --dn2cpp-bin as given, unchecked, by stated contract, and every gate
+# reaches it through stage_editor_toolchain naming $SELFHOST_BIN explicitly — so
+# its own stamp check protects hand-run packaging and never a gate.
+# stage_editor_toolchain runs AFTER gate_cache_check in every consumer, where
+# godot_fork_ctx's keys fingerprint the stale artifact itself and a rerun reports
+# "cached green" BECAUSE nothing changed. The preflight is upstream of the cache
+# check in all six consumers, which is what lets a stale input fail even on a warm
+# cache, and is what the CACHE-KEY CONSTRAINT in this file's header demands of any
+# assert here.
 #
 # FAIL rather than gate_skip: a skip is for what the box cannot carry, which is
-# certainly the wrong reading for a binary the tree builds itself.
+# certainly the wrong reading for inputs the tree and the fork build themselves.
 godot_fork_preflight() {
-    if [ ! -x "$FORK_EDITOR" ] || [ ! -f "$FORK_ROOT/pin.txt" ] \
-        || [ ! -d "$FORK_GODOTSHARP" ] \
-        || ! compgen -G "$FORK_ROOT/nuget/Godot.NET.Sdk.*.nupkg" >/dev/null; then
+    if ! godot_fork_cache_complete; then
         # Name the remedy only on the host where the remedy exists. This list
         # must track gates/setup-godot-fork.sh's per-OS arms exactly: anywhere
         # else "run gates/setup-godot-fork.sh" is an instruction that cannot
@@ -479,6 +837,17 @@ godot_fork_preflight() {
         echo "FAIL: $SELFHOST_BIN predates the current sources" >&2
         echo "      stamped $SELFHOST_SRC_STAMPED != $SELFHOST_SRC_NOW (src_tree_hash of src/ runtime/ third_party/)" >&2
         echo "      Rebuild the self-hosted CLI: gates/selfhost-emit.sh" >&2
+        exit 1
+    fi
+    # The same judgement about the OTHER input, and a FAIL for the same reason:
+    # the cache is complete, so this box carries the input — it carries a WRONG
+    # one. godot_fork_cache_fresh states above what makes a stale cache worse
+    # than an absent one, and why nothing downstream of gate_cache_check can see
+    # it at all.
+    if ! godot_fork_cache_fresh; then
+        echo "FAIL: the fork cache at $FORK_ROOT no longer describes the fork" >&2
+        echo "      $FORK_CACHE_WHY" >&2
+        echo "      Rebuild it: gates/setup-godot-fork.sh" >&2
         exit 1
     fi
 }

--- a/gates/build-and-run-godot-editor-export-ios.sh
+++ b/gates/build-and-run-godot-editor-export-ios.sh
@@ -52,54 +52,21 @@ BUNDLE_ID=org.dn2cpp.editorexportsample
 IOS_TEMPLATE="$FORK_ROOT/ios_template.zip"
 
 godot_fork_preflight
-if ! command -v xcodebuild >/dev/null 2>&1; then
-    gate_skip "xcodebuild not found — Xcode required for the iOS editor-export gate"
+if ! godot_fork_ios_ready "$IOS_TEMPLATE"; then
+    if [ "$FORK_IOS_READY_KIND" = prerequisite ]; then
+        gate_skip "$FORK_IOS_READY_WHY"
+    fi
+    echo "FAIL: $FORK_IOS_READY_WHY" >&2
+    exit 1
 fi
-if [ ! -f "$IOS_TEMPLATE" ]; then
-    gate_skip "no $IOS_TEMPLATE — run gates/setup-godot-fork-ios.sh"
-fi
-# Snapshot once, never `simctl … | grep -q` — under pipefail that reports 141 when
-# grep -q exits early, so a machine WITH simulators skips blaming Xcode. Full
-# reasoning at the same probe in gates/build-and-run-ios-sim-console.sh.
-_sim_devices="$(xcrun simctl list devices available 2>/dev/null || true)"
-if ! grep -q iPhone <<<"$_sim_devices"; then
-    gate_skip "no available iPhone simulator device"
-fi
-# Cheap tripwire on the template itself: a stock (unrepaired) ios.zip dropped
-# at the path would fail only minutes later, inside xcodebuild. Only the archs
-# after lipo's colon count — the slice's own path contains "arm64"
-# (ios-arm64_x86_64-simulator), which must not satisfy the check.
-_tmp="$(mktemp -d)"
-# `|| true`: a template with no simulator slice at all makes grep exit 1, which
-# under `set -e`/`pipefail` would abort the gate instead of reaching the skip
-# below — the skip path has to survive the very condition it exists to report.
-# The first match is taken off a captured string rather than with `| head -1`:
-# head quits after its line and the grep behind it dies of SIGPIPE, which
-# `pipefail` reports as the pipeline's status (see _common.sh's note beside
-# `set -o pipefail`).
-_sim_entries="$(unzip -l "$IOS_TEMPLATE" 2>/dev/null | grep -oE 'libgodot\.ios\.debug\.xcframework/ios-[a-z0-9_]*-simulator/libgodot\.a' || true)"
-_sim_entry="${_sim_entries%%$'\n'*}"
-if [ -n "$_sim_entry" ] && unzip -q "$IOS_TEMPLATE" "$_sim_entry" -d "$_tmp" 2>/dev/null \
-    && grep -q arm64 <<<"$(lipo -info "$_tmp/$_sim_entry" 2>/dev/null | LC_ALL=C sed 's/^.*: //')"; then
-    rm -rf "$_tmp"
-else
-    rm -rf "$_tmp"
-    gate_skip "$IOS_TEMPLATE has no arm64 debug simulator slice — re-run gates/setup-godot-fork-ios.sh"
-fi
+echo "iOS template: readable, current, arm64 simulator slice present"
 
 echo "== 1/9 Fork pin + interop-ABI tripwire =="
 godot_fork_pin_abi_check
 
-# The template is the second engine in this gate, and the arm64 probe above does
-# not see its VERSION: the preset points custom_template at it and Godot
-# validates that path with FileAccess::exists alone, so a zip spliced before a
-# re-pin exports, runs on the simulator and matches every expectation here while
-# shipping the older engine, which a re-pin has already produced once.
-# Live, before gate_cache_check, for the reason the preflight is:
-# `tmpl=` in the key fingerprints the stale zip itself, so a warm key replays a
-# green *because* nothing changed.
-godot_fork_template_check "$IOS_TEMPLATE" "iOS export template" \
-    "FORCE=1 gates/setup-godot-fork-ios.sh"
+# godot_fork_ios_ready above checked this second engine's provenance live, before
+# gate_cache_check, as well as the repaired simulator slice. The shared predicate
+# is also pre-merge's early refusal, so the two cannot disagree about readiness.
 
 # No local transpile happens here — the forked editor drives the whole pipeline
 # from the packaged toolchain — so the key is inputs-only: the self-hosted CLI,

--- a/gates/pre-merge.sh
+++ b/gates/pre-merge.sh
@@ -61,10 +61,17 @@
 #     only when a stamp disagrees, so a box whose cache is current pays a couple
 #     of tree hashes.
 #     The Web templates ride along because DN2CPP_REQUIRE_ALL=1 makes their
-#     absence a failure rather than a skip. The iOS template stays manual because
-#     its repair consumes Xcode and an official templates archive; its presence,
-#     provenance and host prerequisites are checked up front, so REQUIRE_ALL does
-#     not discover the manual work inside the suite.
+#     absence a failure rather than a skip, and the Emscripten SDK they need is
+#     unpacked here (gates/setup-emsdk.sh) when no mutable one resolves. The iOS
+#     template stays manual because its repair consumes Xcode and an official
+#     templates archive; its presence, provenance and host prerequisites are
+#     checked up front, so REQUIRE_ALL does not discover the manual work inside
+#     the suite. A HOST prerequisite this box lacks (no Xcode, no emcc even after
+#     the unpack) is not a refusal: the suites still run, the affected gates are
+#     red under REQUIRE_ALL, and the verdict lists the gaps. A suite red ONLY
+#     for such gates does not withhold the other configuration either; a suite
+#     with any other failure does. Only a repairable ARTIFACT — a stale or
+#     missing zip on a host that could build it — refuses.
 #
 # WHY THIS IS NOT A GATE. It runs the suite — twice. It lives beside
 # gates/verify-locks.sh and gates/measure-*.sh, outside the build-and-run-*.sh
@@ -83,11 +90,14 @@
 # lock machinery the suite itself runs under every time, and the console selfhost
 # harness emits what the suite's own gates transpile through, whereas nothing in
 # either suite can observe that a bucket's green was a fact about ja-JP.
-# gates/selfhost-emit.sh and the two gates/setup-godot-fork*.sh aids are in on a
-# different test again, and they are the only things that may be: they answer no
-# verdict at all — they produce the files the suites refuse to run without. That
-# is the whole entry condition, and "it is useful" is not it: dist/smoke-test.sh
-# is useful and stays out, because the suite already covers what it looks at.
+# gates/selfhost-emit.sh, the two gates/setup-godot-fork*.sh aids and
+# gates/setup-emsdk.sh are in on a different test again, and they are the only
+# things that may be: they answer no verdict at all — they produce the files the
+# suites refuse to run without. setup-emsdk.sh qualifies through the Web
+# templates: without the SDK they cannot be baked, and the suites refuse to run
+# without them. That is the whole entry condition, and "it is useful" is not it:
+# dist/smoke-test.sh is useful and stays out, because the suite already covers
+# what it looks at.
 #
 # WHY IT RE-DERIVES THE VERDICT INSTEAD OF TRUSTING THE EXIT CODE. The runner's
 # exit code and this script's verdict are not the same question, and the gap is
@@ -248,18 +258,21 @@ if [ "${DN2CPP_PREMERGE_PROBE:-0}" = "forkweb" ]; then
     printf 'ok%s\n' "$probe_stale"
     exit 0
 fi
-# `=forkios` is a refusal probe, not a builder. The iOS template needs Xcode and
+# `=forkios` is a readiness probe, not a builder. The iOS template needs Xcode and
 # an official templates archive, so pre-merge never creates it; it does ensure a
 # REQUIRE_ALL run does not discover its absence or stale provenance hours later.
+# A `bad` answer carries the KIND godot_fork_ios_ready distinguishes — `artifact`
+# (repairable here) or `prerequisite` (this host cannot) — because the reader
+# refuses on one and continues red on the other.
 if [ "${DN2CPP_PREMERGE_PROBE:-0}" = "forkios" ]; then
     source "$REPO/gates/_common.sh"
     source "$REPO/gates/_godot_fork.sh"
     godot_fork_resolve >/dev/null 2>&1 \
-        || { printf 'bad the fork worktree does not resolve\n'; exit 0; }
+        || { printf 'bad artifact the fork worktree does not resolve\n'; exit 0; }
     BASE_COMMIT="$(cat "$FORK_PIN_EXPECTED")"
     probe_ios="$FORK_ROOT/ios_template.zip"
     if ! godot_fork_ios_ready "$probe_ios"; then
-        printf 'bad %s\n' "$FORK_IOS_READY_WHY"
+        printf 'bad %s %s\n' "${FORK_IOS_READY_KIND:-artifact}" "$FORK_IOS_READY_WHY"
         exit 0
     fi
     printf 'ok current\n'
@@ -659,13 +672,27 @@ premerge_fork_web_state() {
 }
 
 # premerge_fork_ios_state — 0 when the manually-built iOS template and its host
-# prerequisites are ready, 1 with FORK_IOS_WHY otherwise.
+# prerequisites are ready, 1 with FORK_IOS_KIND (prerequisite|artifact) and
+# FORK_IOS_WHY otherwise. A probe that did not answer is read as `artifact`, the
+# refusing side: continuing on a guess is the failure this phase exists to avoid.
 premerge_fork_ios_state() {
-    local out="" tag="" why=""
+    local out="" tag="" kind="" why=""
     out=$(DN2CPP_PREMERGE_PROBE=forkios bash "$REPO/gates/pre-merge.sh" 2>/dev/null) || out=""
-    read -r tag why <<<"$out" || :
+    read -r tag kind why <<<"$out" || :
+    FORK_IOS_KIND=${kind:-artifact}
     FORK_IOS_WHY=${why:-the iOS prerequisite probe returned nothing}
     [ "${tag:-}" = ok ]
+}
+
+# premerge_emsdk_argv — the pinned Emscripten SDK unpack, same shape and same
+# reason as premerge_fork_argv. It is idempotent and exits early once unpacked,
+# so running it is the cheap half of "does a mutable emcc resolve".
+premerge_emsdk_argv() {
+    PREMERGE_EMSDK_ARGV=()
+    if [ "${DN2CPP_PREMERGE_NO_CAFFEINATE:-0}" != "1" ] && command -v caffeinate >/dev/null 2>&1; then
+        PREMERGE_EMSDK_ARGV+=(caffeinate -i)
+    fi
+    PREMERGE_EMSDK_ARGV+=(bash "$REPO/gates/setup-emsdk.sh")
 }
 
 # ── the verdict, re-derived from the run's own artifacts ─────────────────────
@@ -673,13 +700,23 @@ premerge_fork_ios_state() {
 # premerge_verdict LABEL RC LOGDIR EXPECTED_GATES — 0 when the run is a genuine
 # green, 1 otherwise. Collects every problem rather than stopping at the first:
 # a run this long should hand back everything it knows in one pass.
+#
+# A red run is also classified. VERDICT_PREREQ_ONLY=1 when every problem is a
+# gate that called gate_skip under DN2CPP_REQUIRE_ALL=1 — its log carries
+# gate_skip's fixed FAIL marker — with the failed gates in VERDICT_PREREQ_GATES.
+# Such a run is still red (the merge needs a host that runs them), but it is not
+# the caller's reason to withhold the other configuration: those gates cannot go
+# green on this host whatever the tree says. A gate that failed for any other
+# reason, a skip, a cached record or a missing record makes the run plainly red.
 premerge_verdict() {
     local label="$1" rc="$2" logdir="$3" expected="$4"
     local timings="$logdir/_timings.txt"
     local skips="$logdir/_skips.txt"
     local fails="$logdir/_failures.txt"
-    local bad_count=0
+    local bad_count=0 plain_red=0 n_fail=0 n_prereq=0
     local n_lines n_ran n_other
+    VERDICT_PREREQ_ONLY=0
+    VERDICT_PREREQ_GATES=""
 
     if [ "$rc" -ne 0 ]; then
         bad "$label: the runner exited $rc."
@@ -693,8 +730,22 @@ premerge_verdict() {
     fi
 
     if [ -s "$fails" ]; then
-        bad "$label: $(wc -l < "$fails" | tr -d ' ') gate(s) FAILED:"
-        while IFS= read -r n; do note "failed: $n"; done < "$fails"
+        n_fail=$(wc -l < "$fails" | tr -d ' ')
+        bad "$label: $n_fail gate(s) FAILED:"
+        # run_gate names the gate's log after the gate: $LOGDIR/<gate>.log. A
+        # failure recorded without such a log (the runner's audit of gates that
+        # left no record) has no marker and is plainly red.
+        while IFS= read -r n; do
+            if grep -q '^FAIL: prerequisite absent, and DN2CPP_REQUIRE_ALL=1 demands every gate run:' \
+                "$logdir/$n.log" 2>/dev/null; then
+                note "failed: $n (prerequisite absent)"
+                n_prereq=$((n_prereq + 1))
+                VERDICT_PREREQ_GATES="${VERDICT_PREREQ_GATES:+$VERDICT_PREREQ_GATES, }$n"
+            else
+                note "failed: $n"
+                plain_red=1
+            fi
+        done < "$fails"
         bad_count=$((bad_count + 1))
     fi
 
@@ -726,6 +777,15 @@ premerge_verdict() {
     fi
 
     if [ "$bad_count" -ne 0 ]; then
+        # Prerequisite-only means: the failed gates all hit gate_skip, no skip
+        # or missing record, and the only non-'ran' records are those failures
+        # (a cached record would make n_other exceed them). The runner's own
+        # non-zero exit is the expected face of a failed gate, not extra news.
+        if [ "$n_fail" -gt 0 ] && [ "$plain_red" -eq 0 ] && [ "$n_prereq" -eq "$n_fail" ] \
+            && [ ! -s "$skips" ] && [ "$n_lines" -eq "$expected" ] && [ "$n_other" -eq "$n_fail" ]; then
+            VERDICT_PREREQ_ONLY=1
+            note "$label: prerequisite-only failures: $n_fail — every failed gate called gate_skip under REQUIRE_ALL."
+        fi
         return 1
     fi
     good "$label: $n_lines/$expected gates ran and passed, 0 skipped, 0 cached."
@@ -852,11 +912,28 @@ if [ "${DN2CPP_PREMERGE_SELFTEST:-0}" = "1" ]; then
     cat > "$FAKE/gates/run-all-gates.sh" <<'STUB'
 #!/usr/bin/env bash
 # Stub runner: records the config it was called with, writes the artifacts a
-# green suite writes, and exits the status this case asked for.
+# green suite writes, and exits the status this case asked for. With
+# DN2CPP_STUB_FAIL_<CONFIG>=prereq|mixed it fails gate02 the way run_gate records
+# a gate_skip under REQUIRE_ALL (the marker in $LOGDIR/gate02.log), and `mixed`
+# fails gate01 plainly beside it.
 mkdir -p "$LOGDIR"
 : > "$LOGDIR/_skips.txt"
 : > "$LOGDIR/_failures.txt"
-printf 'gate01 1 ran\ngate02 1 ran\n' > "$LOGDIR/_timings.txt"
+eval "fail_mode=\${DN2CPP_STUB_FAIL_$CONFIG:-}"
+case "$fail_mode" in
+    prereq|mixed)
+        printf 'FAIL: prerequisite absent, and DN2CPP_REQUIRE_ALL=1 demands every gate run: stub tool missing\n' > "$LOGDIR/gate02.log"
+        if [ "$fail_mode" = mixed ]; then
+            printf 'stub assertion failed\n' > "$LOGDIR/gate01.log"
+            printf 'gate01 1 failed\ngate02 1 failed\n' > "$LOGDIR/_timings.txt"
+            printf 'gate01\ngate02\n' > "$LOGDIR/_failures.txt"
+        else
+            printf 'gate01 1 ran\ngate02 1 failed\n' > "$LOGDIR/_timings.txt"
+            printf 'gate02\n' > "$LOGDIR/_failures.txt"
+        fi
+        ;;
+    *) printf 'gate01 1 ran\ngate02 1 ran\n' > "$LOGDIR/_timings.txt" ;;
+esac
 printf '%s\n' "$CONFIG" >> "$(dirname "$LOGDIR")/_stub_calls.txt"
 eval "exit \${DN2CPP_STUB_RC_$CONFIG:-0}"
 STUB
@@ -904,6 +981,18 @@ printf '%s\n' "$flavor" >> "${DN2CPP_STUB_FORKWEB_MARK:-/dev/null}"
 exit "${DN2CPP_STUB_FORKWEB_RC:-0}"
 WSTUB
     chmod +x "$FAKE/gates/setup-godot-fork-web.sh"
+    # Stub SDK unpack: records the call, and on success creates the READY file the
+    # stub resolver below reads — so a case can prove the phase re-probed after
+    # provisioning instead of trusting the unpack's exit 0.
+    cat > "$FAKE/gates/setup-emsdk.sh" <<'ESTUB'
+#!/usr/bin/env bash
+echo "stub emsdk unpack"
+printf 'called\n' >> "${DN2CPP_STUB_EMSDK_MARK:-/dev/null}"
+rc="${DN2CPP_STUB_EMSDK_RC:-0}"
+[ "$rc" != 0 ] || [ -z "${DN2CPP_STUB_EMSDK_READY:-}" ] || : > "$DN2CPP_STUB_EMSDK_READY"
+exit "$rc"
+ESTUB
+    chmod +x "$FAKE/gates/setup-emsdk.sh"
     # Stub HELPERS, not just stub scripts, and this pair is what lets the two fork
     # probes ANSWER inside the fake repo. The probes are the subject here — their
     # exit-code-to-state mapping is the thing under test — so the predicates
@@ -922,7 +1011,10 @@ cd -P "$(dirname "${BASH_SOURCE[1]}")/.."
 DN2CPP_OS="${DN2CPP_STUB_OS:-linux}"
 EXE_EXT=
 first_line() { local x="$1"; printf '%s\n' "${x%%$'\n'*}"; }
-dn2cpp_emsdk_resolve() { return "${DN2CPP_STUB_EMSDK_RESOLVE:-0}"; }
+dn2cpp_emsdk_resolve() {
+    [ -n "${DN2CPP_STUB_EMSDK_READY:-}" ] && [ -f "$DN2CPP_STUB_EMSDK_READY" ] && return 0
+    return "${DN2CPP_STUB_EMSDK_RESOLVE:-0}"
+}
 emcc() { printf '%s\n' "${DN2CPP_STUB_EMCC_VERSION:-stub-emcc}"; }
 xcodebuild() { :; }
 lipo() { :; }
@@ -962,8 +1054,12 @@ godot_fork_web_template_fresh() {
 }
 godot_fork_ios_ready() {
     local zip="$1"
-    FORK_IOS_READY_KIND=artifact
+    FORK_IOS_READY_KIND="${DN2CPP_STUB_IOS_KIND:-artifact}"
     FORK_IOS_READY_WHY="the stub iOS template is not ready"
+    if [ "$FORK_IOS_READY_KIND" = prerequisite ]; then
+        FORK_IOS_READY_WHY="the stub host has no xcodebuild"
+        return 1
+    fi
     [ -f "$zip" ] \
         && [ "$(head -1 "$zip.provenance" 2>/dev/null || true)" = 'engine=stubengine base=stubbase' ]
 }
@@ -1000,6 +1096,8 @@ GFSTUB
         DN2CPP_GODOT_FORK_ROOT="${DN2CPP_STUB_FORKROOT:-$ST_FORKROOT}" \
         DN2CPP_STUB_FORK_MARK="$root/_fork_calls.txt" \
         DN2CPP_STUB_FORKWEB_MARK="$root/_forkweb_calls.txt" \
+        DN2CPP_STUB_EMSDK_MARK="$root/_emsdk_calls.txt" \
+        DN2CPP_STUB_EMSDK_READY="$root/_emsdk_ready" \
         DN2CPP_STUB_RC_Release="$rel_rc" \
         DN2CPP_STUB_RC_Debug="$dbg_rc" \
             bash "$FAKE/gates/pre-merge.sh" $extra >"$root/_out.txt" 2>&1 || rc=$?
@@ -1027,6 +1125,19 @@ GFSTUB
     e2e red-release  1 1 0 "Release,"
     e2e red-debug    1 0 1 "Release,Debug,"
     e2e keep-going   1 1 1 "Release,Debug," --keep-going
+
+    # A Release whose only failures are gate_skips under REQUIRE_ALL is red but
+    # does not withhold Debug: those gates cannot pass on this host, and the
+    # verdict lists them as a host gap. One plainly failed gate beside them
+    # withholds Debug as before.
+    DN2CPP_STUB_FAIL_Release=prereq e2e red-release-prereq-only 1 1 0 "Release,Debug,"
+    if grep -q 'host prerequisites absent here: Release: gate02 (prerequisite absent)' \
+        "$ST_TMP/e2e-red-release-prereq-only/_out.txt"; then
+        st_ok "red-release-prereq-only: the verdict lists the gate as a host gap"
+    else
+        st_bad "red-release-prereq-only: the verdict does not list gate02 as a host gap — see $ST_TMP/e2e-red-release-prereq-only/_out.txt"
+    fi
+    DN2CPP_STUB_FAIL_Release=mixed e2e red-release-mixed 1 1 0 "Release,"
 
     # Phase 0's three outcomes. The one that matters is the middle case: a red
     # culture harness must stop the suites BEFORE they run (empty call list), or
@@ -1154,20 +1265,61 @@ GFSTUB
         st_bad "fork-no-arm: refused without saying why — see $ST_TMP/e2e-fork-no-arm/_out.txt"
     fi
 
-    # The Web templates, on a box with no Emscripten SDK. The refusal is the
-    # branch that matters: DN2CPP_REQUIRE_ALL=1 makes an absent template a
-    # failure, this script does not provision SDKs, and a run that started the
-    # suites anyway would spend hours to reach the same answer.
+    # The iOS template's two not-ready shapes. A missing HOST prerequisite (no
+    # Xcode) continues: the suites run, forkios is red in the results, and the
+    # verdict names the gap — with no receipt, because red is red. A repairable
+    # ARTIFACT (the zip is absent on a host that could build it) keeps the exit 2
+    # refusal before the first suite.
+    DN2CPP_STUB_IOS_KIND=prerequisite e2e forkios-no-xcode 1 0 0 "Release,Debug,"
+    if grep -q 'forkios=RED' "$ST_TMP/e2e-forkios-no-xcode/_out.txt" \
+        && grep -q 'host prerequisites absent here' "$ST_TMP/e2e-forkios-no-xcode/_out.txt"; then
+        st_ok "forkios-no-xcode: suites ran, verdict names forkios=RED and the host gap"
+    else
+        st_bad "forkios-no-xcode: verdict lacks forkios=RED or the host gap — see $ST_TMP/e2e-forkios-no-xcode/_out.txt"
+    fi
+    ST_IOSLESS="$ST_TMP/forkroot-iosless"
+    mkdir -p "$ST_IOSLESS"
+    for f in web_template.zip web_template.zip.provenance web_template_cri.zip \
+            web_template_cri.zip.provenance web_emcc.txt web_emcc_cri.txt; do
+        cp "$ST_FORKROOT/$f" "$ST_IOSLESS/$f"
+    done
+    DN2CPP_STUB_FORKROOT="$ST_IOSLESS" e2e forkios-stale-artifact 2 0 0 ""
+    if grep -q 'setup-godot-fork-ios.sh' "$ST_TMP/e2e-forkios-stale-artifact/_out.txt"; then
+        st_ok "forkios-stale-artifact: refused naming the iOS aid, before the first suite"
+    else
+        st_bad "forkios-stale-artifact: refused without naming gates/setup-godot-fork-ios.sh"
+    fi
+
+    # The Web templates, on a box with no mutable Emscripten SDK. The SDK is
+    # provisioned, not refused: the phase runs gates/setup-emsdk.sh once, re-probes,
+    # and bakes. When the unpack fails the suites still run and forkweb is a red
+    # host gap at the verdict, not a withheld run.
     ST_WEBLESS="$ST_TMP/forkroot-webless"
     mkdir -p "$ST_WEBLESS"
     cp "$ST_FORKROOT/ios_template.zip" "$ST_WEBLESS/ios_template.zip"
     cp "$ST_FORKROOT/ios_template.zip.provenance" "$ST_WEBLESS/ios_template.zip.provenance"
     DN2CPP_STUB_EMSDK_RESOLVE=1 DN2CPP_STUB_FORKROOT="$ST_WEBLESS" \
-        e2e forkweb-no-emcc 1 0 0 ""
-    if grep -q 'setup-emsdk.sh' "$ST_TMP/e2e-forkweb-no-emcc/_out.txt"; then
-        st_ok "forkweb-no-emcc: refused naming the SDK aid, before the first suite"
+        e2e forkweb-provision 0 0 0 "Release,Debug,"
+    ST_EMSDK_CALLS="$(cat "$ST_TMP/e2e-forkweb-provision/_emsdk_calls.txt" 2>/dev/null | tr '\n' ',')"
+    ST_BAKED="$(cat "$ST_TMP/e2e-forkweb-provision/_forkweb_calls.txt" 2>/dev/null | tr '\n' ',')"
+    if [ "$ST_EMSDK_CALLS" = "called," ] && [ "$ST_BAKED" = "stock,cri," ]; then
+        st_ok "forkweb-provision: the SDK was unpacked once, then both flavors baked"
     else
-        st_bad "forkweb-no-emcc: refused without naming gates/setup-emsdk.sh"
+        st_bad "forkweb-provision: emsdk calls [$ST_EMSDK_CALLS] (want [called,]), bakes [$ST_BAKED] (want [stock,cri,])"
+    fi
+    if grep -q '^forkweb: rebaked' "$ST_TMP/e2e-forkweb-provision/_receipt.txt" 2>/dev/null; then
+        st_ok "forkweb-provision: the receipt records the rebake"
+    else
+        st_bad "forkweb-provision: the receipt does not record the rebake"
+    fi
+    DN2CPP_STUB_EMSDK_RESOLVE=1 DN2CPP_STUB_EMSDK_RC=1 DN2CPP_STUB_FORKROOT="$ST_WEBLESS" \
+        e2e forkweb-provision-red 1 0 0 "Release,Debug,"
+    if grep -q 'forkweb=RED' "$ST_TMP/e2e-forkweb-provision-red/_out.txt" \
+        && grep -q 'host prerequisites absent here' "$ST_TMP/e2e-forkweb-provision-red/_out.txt" \
+        && grep -q '_emsdk.log' "$ST_TMP/e2e-forkweb-provision-red/_out.txt"; then
+        st_ok "forkweb-provision-red: suites ran, verdict names forkweb=RED, the host gap and _emsdk.log"
+    else
+        st_bad "forkweb-provision-red: verdict lacks forkweb=RED, the host gap or _emsdk.log — see $ST_TMP/e2e-forkweb-provision-red/_out.txt"
     fi
 
     # The bake arm itself, reachable on any host: EMSDK set is what the phase
@@ -1981,6 +2133,8 @@ if [ "$DRY_RUN" = "1" ]; then
         printf '\n  godot fork iOS template (manual prerequisite):\n'
         if premerge_fork_ios_state; then
             printf '    current and host prerequisites are available\n'
+        elif [ "$FORK_IOS_KIND" = prerequisite ]; then
+            printf '    %s — a host prerequisite; this run would continue, and the iOS gates go red at the verdict\n' "$FORK_IOS_WHY"
         else
             printf '    %s — this pre-merge run would refuse before its suites\n' "$FORK_IOS_WHY"
         fi
@@ -1989,6 +2143,12 @@ if [ "$DRY_RUN" = "1" ]; then
         if [ -z "$FORK_WEB_STALE" ]; then
             printf '    both flavors are baked from these engine sources — NOT rebaked\n'
         else
+            if [ "$FORK_WEB_SDK" != 1 ]; then
+                premerge_emsdk_argv
+                printf '    no mutable emcc resolves; this would run first, then bake:\n      '
+                printf '%s ' "${PREMERGE_EMSDK_ARGV[@]}"
+                printf '\n'
+            fi
             for flavor in $FORK_WEB_STALE; do
                 premerge_fork_web_argv "$flavor"
                 printf '    %s is absent or stale; this would run:\n      ' "$flavor"
@@ -2019,7 +2179,15 @@ if [ "$DRY_RUN" = "1" ]; then
 fi
 
 mkdir -p "$LOGROOT"
+# OVERALL is the verdict; INPUTS_RED is the narrower "may the suites start". They
+# part where a HOST prerequisite is missing: that makes the verdict red but is no
+# reason to withhold every gate this host can run. Only a broken suite INPUT —
+# culture, self-host binary, fork cache, a bake that failed — withholds them.
+# HOST_GAPS lists the missing prerequisites for the verdict.
 OVERALL=0
+INPUTS_RED=0
+SUITE_RED=0
+HOST_GAPS=""
 RESULTS=""
 T0=$(date +%s)
 
@@ -2056,6 +2224,7 @@ case "$CULTURE_RC" in
         note "is the driver pin the harness names; do not merge without it."
         RESULTS="${RESULTS}culture=RED "
         OVERALL=1
+        INPUTS_RED=1
         ;;
 esac
 
@@ -2089,6 +2258,7 @@ else
         bad "self-host: FAILED (exit $SELFHOST_RC) — see $LOGROOT/_selfhost.log"
         RESULTS="${RESULTS}selfhost=RED "
         OVERALL=1
+        INPUTS_RED=1
     fi
 fi
 
@@ -2156,24 +2326,40 @@ if [ "$FORK_RUN" = "1" ]; then
             note "$FORK_WHY"
             RESULTS="${RESULTS}fork=RED "
             OVERALL=1
+            INPUTS_RED=1
         fi
     else
         FORK_NOTE="FAILED (exit $FORK_RC)"
         bad "fork: FAILED (exit $FORK_RC) — see $LOGROOT/_fork.log"
         RESULTS="${RESULTS}fork=RED "
         OVERALL=1
+        INPUTS_RED=1
     fi
 fi
 
 # The iOS artifact stays manual: unlike desktop and Web, producing it needs an
-# official templates archive and an Xcode simulator toolchain. Refuse before the
-# suites rather than converting the iOS gate's late REQUIRE_ALL skip into an
-# hour-delayed surprise.
-if [ "$OVERALL" -eq 0 ] && ! premerge_fork_ios_state; then
-    bad "fork iOS template: $FORK_IOS_WHY"
-    note "Prepare it manually, then rerun pre-merge:"
-    note "  FORCE=1 ./gates/setup-godot-fork-ios.sh"
-    exit 2
+# official templates archive and an Xcode simulator toolchain. The two ways it
+# can be not ready are treated differently. A repairable ARTIFACT (stale or
+# missing zip on a host with Xcode) refuses before the suites, rather than
+# converting the iOS gate's late REQUIRE_ALL skip into an hour-delayed surprise
+# over minutes of manual work. A missing HOST prerequisite cannot be repaired
+# here, so refusing would withhold every other gate for nothing: the run
+# continues, the iOS gates go red under REQUIRE_ALL, and the verdict names the
+# gap. Red, never skipped — the merge still needs a host that can run them.
+if [ "$INPUTS_RED" -eq 0 ] && ! premerge_fork_ios_state; then
+    if [ "$FORK_IOS_KIND" = prerequisite ]; then
+        bad "fork iOS template: $FORK_IOS_WHY"
+        note "A host prerequisite, not a repairable artifact: the suites still run,"
+        note "and the iOS gates are reported red at the verdict."
+        RESULTS="${RESULTS}forkios=RED "
+        HOST_GAPS="${HOST_GAPS}iOS template ($FORK_IOS_WHY); "
+        OVERALL=1
+    else
+        bad "fork iOS template: $FORK_IOS_WHY"
+        note "Prepare it manually, then rerun pre-merge:"
+        note "  FORCE=1 ./gates/setup-godot-fork-ios.sh"
+        exit 2
+    fi
 fi
 
 # The Web export templates, on the same argument and with one difference: absent
@@ -2183,45 +2369,61 @@ fi
 # Only reached when the desktop cache is good, since the bake reads the fork
 # editor's version and the engine sources the provenance is taken over — baking
 # over a broken cache would stamp the zips against a tree the next step moves.
+# A missing iOS prerequisite is not such a reason: the Web bake does not read it.
 FORK_WEB_NOTE="not asked"
-if [ "$OVERALL" -eq 0 ]; then
+if [ "$INPUTS_RED" -eq 0 ]; then
     premerge_fork_web_state
+    FORK_WEB_BAKE=1
     if [ -z "$FORK_WEB_STALE" ]; then
         FORK_WEB_NOTE="reused (both flavors current)"
         good "fork web templates: both flavors are baked from these engine sources."
         RESULTS="${RESULTS}forkweb=reused "
+        FORK_WEB_BAKE=0
     elif [ "$FORK_WEB_SDK" != 1 ]; then
-        # Refused rather than attempted, and named as a HOST prerequisite: the bake
-        # needs an Emscripten SDK, and this script does not provision toolchains —
-        # growing it into dist/release-run.sh is what the junk-drawer rule above
-        # forbids. A refusal and not a skip, because the suite that follows demands
-        # both zips and DN2CPP_REQUIRE_ALL=1 leaves it no way to tolerate one.
-        FORK_WEB_NOTE="FAILED (no emcc; flavors due: $FORK_WEB_STALE)"
-        bad "fork web templates: $FORK_WEB_STALE must be baked, and the SDK resolver"
-        bad "cannot provide the mutable emcc that gates/setup-godot-fork-web.sh uses."
-        note "Provision the SDK first, then re-run this script:"
-        note "  ./gates/setup-emsdk.sh"
-        RESULTS="${RESULTS}forkweb=RED "
-        OVERALL=1
-    else
+        # Provisioned, not refused: the bake needs the mutable Emscripten SDK, and
+        # gates/setup-emsdk.sh unpacks the pinned one into the path the resolver
+        # searches. Asked once — a second miss after a successful unpack means the
+        # SDK is unusable on this host, which is a host gap, not a retry.
+        note "fork web templates: no mutable Emscripten SDK — unpacking the pinned one."
+        note "(gates/setup-emsdk.sh; the first run downloads the archive, later runs skip.)"
+        premerge_emsdk_argv
+        "${PREMERGE_EMSDK_ARGV[@]}" 2>&1 | tee "$LOGROOT/_emsdk.log"
+        rc_emsdk=${PIPESTATUS[0]}
+        [ "$rc_emsdk" -eq 0 ] && premerge_fork_web_state
+        if [ "$rc_emsdk" -ne 0 ] || [ "$FORK_WEB_SDK" != 1 ]; then
+            FORK_WEB_NOTE="FAILED (SDK provisioning; flavors due: $FORK_WEB_STALE)"
+            bad "fork web templates: gates/setup-emsdk.sh did not yield a usable emcc (exit $rc_emsdk)"
+            note "See $LOGROOT/_emsdk.log"
+            RESULTS="${RESULTS}forkweb=RED "
+            HOST_GAPS="${HOST_GAPS}Web templates (no emcc); "
+            OVERALL=1
+            FORK_WEB_BAKE=0
+        fi
+    fi
+    if [ "$FORK_WEB_BAKE" = 1 ]; then
         FORK_WEB_NOTE="rebaked ($FORK_WEB_STALE)"
+        bake_rc=0
         for flavor in $FORK_WEB_STALE; do
             note "fork web templates: baking the $flavor flavor."
             premerge_fork_web_argv "$flavor"
             "${PREMERGE_FORK_WEB_ARGV[@]}" 2>&1 | tee "$LOGROOT/_forkweb-$flavor.log"
             rc_web=${PIPESTATUS[0]}
             if [ "$rc_web" -ne 0 ]; then
+                # The zips are now a broken INPUT, not a host gap: the suites
+                # would fail over them, so they are withheld like a red fork cache.
                 FORK_WEB_NOTE="FAILED ($flavor, exit $rc_web)"
                 bad "fork web templates: the $flavor bake FAILED (exit $rc_web)"
                 note "See $LOGROOT/_forkweb-$flavor.log"
                 RESULTS="${RESULTS}forkweb=RED "
                 OVERALL=1
+                INPUTS_RED=1
+                bake_rc=1
                 break
             fi
         done
         # godot_fork_template_check is the one that re-asks, in every consumer,
         # for the reason written at the desktop arm above.
-        [ "$OVERALL" -eq 0 ] && {
+        [ "$bake_rc" -eq 0 ] && {
             good "fork web templates: rebaked $FORK_WEB_STALE."
             RESULTS="${RESULTS}forkweb=rebaked "
         }
@@ -2230,8 +2432,12 @@ fi
 
 for cfg in $CONFIGS; do
     logdir="$LOGROOT/$(printf '%s' "$cfg" | tr 'A-Z' 'a-z')"
-    if [ "$OVERALL" -ne 0 ] && [ "$KEEP_GOING" != "1" ]; then
-        bad "$cfg: NOT RUN — an earlier run failed (pass --keep-going to run both regardless)."
+    # Withheld after a broken input or a plainly red suite, never for a host
+    # gap: a red Release already answers the merge question, but a Release whose
+    # only failures are gates this host lacks the prerequisites for says nothing
+    # about the gates it can run — so Debug runs, and the gap is listed instead.
+    if { [ "$INPUTS_RED" -ne 0 ] || [ "$SUITE_RED" -ne 0 ]; } && [ "$KEEP_GOING" != "1" ]; then
+        bad "$cfg: NOT RUN — an earlier input or suite failed (pass --keep-going to run both regardless)."
         RESULTS="$RESULTS$cfg=not-run "
         continue
     fi
@@ -2246,6 +2452,12 @@ for cfg in $CONFIGS; do
     else
         RESULTS="$RESULTS$cfg=RED "
         OVERALL=1
+        if [ "$VERDICT_PREREQ_ONLY" = 1 ]; then
+            note "$cfg: red only for prerequisites this host lacks; the other configuration is not withheld."
+            HOST_GAPS="${HOST_GAPS}$cfg: $VERDICT_PREREQ_GATES (prerequisite absent); "
+        else
+            SUITE_RED=1
+        fi
     fi
     note "$cfg elapsed: $(( $(date +%s) - t_cfg ))s   logs: $logdir"
 done
@@ -2293,6 +2505,10 @@ fi
 
 rm -f "$RECEIPT"
 bad "PRE-MERGE FAILED — do not merge."
+if [ -n "$HOST_GAPS" ]; then
+    note "host prerequisites absent here: $HOST_GAPS"
+    note "Those gates cannot pass on this host; the suites were not withheld for them."
+fi
 note "Per-gate logs: $LOGROOT/{release,debug}/<gate>.log"
 note "This run's own output: $TRANSCRIPT"
 exit 1

--- a/gates/pre-merge.sh
+++ b/gates/pre-merge.sh
@@ -3,18 +3,21 @@
 # merge to `main`, so that "which two commands, under which config, with which
 # environment" stops living in somebody's memory.
 #
-#     ./gates/pre-merge.sh                # the real thing (~1-2h, + a self-host build when one is due)
+#     ./gates/pre-merge.sh                # the real thing (~1-2h, plus a self-host
+#                                         # build or a fork-cache refresh when one is due)
 #     ./gates/pre-merge.sh --dry-run      # print the exact runs, execute nothing
 #     ./gates/pre-merge.sh --keep-going   # run Debug even after Release fails
 #     DN2CPP_PREMERGE_SELFTEST=1 ./gates/pre-merge.sh   # self-test, no suite run
 #
-# WHAT IT RUNS, AND WHY EXACTLY THIS. One harness, one build and two full
-# suites, in this order:
+# WHAT IT RUNS, AND WHY EXACTLY THIS. One harness, the inputs the suites cannot
+# run without, and two full suites, in this order:
 #
 #   0. gates/verify-culture-invariance.sh
 #   1. gates/selfhost-emit.sh — only when the binary no longer describes src/
-#   2. CONFIG=Release  DN2CPP_REQUIRE_ALL=1  DN2CPP_GATE_CACHE=0
-#   3. CONFIG=Debug    DN2CPP_REQUIRE_ALL=1  DN2CPP_GATE_CACHE=0
+#   2. gates/setup-godot-fork.sh (+ gates/setup-godot-fork-web.sh per flavor) —
+#      only when the fork cache no longer describes ../godot-dn2cpp
+#   3. CONFIG=Release  DN2CPP_REQUIRE_ALL=1  DN2CPP_GATE_CACHE=0
+#   4. CONFIG=Debug    DN2CPP_REQUIRE_ALL=1  DN2CPP_GATE_CACHE=0
 #
 #   - REQUIRE_ALL, because "all N gates passed" must mean all N *ran*. Without
 #     it a machine missing a prerequisite reports green over a hole, which is
@@ -48,6 +51,20 @@
 #     turns into a failure; with a stale one they FAIL outright — and either way
 #     the news arrives hours into the run. It builds only when the stamp no longer
 #     matches src_tree_hash, so a tree whose binary is current pays nothing here.
+#   - The fork cache is here for the SAME reason and on the same terms, and it is
+#     what makes this script the ONE thing to run after updating ../godot-dn2cpp
+#     rather than the second thing. godot_fork_preflight demands a cache that
+#     describes the fork worktree as it is now, and a stale one is worse than an
+#     absent one: godot_fork_ctx's keys fingerprint the stale editor and
+#     GodotTools.dll THEMSELVES, so nothing moves and the fork gates replay a warm
+#     green over an editor that does not contain the edit under test. It refreshes
+#     only when a stamp disagrees, so a box whose cache is current pays a couple
+#     of tree hashes.
+#     The Web templates ride along because DN2CPP_REQUIRE_ALL=1 makes their
+#     absence a failure rather than a skip. The iOS template stays manual because
+#     its repair consumes Xcode and an official templates archive; its presence,
+#     provenance and host prerequisites are checked up front, so REQUIRE_ALL does
+#     not discover the manual work inside the suite.
 #
 # WHY THIS IS NOT A GATE. It runs the suite — twice. It lives beside
 # gates/verify-locks.sh and gates/measure-*.sh, outside the build-and-run-*.sh
@@ -66,9 +83,11 @@
 # lock machinery the suite itself runs under every time, and the console selfhost
 # harness emits what the suite's own gates transpile through, whereas nothing in
 # either suite can observe that a bucket's green was a fact about ja-JP.
-# gates/selfhost-emit.sh is in on a different test again, and it is the only thing
-# that may be: it answers no verdict at all — it produces a file the suites refuse
-# to run without.
+# gates/selfhost-emit.sh and the two gates/setup-godot-fork*.sh aids are in on a
+# different test again, and they are the only things that may be: they answer no
+# verdict at all — they produce the files the suites refuse to run without. That
+# is the whole entry condition, and "it is useful" is not it: dist/smoke-test.sh
+# is useful and stays out, because the suite already covers what it looks at.
 #
 # WHY IT RE-DERIVES THE VERDICT INSTEAD OF TRUSTING THE EXIT CODE. The runner's
 # exit code and this script's verdict are not the same question, and the gap is
@@ -122,18 +141,128 @@ set -uo pipefail
 
 REPO=$(cd "$(dirname "$0")/.." && pwd)
 
-# ── the self-host freshness probe (a child of this script, never a source) ────
-# The predicate is selfhost_bin_fresh (gates/_common.sh), and reaching it means
-# BEING the script that sources _common.sh: it cd's to its sourcer's parent and
-# turns on `set -euo pipefail`, so a `bash -c` sourcing it dies on its own `set
-# -u` and this script must not inherit either option. Hence a child of itself in
-# probe mode, printing `<0|1> <src-tree-hash> <binary path>` on one line.
-# Ahead of the self-test block on purpose: the self-test spawns this mode.
+# ── the freshness probes (children of this script, never a source) ────────────
+# The predicates are selfhost_bin_fresh and godot_fork_cache_fresh
+# (gates/_common.sh, gates/_godot_fork.sh), and reaching either means BEING the
+# script that sources _common.sh: it cd's to its sourcer's parent and turns on
+# `set -euo pipefail`, so a `bash -c` sourcing it dies on its own `set -u` and
+# this script must not inherit either option. Hence a child of itself in probe
+# mode. Ahead of the self-test block on purpose: the self-test spawns both modes.
+#
+# `=1` is the SELF-HOST probe and its output line is FROZEN — `<0|1>
+# <src-tree-hash> <binary path>` — because premerge_selfhost_state reads it
+# positionally and the self-test asserts the shape. `=fork` is the FORK-CACHE
+# probe: `<0|1|2|3> <fork-head> <engine-hash> <tools-hash> <reason…>` — 1 stale,
+# 2 no cache on this box, 3 this OS has no arm for the lane. Four answers and
+# not two because the phase acts differently on each: refresh, build, refuse.
+# Collapsing 2 into 1 would report a cold build as a refresh, and collapsing 3
+# into 2 would start a build that cannot succeed.
 if [ "${DN2CPP_PREMERGE_PROBE:-0}" = "1" ]; then
     source "$REPO/gates/_common.sh"
     probe_rc=0
     selfhost_bin_fresh || probe_rc=1
     printf '%s %s %s\n' "$probe_rc" "$SELFHOST_SRC_NOW" "$SELFHOST_BIN_PATH"
+    exit 0
+fi
+if [ "${DN2CPP_PREMERGE_PROBE:-0}" = "fork" ]; then
+    source "$REPO/gates/_common.sh"
+    source "$REPO/gates/_godot_fork.sh"
+    probe_rc=0
+    FORK_CACHE_HEAD=""
+    FORK_CACHE_ENGINE_NOW=""
+    FORK_CACHE_TOOLS_NOW=""
+    case "${DN2CPP_OS:-}" in
+        macos|windows|linux) ;;
+        *)
+            # 3, and the OS list must track gates/setup-godot-fork.sh's per-OS
+            # arms exactly — godot_fork_preflight's rule: anywhere else "run
+            # gates/setup-godot-fork.sh" is an instruction that cannot succeed,
+            # and the phase reading this has to refuse instead of starting a build.
+            probe_rc=3
+            FORK_CACHE_WHY="the Godot editor-export fork lane has no ${DN2CPP_OS:-non-desktop} arm"
+            ;;
+    esac
+    if [ "$probe_rc" = "0" ] && ! godot_fork_cache_complete; then
+        probe_rc=2
+        FORK_CACHE_WHY="no fork cache at $FORK_ROOT"
+        # An absent cache still has a fork it WOULD describe, and the phase prints
+        # it: "building a cache for <head>" is a different line from "building a
+        # cache", and only one of them lets a reader notice the wrong worktree
+        # before the scons run rather than after it.
+        if godot_fork_resolve >/dev/null 2>&1; then
+            FORK_CACHE_HEAD="$(git -C "$FORK" rev-parse --short HEAD 2>/dev/null || true)"
+        fi
+    elif [ "$probe_rc" = "0" ] && ! godot_fork_cache_fresh; then
+        probe_rc=1
+    fi
+    # The reason is LAST and unquoted on purpose: it is prose with spaces in it,
+    # and the reader (premerge_fork_state) takes it as the line's remainder.
+    printf '%s %s %s %s %s\n' "$probe_rc" "${FORK_CACHE_HEAD:-unknown}" \
+        "${FORK_CACHE_ENGINE_NOW:-unknown}" "${FORK_CACHE_TOOLS_NOW:-unknown}" \
+        "${FORK_CACHE_WHY:-current}"
+    exit 0
+fi
+# `=forkweb` names the Web template FLAVORS that have to be baked: `ok` alone when
+# both are current, `ok <flavor…>` otherwise. The `ok` is load-bearing — it is how
+# the reader tells "both current" from "the probe could not answer", which must
+# mean bake, not skip.
+#
+# A third probe rather than more fields on `=fork` because it asks about a
+# different artifact: the two zips can be stale while the desktop cache is current
+# (an interrupted re-bake) and current while it is stale (an engine edit not yet
+# built), so folding them into one answer would let either state hide the other.
+if [ "${DN2CPP_PREMERGE_PROBE:-0}" = "forkweb" ]; then
+    source "$REPO/gates/_common.sh"
+    source "$REPO/gates/_godot_fork.sh"
+    # No fork worktree, no provenance to compare against. Silence, not `ok`: the
+    # reader then bakes, which is the safe half — and the `=fork` probe has
+    # already made this run refuse, so nothing reaches the bake anyway.
+    godot_fork_resolve >/dev/null 2>&1 || exit 0
+    # The builder resolves the unpacked, mutable SDK rather than accepting the
+    # frozen one bundled for exports. Use that exact resolver here: ambient
+    # `command -v emcc` can name another SDK and make the probe disagree with the
+    # build it decides whether to run.
+    dn2cpp_emsdk_resolve --no-bundled >/dev/null 2>&1 || exit 0
+    command -v emcc >/dev/null 2>&1 || exit 0
+    probe_emcc="$(first_line "$(emcc --version 2>/dev/null)")"
+    [ -n "$probe_emcc" ] || exit 0
+    BASE_COMMIT="$(cat "$FORK_PIN_EXPECTED")"
+    probe_want="$(godot_fork_engine_provenance)"
+    probe_stale=""
+    for probe_flavor in stock cri; do
+        case "$probe_flavor" in
+            stock)
+                probe_zip="$FORK_ROOT/web_template.zip"
+                probe_emcc_stamp="$FORK_ROOT/web_emcc.txt"
+                ;;
+            cri)
+                probe_zip="$FORK_ROOT/web_template_cri.zip"
+                probe_emcc_stamp="$FORK_ROOT/web_emcc_cri.txt"
+                ;;
+        esac
+        if ! godot_fork_web_template_fresh "$probe_zip" "$probe_flavor" \
+            "$probe_emcc_stamp" "$probe_emcc" "$probe_want"; then
+            probe_stale="$probe_stale $probe_flavor"
+        fi
+    done
+    printf 'ok%s\n' "$probe_stale"
+    exit 0
+fi
+# `=forkios` is a refusal probe, not a builder. The iOS template needs Xcode and
+# an official templates archive, so pre-merge never creates it; it does ensure a
+# REQUIRE_ALL run does not discover its absence or stale provenance hours later.
+if [ "${DN2CPP_PREMERGE_PROBE:-0}" = "forkios" ]; then
+    source "$REPO/gates/_common.sh"
+    source "$REPO/gates/_godot_fork.sh"
+    godot_fork_resolve >/dev/null 2>&1 \
+        || { printf 'bad the fork worktree does not resolve\n'; exit 0; }
+    BASE_COMMIT="$(cat "$FORK_PIN_EXPECTED")"
+    probe_ios="$FORK_ROOT/ios_template.zip"
+    if ! godot_fork_ios_ready "$probe_ios"; then
+        printf 'bad %s\n' "$FORK_IOS_READY_WHY"
+        exit 0
+    fi
+    printf 'ok current\n'
     exit 0
 fi
 
@@ -144,7 +273,7 @@ for arg in "$@"; do
         --dry-run)    DRY_RUN=1 ;;
         --keep-going) KEEP_GOING=1 ;;
         -h|--help)
-            sed -n '2,9p' "$0" | sed 's/^# \{0,1\}//'
+            sed -n '2,10p' "$0" | sed 's/^# \{0,1\}//'
             exit 0
             ;;
         *)
@@ -452,6 +581,93 @@ premerge_selfhost_state() {
     SELFHOST_BIN=${bin:-artifacts/selfhost-fullcli/dn2cpp}
 }
 
+# premerge_fork_argv — the fork-cache setup's command line, same shape and same
+# reason as the three above. The desktop aid only: the Web arm is a separate argv
+# because it is conditional on a different artifact and needs a different
+# environment.
+premerge_fork_argv() {
+    PREMERGE_FORK_ARGV=()
+    if [ "${DN2CPP_PREMERGE_NO_CAFFEINATE:-0}" != "1" ] && command -v caffeinate >/dev/null 2>&1; then
+        PREMERGE_FORK_ARGV+=(caffeinate -i)
+    fi
+    PREMERGE_FORK_ARGV+=(bash "$REPO/gates/setup-godot-fork.sh")
+}
+
+# premerge_fork_web_argv FLAVOR — the Web template bake for `stock` or `cri`. The
+# flavor is an ENV variable to the same script (CRI=1), not an argument, because
+# that is the interface gates/setup-godot-fork-web.sh publishes and docs/RELEASE.md
+# drives it by.
+premerge_fork_web_argv() {
+    PREMERGE_FORK_WEB_ARGV=()
+    if [ "${DN2CPP_PREMERGE_NO_CAFFEINATE:-0}" != "1" ] && command -v caffeinate >/dev/null 2>&1; then
+        PREMERGE_FORK_WEB_ARGV+=(caffeinate -i)
+    fi
+    # CRI is pinned in BOTH arms, never merely set in one: a shell that exported
+    # CRI=1 for a hand-run bake would otherwise leak it into the stock bake, which
+    # then publishes a CRI-glued zip under the stock name — the one mislabel
+    # godot_fork_web_template_flavor exists to refuse downstream.
+    if [ "$1" = "cri" ]; then
+        PREMERGE_FORK_WEB_ARGV+=(env "CRI=1")
+    else
+        PREMERGE_FORK_WEB_ARGV+=(env "CRI=0")
+    fi
+    PREMERGE_FORK_WEB_ARGV+=(bash "$REPO/gates/setup-godot-fork-web.sh")
+}
+
+# premerge_fork_state — ask the fork probe, into FORK_STATE (0 current, 1 stale,
+# 2 absent), FORK_HEAD_SHORT, FORK_ENGINE, FORK_TOOLS and FORK_WHY. A probe that
+# cannot answer at all means STALE rather than absent: premerge_selfhost_state's
+# rule — never omit work on a guess — plus the narrower reading of the two, since
+# "absent" would let the phase claim it built a cache from nothing.
+premerge_fork_state() {
+    local out="" st="" head="" eng="" tools="" why=""
+    out=$(DN2CPP_PREMERGE_PROBE=fork bash "$REPO/gates/pre-merge.sh" 2>/dev/null) || out=""
+    read -r st head eng tools why <<<"$out" || :
+    FORK_STATE=${st:-1}
+    FORK_HEAD_SHORT=${head:-unknown}
+    FORK_ENGINE=${eng:-unknown}
+    FORK_TOOLS=${tools:-unknown}
+    FORK_WHY=${why:-the fork-cache probe returned nothing}
+}
+
+# premerge_fork_web_state — which Web template flavors this run has to bake, as a
+# space-separated list in FORK_WEB_STALE (empty when both are current).
+#
+# Absent and stale are ONE answer here, unlike the desktop cache. Under
+# DN2CPP_REQUIRE_ALL=1 a missing Web template is not a skip — gate_skip converts
+# to a failure — and a present-but-stale one is godot_fork_template_check's hard
+# refusal. So both zips have to exist AND be stamped with the engine provenance
+# before the suite starts, and there is no third outcome to distinguish.
+#
+# The comparison is godot_fork_engine_provenance, the same string
+# godot_fork_template_check demands, asked through the probe rather than here:
+# this function holds no $FORK.
+premerge_fork_web_state() {
+    local out="" tag=""
+    out=$(DN2CPP_PREMERGE_PROBE=forkweb bash "$REPO/gates/pre-merge.sh" 2>/dev/null) || out=""
+    read -r tag FORK_WEB_STALE <<<"$out" || :
+    if [ "${tag:-}" != "ok" ]; then
+        # The probe did not answer. Bake both rather than believe nothing is due:
+        # premerge_selfhost_state's rule — this phase must never omit work on a
+        # guess — and here the guess would be the one that lets the suite start.
+        FORK_WEB_STALE="stock cri"
+        FORK_WEB_SDK=0
+        return
+    fi
+    FORK_WEB_SDK=1
+    FORK_WEB_STALE=${FORK_WEB_STALE:-}
+}
+
+# premerge_fork_ios_state — 0 when the manually-built iOS template and its host
+# prerequisites are ready, 1 with FORK_IOS_WHY otherwise.
+premerge_fork_ios_state() {
+    local out="" tag="" why=""
+    out=$(DN2CPP_PREMERGE_PROBE=forkios bash "$REPO/gates/pre-merge.sh" 2>/dev/null) || out=""
+    read -r tag why <<<"$out" || :
+    FORK_IOS_WHY=${why:-the iOS prerequisite probe returned nothing}
+    [ "${tag:-}" = ok ]
+}
+
 # ── the verdict, re-derived from the run's own artifacts ─────────────────────
 
 # premerge_verdict LABEL RC LOGDIR EXPECTED_GATES — 0 when the run is a genuine
@@ -657,9 +873,9 @@ CSTUB
     chmod +x "$FAKE/gates/verify-culture-invariance.sh"
     # Stub self-host build, for the reason the culture stub exists — and one more:
     # the real one is a many-minute native link, and a self-test that could reach
-    # it is a self-test nobody runs. The fake repo carries no gates/_common.sh, so
-    # the freshness probe cannot answer there and every e2e case takes the rebuild
-    # arm, which is what makes this stub the ONLY selfhost-emit.sh reachable here.
+    # it is a self-test nobody runs. The fake repo's stub gates/_common.sh below
+    # answers the freshness probe STALE, so every e2e case takes the rebuild arm
+    # and this stub is the only selfhost-emit.sh reachable here.
     cat > "$FAKE/gates/selfhost-emit.sh" <<'SSTUB'
 #!/usr/bin/env bash
 echo "stub self-host build"
@@ -667,17 +883,123 @@ printf 'called\n' >> "${DN2CPP_STUB_SELFHOST_MARK:-/dev/null}"
 exit "${DN2CPP_STUB_SELFHOST_RC:-0}"
 SSTUB
     chmod +x "$FAKE/gates/selfhost-emit.sh"
+    # Stub fork setup aids, for the reason the culture and self-host stubs exist:
+    # the real ones drive scons and Emscripten. Each records that it was called,
+    # so a case can assert the phase built exactly when it should have.
+    cat > "$FAKE/gates/setup-godot-fork.sh" <<'FSTUB'
+#!/usr/bin/env bash
+echo "stub fork setup"
+printf 'called\n' >> "${DN2CPP_STUB_FORK_MARK:-/dev/null}"
+rc="${DN2CPP_STUB_FORK_RC:-0}"
+[ "$rc" != 0 ] || [ "${DN2CPP_STUB_FORK_NO_MARK:-0}" = 1 ] \
+    || : > "$DN2CPP_GODOT_FORK_ROOT/.stub-fork-fresh"
+exit "$rc"
+FSTUB
+    chmod +x "$FAKE/gates/setup-godot-fork.sh"
+    cat > "$FAKE/gates/setup-godot-fork-web.sh" <<'WSTUB'
+#!/usr/bin/env bash
+echo "stub web template bake (CRI=${CRI:-0})"
+if [ "${CRI:-0}" = "1" ]; then flavor=cri; else flavor=stock; fi
+printf '%s\n' "$flavor" >> "${DN2CPP_STUB_FORKWEB_MARK:-/dev/null}"
+exit "${DN2CPP_STUB_FORKWEB_RC:-0}"
+WSTUB
+    chmod +x "$FAKE/gates/setup-godot-fork-web.sh"
+    # Stub HELPERS, not just stub scripts, and this pair is what lets the two fork
+    # probes ANSWER inside the fake repo. The probes are the subject here — their
+    # exit-code-to-state mapping is the thing under test — so the predicates
+    # beneath them are what gets faked, exactly as run-all-gates.sh is faked
+    # beneath the suite phases.
+    #
+    # The self-host half stays deliberately STALE: every pre-existing e2e case
+    # asserts the rebuild arm ran the stub, and a stub that answered "fresh" would
+    # silently delete those assertions rather than fail them.
+    cat > "$FAKE/gates/_common.sh" <<'CMSTUB'
+# Stub _common.sh: only what gates/pre-merge.sh's probe arms read from it — the
+# cd to the repo root (which is how FORK_PIN_EXPECTED resolves), an OS name, and
+# the self-host freshness predicate.
+set -euo pipefail
+cd -P "$(dirname "${BASH_SOURCE[1]}")/.."
+DN2CPP_OS="${DN2CPP_STUB_OS:-linux}"
+EXE_EXT=
+first_line() { local x="$1"; printf '%s\n' "${x%%$'\n'*}"; }
+dn2cpp_emsdk_resolve() { return "${DN2CPP_STUB_EMSDK_RESOLVE:-0}"; }
+emcc() { printf '%s\n' "${DN2CPP_STUB_EMCC_VERSION:-stub-emcc}"; }
+xcodebuild() { :; }
+lipo() { :; }
+xcrun() { printf 'iPhone 16 (stub) (Booted)\n'; }
+selfhost_bin_fresh() {
+    SELFHOST_BIN_PATH="artifacts/selfhost-fullcli/dn2cpp"
+    SELFHOST_SRC_STAMPED="<no stamp>"
+    SELFHOST_SRC_NOW="stubsrc"
+    return 1
+}
+CMSTUB
+    cat > "$FAKE/gates/_godot_fork.sh" <<'GFSTUB'
+# Stub _godot_fork.sh: the two cache predicates the fork probes call, plus the
+# little the forkweb probe reads. Each answer is an env knob, so a case names the
+# state it wants instead of building a fork to have one.
+FORK_ROOT="${DN2CPP_GODOT_FORK_ROOT:-/nonexistent/stub-fork-root}"
+FORK_PIN_EXPECTED=gates/expected/godot-fork-pin.txt
+godot_fork_resolve() { FORK="${DN2CPP_STUB_FORK_CLONE:-/nonexistent/stub-fork}"; return "${DN2CPP_STUB_FORK_RESOLVE:-0}"; }
+godot_fork_engine_provenance() { printf 'engine=stubengine base=stubbase\n'; }
+godot_fork_cache_complete() {
+    [ -f "$FORK_ROOT/.stub-fork-fresh" ] && return 0
+    return "${DN2CPP_STUB_FORK_COMPLETE:-0}"
+}
+godot_fork_cache_fresh() {
+    FORK_CACHE_HEAD="${DN2CPP_STUB_FORK_HEAD:-deadbee}"
+    FORK_CACHE_ENGINE_NOW="${DN2CPP_STUB_FORK_ENGINE:-stubengine}"
+    FORK_CACHE_TOOLS_NOW="${DN2CPP_STUB_FORK_TOOLS:-stubtools}"
+    FORK_CACHE_WHY="${DN2CPP_STUB_FORK_WHY:-the stub says stale}"
+    [ -f "$FORK_ROOT/.stub-fork-fresh" ] && return 0
+    return "${DN2CPP_STUB_FORK_FRESH:-1}"
+}
+godot_fork_web_template_fresh() {
+    local zip="$1" flavor="$2" emcc_stamp="$3" emcc="$4" engine="$5"
+    [ -f "$zip" ] && [ "$(cat "$zip")" = "$flavor" ] \
+        && [ "$(head -1 "$emcc_stamp" 2>/dev/null || true)" = "$emcc" ] \
+        && [ "$(head -1 "$zip.provenance" 2>/dev/null || true)" = "$engine" ]
+}
+godot_fork_ios_ready() {
+    local zip="$1"
+    FORK_IOS_READY_KIND=artifact
+    FORK_IOS_READY_WHY="the stub iOS template is not ready"
+    [ -f "$zip" ] \
+        && [ "$(head -1 "$zip.provenance" 2>/dev/null || true)" = 'engine=stubengine base=stubbase' ]
+}
+GFSTUB
+
+    # A fork artifact root the forkweb probe can read for real. The probe logic is
+    # the subject — "which flavors are due" — so its INPUTS are faked and it runs
+    # unmodified: two zips, each stamped with the provenance the stub helper
+    # reports, which is the state "nothing due" looks like.
+    ST_FORKROOT="$ST_TMP/forkroot"
+    mkdir -p "$ST_FORKROOT" "$FAKE/gates/expected"
+    printf 'stubbase\n' > "$FAKE/gates/expected/godot-fork-pin.txt"
+    for z in web_template web_template_cri; do
+        [ "$z" = web_template ] && flavor=stock || flavor=cri
+        printf '%s\n' "$flavor" > "$ST_FORKROOT/$z.zip"
+        printf 'engine=stubengine base=stubbase\n' > "$ST_FORKROOT/$z.zip.provenance"
+    done
+    printf 'stub-emcc\n' > "$ST_FORKROOT/web_emcc.txt"
+    printf 'stub-emcc\n' > "$ST_FORKROOT/web_emcc_cri.txt"
+    printf 'not a real iOS template\n' > "$ST_FORKROOT/ios_template.zip"
+    printf 'engine=stubengine base=stubbase\n' > "$ST_FORKROOT/ios_template.zip.provenance"
 
     # e2e NAME EXPECT_RC RELEASE_RC DEBUG_RC EXPECT_CALLS [EXTRA_ARG] [CULTURE_RC] [SELFHOST_RC]
     e2e() {
         local name="$1" want_rc="$2" rel_rc="$3" dbg_rc="$4" want_calls="$5" extra="${6:-}" cult="${7:-0}" sh_rc="${8:-0}"
         local root="$ST_TMP/e2e-$name" rc=0 calls
         mkdir -p "$root"
+        rm -f "${DN2CPP_STUB_FORKROOT:-$ST_FORKROOT}/.stub-fork-fresh"
         DN2CPP_PREMERGE_SELFTEST=0 \
         DN2CPP_PREMERGE_LOGROOT="$root" \
         DN2CPP_STUB_CULTURE_RC="$cult" \
         DN2CPP_STUB_SELFHOST_RC="$sh_rc" \
         DN2CPP_STUB_SELFHOST_MARK="$root/_selfhost_calls.txt" \
+        DN2CPP_GODOT_FORK_ROOT="${DN2CPP_STUB_FORKROOT:-$ST_FORKROOT}" \
+        DN2CPP_STUB_FORK_MARK="$root/_fork_calls.txt" \
+        DN2CPP_STUB_FORKWEB_MARK="$root/_forkweb_calls.txt" \
         DN2CPP_STUB_RC_Release="$rel_rc" \
         DN2CPP_STUB_RC_Debug="$dbg_rc" \
             bash "$FAKE/gates/pre-merge.sh" $extra >"$root/_out.txt" 2>&1 || rc=$?
@@ -749,6 +1071,404 @@ SSTUB
     else
         st_bad "both-green: the receipt does not record the self-host build"
     fi
+
+    # ── phase 2, the fork cache ───────────────────────────────────────────────
+    # The state the stub helpers report is what each case names; the assertions
+    # are on the two things a reader of this phase depends on — whether the setup
+    # aid RAN, and what the verdict and receipt SAY it ran over. Both matter: a
+    # phase that rebuilds silently and a phase that reports a rebuild it skipped
+    # are the two ways this can be wrong, and only one of them is visible in the
+    # exit code.
+    #
+    # every pre-existing case above already exercised the STALE arm, because the
+    # stub answers stale by default — so what is left is the other three answers.
+    DN2CPP_STUB_FORK_FRESH=0 e2e fork-fresh 0 0 0 "Release,Debug,"
+    if [ -f "$ST_TMP/e2e-fork-fresh/_fork_calls.txt" ]; then
+        st_bad "fork-fresh: the phase rebuilt a cache it was told was current"
+    else
+        st_ok "fork-fresh: a current cache is not rebuilt"
+    fi
+    if grep -q '^fork:    reused' "$ST_TMP/e2e-fork-fresh/_receipt.txt" 2>/dev/null; then
+        st_ok "fork-fresh: the receipt records the cache as reused"
+    else
+        st_bad "fork-fresh: the receipt does not record the fork cache — see $ST_TMP/e2e-fork-fresh/_receipt.txt"
+    fi
+
+    # The stale arm's positive half, asserted where the default already puts us.
+    if [ -f "$ST_TMP/e2e-both-green/_fork_calls.txt" ]; then
+        st_ok "both-green: a stale cache is refreshed through the fake repo's stub"
+    else
+        st_bad "both-green: no fork-cache refresh was attempted at all"
+    fi
+    if grep -q '^fork:    rebuilt' "$ST_TMP/e2e-both-green/_receipt.txt" 2>/dev/null; then
+        st_ok "both-green: the receipt records the fork cache's provenance"
+    else
+        st_bad "both-green: the receipt does not record the fork rebuild"
+    fi
+    if grep -q '^forkweb: reused' "$ST_TMP/e2e-both-green/_receipt.txt" 2>/dev/null; then
+        st_ok "both-green: the receipt records the Web templates as current"
+    else
+        st_bad "both-green: the receipt does not record the Web templates"
+    fi
+
+    # A failed refresh must stop the suites, exactly as a failed self-host build
+    # does: an empty call list is the assertion, not a nicety.
+    DN2CPP_STUB_FORK_RC=1 e2e fork-red 1 0 0 ""
+    if grep -q 'fork=RED' "$ST_TMP/e2e-fork-red/_out.txt"; then
+        st_ok "fork-red: the verdict names fork=RED"
+    else
+        st_bad "fork-red: the verdict does not name fork=RED — see $ST_TMP/e2e-fork-red/_out.txt"
+    fi
+
+    # Absent is a DIFFERENT answer from stale, and the phase has to say so before
+    # spending tens of minutes: a reader who sees "refreshing" where the truth is
+    # "building from nothing" has no way to notice the wrong worktree.
+    DN2CPP_STUB_FORK_COMPLETE=1 e2e fork-absent 0 0 0 "Release,Debug,"
+    if grep -q 'no cache on this box yet' "$ST_TMP/e2e-fork-absent/_out.txt"; then
+        st_ok "fork-absent: the phase says it is building a cache, not refreshing one"
+    else
+        st_bad "fork-absent: an absent cache is reported as a stale one — see $ST_TMP/e2e-fork-absent/_out.txt"
+    fi
+    if grep -q '^fork:    rebuilt (fork deadbee, engine stubengine, tools stubtools)' \
+        "$ST_TMP/e2e-fork-absent/_receipt.txt" 2>/dev/null; then
+        st_ok "fork-absent: receipt carries post-build fork hashes"
+    else
+        st_bad "fork-absent: receipt retained pre-build unknowns"
+    fi
+
+    DN2CPP_STUB_FORK_NO_MARK=1 e2e fork-false-green 1 0 0 ""
+    if grep -q 'setup exited 0 but the rebuilt cache is not current' \
+        "$ST_TMP/e2e-fork-false-green/_out.txt"; then
+        st_ok "fork-false-green: setup exit 0 is re-probed and refused"
+    else
+        st_bad "fork-false-green: setup exit 0 was trusted without a fresh cache"
+    fi
+
+    # A host with no arm for the lane: refused up front with exit 2, the same
+    # status and the same reason as the SKIP_GODOT refusal. Not exit 1 — this is
+    # not a red merge gate, it is a run that cannot be performed here.
+    DN2CPP_STUB_OS=android e2e fork-no-arm 2 0 0 ""
+    if grep -q 'no pre-merge run on this host' "$ST_TMP/e2e-fork-no-arm/_out.txt"; then
+        st_ok "fork-no-arm: refused with the reason, before the first suite"
+    else
+        st_bad "fork-no-arm: refused without saying why — see $ST_TMP/e2e-fork-no-arm/_out.txt"
+    fi
+
+    # The Web templates, on a box with no Emscripten SDK. The refusal is the
+    # branch that matters: DN2CPP_REQUIRE_ALL=1 makes an absent template a
+    # failure, this script does not provision SDKs, and a run that started the
+    # suites anyway would spend hours to reach the same answer.
+    ST_WEBLESS="$ST_TMP/forkroot-webless"
+    mkdir -p "$ST_WEBLESS"
+    cp "$ST_FORKROOT/ios_template.zip" "$ST_WEBLESS/ios_template.zip"
+    cp "$ST_FORKROOT/ios_template.zip.provenance" "$ST_WEBLESS/ios_template.zip.provenance"
+    DN2CPP_STUB_EMSDK_RESOLVE=1 DN2CPP_STUB_FORKROOT="$ST_WEBLESS" \
+        e2e forkweb-no-emcc 1 0 0 ""
+    if grep -q 'setup-emsdk.sh' "$ST_TMP/e2e-forkweb-no-emcc/_out.txt"; then
+        st_ok "forkweb-no-emcc: refused naming the SDK aid, before the first suite"
+    else
+        st_bad "forkweb-no-emcc: refused without naming gates/setup-emsdk.sh"
+    fi
+
+    # The bake arm itself, reachable on any host: EMSDK set is what the phase
+    # reads as "an SDK is provisioned", and the stub records the CRI pin each
+    # flavor was invoked under — an ambient CRI=1 leaking into the stock bake
+    # (premerge_fork_web_argv's mislabel) would surface here as a wrong line.
+    DN2CPP_STUB_FORKROOT="$ST_WEBLESS" e2e forkweb-bake 0 0 0 "Release,Debug,"
+    ST_BAKED="$(cat "$ST_TMP/e2e-forkweb-bake/_forkweb_calls.txt" 2>/dev/null | tr '\n' ',')"
+    if [ "$ST_BAKED" = "stock,cri," ]; then
+        st_ok "forkweb-bake: both flavors baked, each under its own CRI pin"
+    else
+        st_bad "forkweb-bake: flavors recorded [$ST_BAKED] (want [stock,cri,])"
+    fi
+    if grep -q '^forkweb: rebaked' "$ST_TMP/e2e-forkweb-bake/_receipt.txt" 2>/dev/null; then
+        st_ok "forkweb-bake: the receipt records the rebake"
+    else
+        st_bad "forkweb-bake: the receipt does not record the rebake"
+    fi
+
+    # The forkweb probe must schedule exactly the flavor whose builder contract
+    # is broken: flavor, emcc and engine provenance are independent terms.
+    web_probe_case() {
+        local name="$1" root="$ST_TMP/webprobe-$1" want="$2" got
+        cp -R "$ST_FORKROOT" "$root"
+        case "$name" in
+            missing-emcc) rm -f "$root/web_emcc.txt" ;;
+            wrong-flavor) printf 'cri\n' > "$root/web_template.zip" ;;
+            stale-engine) printf 'engine=old base=stubbase\n' > "$root/web_template_cri.zip.provenance" ;;
+        esac
+        got="$(DN2CPP_GODOT_FORK_ROOT="$root" DN2CPP_PREMERGE_PROBE=forkweb \
+            bash "$FAKE/gates/pre-merge.sh" 2>/dev/null || true)"
+        if [ "$got" = "$want" ]; then
+            st_ok "forkweb $name -> [$got]"
+        else
+            st_bad "forkweb $name -> [$got] (wanted [$want])"
+        fi
+    }
+    web_probe_case missing-emcc "ok stock"
+    web_probe_case wrong-flavor "ok stock"
+    web_probe_case stale-engine "ok cri"
+
+    say "fork artifact freshness predicates (real helpers, synthetic artifacts)"
+
+    ST_WEB_REAL="$ST_TMP/web-real"
+    mkdir -p "$ST_WEB_REAL/good" "$ST_WEB_REAL/bad"
+    printf 'plain stock glue\n' > "$ST_WEB_REAL/good/godot.js"
+    printf '__cpp_exception\n' > "$ST_WEB_REAL/good/godot.wasm"
+    printf 'side\n' > "$ST_WEB_REAL/good/godot.side.wasm"
+    (cd "$ST_WEB_REAL/good" && zip -q "$ST_WEB_REAL/good.zip" godot.js godot.wasm godot.side.wasm)
+    printf 'plain stock glue\n' > "$ST_WEB_REAL/bad/godot.js"
+    printf '__cpp_exception\n' > "$ST_WEB_REAL/bad/godot.wasm"
+    (cd "$ST_WEB_REAL/bad" && zip -q "$ST_WEB_REAL/bad.zip" godot.js godot.wasm)
+    for z in good bad; do
+        printf 'stub-emcc\n' > "$ST_WEB_REAL/$z.emcc"
+        printf 'engine=stub base=stubbase\n' > "$ST_WEB_REAL/$z.zip.provenance"
+    done
+    web_real_fresh() {
+        (
+            export DN2CPP_GODOT_FORK_ROOT="$ST_WEB_REAL"
+            DN2CPP_OS=linux
+            source "$REPO/gates/_godot_fork.sh"
+            godot_fork_web_template_fresh "$ST_WEB_REAL/$1.zip" stock \
+                "$ST_WEB_REAL/$1.emcc" stub-emcc 'engine=stub base=stubbase'
+        )
+    }
+    if web_real_fresh good; then
+        st_ok "Web predicate accepts matching flavor/emcc/engine plus dlink/EH structure"
+    else
+        st_bad "Web predicate rejected a structurally current synthetic template"
+    fi
+    if web_real_fresh bad; then
+        st_bad "Web predicate accepted a template with no godot.side.wasm"
+    else
+        st_ok "Web predicate rejects a structurally incomplete template"
+    fi
+
+    ST_IOS_REAL="$ST_TMP/ios-real"
+    ST_IOS_SLICE=libgodot.ios.debug.xcframework/ios-arm64_x86_64-simulator/libgodot.a
+    mkdir -p "$ST_IOS_REAL/bad/$(dirname "$ST_IOS_SLICE")" \
+             "$ST_IOS_REAL/good/$(dirname "$ST_IOS_SLICE")"
+    printf 'X86_ONLY\n' > "$ST_IOS_REAL/bad/$ST_IOS_SLICE"
+    printf 'ARM64\n' > "$ST_IOS_REAL/good/$ST_IOS_SLICE"
+    (cd "$ST_IOS_REAL/bad" && zip -q -r "$ST_IOS_REAL/bad.zip" libgodot.ios.debug.xcframework)
+    (cd "$ST_IOS_REAL/good" && zip -q -r "$ST_IOS_REAL/good.zip" libgodot.ios.debug.xcframework)
+    for z in bad good; do
+        printf 'engine=stub base=stubbase\n' > "$ST_IOS_REAL/$z.zip.provenance"
+    done
+    ios_real_ready() {
+        (
+            export DN2CPP_GODOT_FORK_ROOT="$ST_IOS_REAL"
+            DN2CPP_OS=macos
+            xcodebuild() { :; }
+            xcrun() { printf 'iPhone 16 (stub) (Booted)\n'; }
+            lipo() {
+                local f="$2"
+                if grep -q ARM64 "$f"; then
+                    printf 'Architectures in the fat file: %s are: x86_64 arm64\n' "$f"
+                else
+                    printf 'Non-fat file: %s is architecture: x86_64\n' "$f"
+                fi
+            }
+            source "$REPO/gates/_godot_fork.sh"
+            godot_fork_engine_provenance() { printf 'engine=stub base=stubbase\n'; }
+            godot_fork_ios_ready "$ST_IOS_REAL/$1.zip"
+        )
+    }
+    if ios_real_ready bad; then
+        st_bad "iOS readiness accepts an x86_64-only simulator slice"
+    else
+        st_ok "iOS readiness rejects an unrepaired simulator template"
+    fi
+    if ios_real_ready good; then
+        st_ok "iOS readiness accepts a readable, current arm64 simulator template"
+    else
+        st_bad "iOS readiness rejected a repaired simulator template"
+    fi
+
+    ST_SDK_FORK="$ST_TMP/sdk-fork"
+    ST_SDK_ROOT="$ST_TMP/sdk-root"
+    mkdir -p "$ST_SDK_FORK" "$ST_SDK_ROOT/nuget"
+    cat > "$ST_SDK_FORK/version.py" <<'VERSION'
+major = 4
+minor = 8
+patch = 1
+status = "stable"
+VERSION
+    managed_version() {
+        (
+            export DN2CPP_GODOT_FORK_ROOT="$ST_SDK_ROOT"
+            DN2CPP_OS=linux
+            source "$REPO/gates/_godot_fork.sh"
+            FORK="$ST_SDK_FORK"
+            godot_fork_managed_package_version
+        )
+    }
+    sed 's/status = "stable"/status = "beta3"/' "$ST_SDK_FORK/version.py" \
+        > "$ST_SDK_FORK/version.py.tmp"
+    mv "$ST_SDK_FORK/version.py.tmp" "$ST_SDK_FORK/version.py"
+    if [ "$(managed_version)" = 4.8.1-beta.3 ]; then
+        st_ok "managed package version matches build_assemblies.py prerelease spelling"
+    else
+        st_bad "managed package version does not normalize beta3 to beta.3"
+    fi
+    sed 's/status = "beta3"/status = "stable"/' "$ST_SDK_FORK/version.py" \
+        > "$ST_SDK_FORK/version.py.tmp"
+    mv "$ST_SDK_FORK/version.py.tmp" "$ST_SDK_FORK/version.py"
+    managed_feed_fresh() {
+        (
+            export DN2CPP_GODOT_FORK_ROOT="$ST_SDK_ROOT"
+            DN2CPP_OS=linux
+            source "$REPO/gates/_godot_fork.sh"
+            FORK="$ST_SDK_FORK"
+            godot_fork_managed_feed_fresh
+        )
+    }
+    : > "$ST_SDK_ROOT/nuget/Godot.NET.Sdk.4.8.0.nupkg"
+    if managed_feed_fresh; then
+        st_bad "SDK feed accepts the wrong sole package"
+    else
+        st_ok "SDK feed rejects a stale sole package"
+    fi
+    : > "$ST_SDK_ROOT/nuget/Godot.NET.Sdk.4.8.1.nupkg"
+    if managed_feed_fresh; then
+        st_bad "SDK feed accepts mixed package versions"
+    else
+        st_ok "SDK feed rejects ambiguous package versions"
+    fi
+    rm -f "$ST_SDK_ROOT/nuget/Godot.NET.Sdk.4.8.0.nupkg"
+    for pkg in Godot.SourceGenerators GodotSharp GodotSharpEditor; do
+        : > "$ST_SDK_ROOT/nuget/$pkg.4.8.1.nupkg"
+    done
+    if managed_feed_fresh; then
+        st_ok "managed feed accepts one current package for all four products"
+    else
+        st_bad "managed feed rejected its four current packages"
+    fi
+    rm -f "$ST_SDK_ROOT/nuget/Godot.SourceGenerators.4.8.1.nupkg"
+    if managed_feed_fresh; then
+        st_bad "managed feed accepts a missing SourceGenerators sibling"
+    else
+        st_ok "managed feed rejects a missing SourceGenerators sibling"
+    fi
+    : > "$ST_SDK_ROOT/nuget/Godot.SourceGenerators.4.8.1.nupkg"
+    : > "$ST_SDK_ROOT/nuget/GodotSharpEditor.4.8.0.nupkg"
+    if managed_feed_fresh; then
+        st_bad "managed feed accepts mixed GodotSharpEditor versions"
+    else
+        st_ok "managed feed rejects mixed GodotSharpEditor versions"
+    fi
+    rm -f "$ST_SDK_ROOT/nuget/GodotSharpEditor.4.8.0.nupkg"
+    : > "$ST_SDK_ROOT/nuget/Godot.NET.Sdk.4.8.0.nupkg"
+    if (source "$REPO/gates/_common.sh"; godot_nuget_sdk_version "$ST_SDK_ROOT/nuget") \
+        >/dev/null 2>&1; then
+        st_bad "godot_nuget_sdk_version selected one package from an ambiguous feed"
+    else
+        st_ok "godot_nuget_sdk_version rejects an ambiguous feed"
+    fi
+
+    ST_CACHE_FORK="$ST_TMP/cache-fork"
+    ST_CACHE_ROOT="$ST_TMP/cache-root"
+    mkdir -p "$ST_CACHE_FORK/modules/mono/mono_gd" \
+             "$ST_CACHE_FORK/modules/mono/glue/GodotSharp/GodotSharp/Generated" \
+             "$ST_CACHE_FORK/bin/GodotSharp/Api/Release" \
+             "$ST_CACHE_FORK/bin/GodotSharp/Dn2Cpp" "$ST_CACHE_ROOT/nuget"
+    cp "$ST_SDK_FORK/version.py" "$ST_CACHE_FORK/version.py"
+    printf 'marker\n' > "$ST_CACHE_FORK/modules/mono/mono_gd/gd_mono.cpp"
+    printf 'bin/\nmodules/mono/glue/GodotSharp/GodotSharp/Generated/\n' > "$ST_CACHE_FORK/.gitignore"
+    git -C "$ST_CACHE_FORK" init -q
+    git -C "$ST_CACHE_FORK" add .
+    git -C "$ST_CACHE_FORK" -c user.name=stub -c user.email=stub@example.invalid commit -qm base
+    ST_CACHE_BASE="$(git -C "$ST_CACHE_FORK" rev-parse HEAD)"
+    printf '%s\n' "$ST_CACHE_BASE" > "$ST_CACHE_ROOT/pin.txt"
+    printf '%s\n' "$ST_CACHE_BASE" > "$ST_TMP/cache-pin.txt"
+    ST_CACHE_EDITOR="$ST_CACHE_FORK/bin/godot.linuxbsd.editor.x86_64.mono"
+    ST_CACHE_TEMPLATE="$ST_CACHE_FORK/bin/godot.linuxbsd.template_release.x86_64.mono"
+    printf '#!/bin/sh\n' > "$ST_CACHE_EDITOR"; chmod +x "$ST_CACHE_EDITOR"
+    printf '#!/bin/sh\n' > "$ST_CACHE_TEMPLATE"; chmod +x "$ST_CACHE_TEMPLATE"
+    printf '%s\n' "$ST_CACHE_EDITOR" > "$ST_CACHE_ROOT/editor.txt"
+    printf '%s\n' "$ST_CACHE_TEMPLATE" > "$ST_CACHE_ROOT/template.txt"
+    printf '%s\n' "$ST_CACHE_FORK" > "$ST_CACHE_ROOT/clone.txt"
+    printf 'api\n' > "$ST_CACHE_FORK/bin/GodotSharp/Api/Release/GodotSharp.dll"
+    printf '{}\n' > "$ST_CACHE_FORK/bin/GodotSharp/Dn2Cpp/manifest.json"
+    printf 'glue\n' > "$ST_CACHE_FORK/modules/mono/glue/GodotSharp/GodotSharp/Generated/GeneratedIncludes.props"
+    for pkg in Godot.NET.Sdk Godot.SourceGenerators GodotSharp GodotSharpEditor; do
+        : > "$ST_CACHE_ROOT/nuget/$pkg.4.8.1.nupkg"
+    done
+    cache_helper() {
+        (
+            export DN2CPP_GODOT_FORK_ROOT="$ST_CACHE_ROOT"
+            DN2CPP_OS=linux
+            source "$REPO/gates/_godot_fork.sh"
+            FORK_PIN_EXPECTED="$ST_TMP/cache-pin.txt"
+            "$@"
+        )
+    }
+    # Compute and stamp in one helper shell so FORK/BASE_COMMIT use the same
+    # dynamic-scope contract as the production predicate.
+    (
+        export DN2CPP_GODOT_FORK_ROOT="$ST_CACHE_ROOT"
+        DN2CPP_OS=linux
+        source "$REPO/gates/_godot_fork.sh"
+        FORK_PIN_EXPECTED="$ST_TMP/cache-pin.txt"
+        godot_fork_resolve >/dev/null
+        BASE_COMMIT="$ST_CACHE_BASE"
+        eng="$(godot_fork_engine_hash)"
+        tools="$(godot_fork_tools_hash)"
+        printf '%s\n' "$eng" > "$FORK_EDITOR.engine-hash"
+        printf '%s\n' "$eng" > "$FORK_TEMPLATE.engine-hash"
+        printf '%s\n' "$eng" > "$FORK/$FORK_GLUE_MARKER.engine-hash"
+        printf '%s\n' "$tools" > "$(godot_fork_tools_stamp)"
+        desktop="$(godot_fork_desktop_template "$FORK_ROOT")"
+        printf 'desktop\n' > "$desktop"
+        printf 'engine=%s base=%s\n' "$eng" "$BASE_COMMIT" > "$desktop.provenance"
+    )
+    if cache_helper godot_fork_cache_fresh; then
+        st_ok "fork cache predicate accepts a complete current synthetic cache"
+    else
+        st_bad "fork cache predicate rejected a complete current synthetic cache"
+    fi
+    ST_CACHE_DESKTOP="$ST_CACHE_ROOT/linux_template.$(cache_helper godot_fork_host_arch)"
+    rm -f "$ST_CACHE_DESKTOP.provenance"
+    if cache_helper godot_fork_cache_fresh; then
+        st_bad "fork cache predicate accepts an unstamped desktop template"
+    else
+        st_ok "fork cache predicate schedules repair for an unstamped desktop template"
+    fi
+
+    # ── the probes' own output shapes ─────────────────────────────────────────
+    # Against the REAL repo, because that is where the real predicates live. The
+    # self-host line is FROZEN: premerge_selfhost_state reads it positionally, and
+    # a field added in front of it would be read as the freshness verdict.
+    ST_PROBE="$(DN2CPP_PREMERGE_PROBE=1 bash "$0" 2>/dev/null || true)"
+    if [ "$(printf '%s\n' "$ST_PROBE" | wc -l | tr -d ' ')" = "1" ] \
+        && [ "$(printf '%s' "$ST_PROBE" | wc -w | tr -d ' ')" = "3" ]; then
+        st_ok "the self-host probe still prints one line of three fields"
+    else
+        st_bad "the self-host probe's frozen output shape changed: [$ST_PROBE]"
+    fi
+    case "$ST_PROBE" in
+        0\ *|1\ *) st_ok "the self-host probe's first field is a verdict" ;;
+        *)         st_bad "the self-host probe does not lead with 0 or 1: [$ST_PROBE]" ;;
+    esac
+    # The fork line carries prose last, so it is asserted on its FIRST fields
+    # only — the reason is deliberately unbounded.
+    ST_FPROBE="$(DN2CPP_PREMERGE_PROBE=fork bash "$0" 2>/dev/null || true)"
+    case "$ST_FPROBE" in
+        0\ *|1\ *|2\ *|3\ *) st_ok "the fork probe leads with one of its four states" ;;
+        *)                   st_bad "the fork probe's first field is not a state: [$ST_FPROBE]" ;;
+    esac
+    if [ "$(printf '%s' "$ST_FPROBE" | wc -w | tr -d ' ')" -ge 5 ]; then
+        st_ok "the fork probe prints its four fields and a reason"
+    else
+        st_bad "the fork probe printed fewer fields than its readers take: [$ST_FPROBE]"
+    fi
+    # An unanswerable Web probe must mean BAKE, never "nothing due": the wrong
+    # default here is the one that lets the suite start over an absent template.
+    ST_WEB_OUT="$(DN2CPP_PREMERGE_PROBE=forkweb bash "$0" 2>/dev/null || true)"
+    case "$ST_WEB_OUT" in
+        ok|ok\ *) st_ok "the forkweb probe answers with its ok sentinel" ;;
+        *)        st_ok "the forkweb probe could not answer here — the reader bakes both" ;;
+    esac
 
     # The transcript, and specifically its LAST line: a form that loses the tail
     # loses the verdict, which is the one line the transcript exists for.
@@ -1150,6 +1870,7 @@ OPTS
     mkdir -p "$SR_ROOT"
     SR_RC=0
     DN2CPP_PREMERGE_SELFTEST=0 DN2CPP_PREMERGE_LOGROOT="$SR_ROOT" \
+    DN2CPP_GODOT_FORK_ROOT="$ST_FORKROOT" \
     DN2CPP_STUB_RC_Release=0 DN2CPP_STUB_RC_Debug=0 \
         bash "$STALE_REPO/gates/pre-merge.sh" >"$SR_ROOT/_out.txt" 2>&1 || SR_RC=$?
     if [ "$SR_RC" = "0" ] && grep -q 'DN2CPP_ALPHA is cached OFF' "$SR_ROOT/_out.txt"; then
@@ -1238,6 +1959,43 @@ if [ "$DRY_RUN" = "1" ]; then
         printf '    %s does not describe src %s; this would run:\n      ' "$SELFHOST_BIN" "$SELFHOST_SRC"
         printf '%s ' "${PREMERGE_SELFHOST_ARGV[@]}"
         printf '\n'
+    fi
+    premerge_fork_state
+    printf '\n  godot fork cache:\n'
+    case "$FORK_STATE" in
+        0)
+            printf '    already describes fork %s (engine %s, tools %s) — NOT rebuilt\n' \
+                "$FORK_HEAD_SHORT" "$FORK_ENGINE" "$FORK_TOOLS"
+            ;;
+        3)
+            printf '    %s — this host has no pre-merge run at all (exit 2)\n' "$FORK_WHY"
+            ;;
+        *)
+            premerge_fork_argv
+            printf '    %s; this would run:\n      ' "$FORK_WHY"
+            printf '%s ' "${PREMERGE_FORK_ARGV[@]}"
+            printf '\n'
+            ;;
+    esac
+    if [ "$FORK_STATE" != "3" ]; then
+        printf '\n  godot fork iOS template (manual prerequisite):\n'
+        if premerge_fork_ios_state; then
+            printf '    current and host prerequisites are available\n'
+        else
+            printf '    %s — this pre-merge run would refuse before its suites\n' "$FORK_IOS_WHY"
+        fi
+        premerge_fork_web_state
+        printf '\n  godot fork web templates:\n'
+        if [ -z "$FORK_WEB_STALE" ]; then
+            printf '    both flavors are baked from these engine sources — NOT rebaked\n'
+        else
+            for flavor in $FORK_WEB_STALE; do
+                premerge_fork_web_argv "$flavor"
+                printf '    %s is absent or stale; this would run:\n      ' "$flavor"
+                printf '%s ' "${PREMERGE_FORK_WEB_ARGV[@]}"
+                printf '\n'
+            done
+        fi
     fi
     for cfg in $CONFIGS; do
         logdir="$LOGROOT/$(printf '%s' "$cfg" | tr 'A-Z' 'a-z')"
@@ -1334,6 +2092,142 @@ else
     fi
 fi
 
+# ── phase 2: the fork cache the Godot lane requires ──────────────────────────
+# Phase 1's argument, for the other input the fork gates demand, and AFTER it
+# because it consumes it: step 3 of gates/setup-godot-fork.sh packages the
+# self-hosted CLI into the export toolchain the editor runs.
+#
+# The reuse condition here MUST be godot_fork_preflight's accept condition, for
+# the same reason phase 1 shares selfhost_bin_fresh: a refresh this phase skips
+# and the fork gates then refuse is hours of green followed by a REQUIRE_ALL
+# failure over a cache this run could have rebuilt first.
+say "godot fork cache (gates/setup-godot-fork.sh)"
+premerge_fork_state
+FORK_NOTE="(unset)"
+FORK_RUN=0
+case "$FORK_STATE" in
+    0)
+        FORK_NOTE="reused (fork $FORK_HEAD_SHORT, engine $FORK_ENGINE, tools $FORK_TOOLS)"
+        good "fork: the cache already describes fork $FORK_HEAD_SHORT."
+        note "engine $FORK_ENGINE, tools $FORK_TOOLS — nothing to rebuild."
+        RESULTS="${RESULTS}fork=reused "
+        ;;
+    3)
+        # Refused before the first suite, not discovered inside it. This box
+        # cannot produce a fork cache at all, and DN2CPP_REQUIRE_ALL=1 turns the
+        # seventeen Godot gates' skips into failures — so there is no pre-merge
+        # run here, and saying so now costs nothing where saying it later costs
+        # the whole Release suite.
+        bad "fork: $FORK_WHY."
+        bad "There is no pre-merge run on this host: gates/setup-godot-fork.sh"
+        bad "builds an engine only for macOS, Windows and Linux, and the merge gate"
+        bad "demands every Godot gate run. Use a desktop host."
+        exit 2
+        ;;
+    2)
+        note "fork: no cache on this box yet — building one for fork ${FORK_HEAD_SHORT}."
+        note "($FORK_WHY. A cold build is tens of minutes when the fork edits engine C++.)"
+        FORK_RUN=1
+        ;;
+    *)
+        note "fork: the cache no longer describes fork ${FORK_HEAD_SHORT} — refreshing it."
+        note "($FORK_WHY)"
+        FORK_RUN=1
+        ;;
+esac
+if [ "$FORK_RUN" = "1" ]; then
+    premerge_fork_argv
+    "${PREMERGE_FORK_ARGV[@]}" 2>&1 | tee "$LOGROOT/_fork.log"
+    FORK_RC=${PIPESTATUS[0]}
+    if [ "$FORK_RC" -eq 0 ]; then
+        # Re-ask before the suites, both to prove setup's exit 0 produced the
+        # promised cache and to record POST-build hashes. A cold-cache probe has
+        # no engine/tools values, so reusing its fields would put `unknown` in the
+        # receipt that exists to identify what the green ran over.
+        premerge_fork_state
+        if [ "$FORK_STATE" = 0 ]; then
+            FORK_NOTE="rebuilt (fork $FORK_HEAD_SHORT, engine $FORK_ENGINE, tools $FORK_TOOLS)"
+            good "fork: rebuilt the cache for fork $FORK_HEAD_SHORT."
+            note "engine $FORK_ENGINE, tools $FORK_TOOLS — post-build freshness verified."
+            RESULTS="${RESULTS}fork=rebuilt "
+        else
+            FORK_NOTE="FAILED (setup exited 0; post-build probe: $FORK_WHY)"
+            bad "fork: setup exited 0 but the rebuilt cache is not current."
+            note "$FORK_WHY"
+            RESULTS="${RESULTS}fork=RED "
+            OVERALL=1
+        fi
+    else
+        FORK_NOTE="FAILED (exit $FORK_RC)"
+        bad "fork: FAILED (exit $FORK_RC) — see $LOGROOT/_fork.log"
+        RESULTS="${RESULTS}fork=RED "
+        OVERALL=1
+    fi
+fi
+
+# The iOS artifact stays manual: unlike desktop and Web, producing it needs an
+# official templates archive and an Xcode simulator toolchain. Refuse before the
+# suites rather than converting the iOS gate's late REQUIRE_ALL skip into an
+# hour-delayed surprise.
+if [ "$OVERALL" -eq 0 ] && ! premerge_fork_ios_state; then
+    bad "fork iOS template: $FORK_IOS_WHY"
+    note "Prepare it manually, then rerun pre-merge:"
+    note "  FORCE=1 ./gates/setup-godot-fork-ios.sh"
+    exit 2
+fi
+
+# The Web export templates, on the same argument and with one difference: absent
+# and stale are ONE answer, because under DN2CPP_REQUIRE_ALL=1 a missing template
+# is no longer a skip. premerge_fork_web_state says why.
+#
+# Only reached when the desktop cache is good, since the bake reads the fork
+# editor's version and the engine sources the provenance is taken over — baking
+# over a broken cache would stamp the zips against a tree the next step moves.
+FORK_WEB_NOTE="not asked"
+if [ "$OVERALL" -eq 0 ]; then
+    premerge_fork_web_state
+    if [ -z "$FORK_WEB_STALE" ]; then
+        FORK_WEB_NOTE="reused (both flavors current)"
+        good "fork web templates: both flavors are baked from these engine sources."
+        RESULTS="${RESULTS}forkweb=reused "
+    elif [ "$FORK_WEB_SDK" != 1 ]; then
+        # Refused rather than attempted, and named as a HOST prerequisite: the bake
+        # needs an Emscripten SDK, and this script does not provision toolchains —
+        # growing it into dist/release-run.sh is what the junk-drawer rule above
+        # forbids. A refusal and not a skip, because the suite that follows demands
+        # both zips and DN2CPP_REQUIRE_ALL=1 leaves it no way to tolerate one.
+        FORK_WEB_NOTE="FAILED (no emcc; flavors due: $FORK_WEB_STALE)"
+        bad "fork web templates: $FORK_WEB_STALE must be baked, and the SDK resolver"
+        bad "cannot provide the mutable emcc that gates/setup-godot-fork-web.sh uses."
+        note "Provision the SDK first, then re-run this script:"
+        note "  ./gates/setup-emsdk.sh"
+        RESULTS="${RESULTS}forkweb=RED "
+        OVERALL=1
+    else
+        FORK_WEB_NOTE="rebaked ($FORK_WEB_STALE)"
+        for flavor in $FORK_WEB_STALE; do
+            note "fork web templates: baking the $flavor flavor."
+            premerge_fork_web_argv "$flavor"
+            "${PREMERGE_FORK_WEB_ARGV[@]}" 2>&1 | tee "$LOGROOT/_forkweb-$flavor.log"
+            rc_web=${PIPESTATUS[0]}
+            if [ "$rc_web" -ne 0 ]; then
+                FORK_WEB_NOTE="FAILED ($flavor, exit $rc_web)"
+                bad "fork web templates: the $flavor bake FAILED (exit $rc_web)"
+                note "See $LOGROOT/_forkweb-$flavor.log"
+                RESULTS="${RESULTS}forkweb=RED "
+                OVERALL=1
+                break
+            fi
+        done
+        # godot_fork_template_check is the one that re-asks, in every consumer,
+        # for the reason written at the desktop arm above.
+        [ "$OVERALL" -eq 0 ] && {
+            good "fork web templates: rebaked $FORK_WEB_STALE."
+            RESULTS="${RESULTS}forkweb=rebaked "
+        }
+    fi
+fi
+
 for cfg in $CONFIGS; do
     logdir="$LOGROOT/$(printf '%s' "$cfg" | tr 'A-Z' 'a-z')"
     if [ "$OVERALL" -ne 0 ] && [ "$KEEP_GOING" != "1" ]; then
@@ -1377,6 +2271,12 @@ if [ "$OVERALL" -eq 0 ]; then
         # Which sources the binary the fork lane ran on was built from: a green
         # produced over somebody else's self-host binary is a different claim.
         printf 'selfhost: %s\n' "$SELFHOST_NOTE"
+        # And which FORK the Godot lane ran on. The editor drives that whole
+        # pipeline, so a green produced over another fork head — or over a cache
+        # that predates this one — is likewise a different claim, and the fork's
+        # head is in no other line of this receipt.
+        printf 'fork:    %s\n' "$FORK_NOTE"
+        printf 'forkweb: %s\n' "$FORK_WEB_NOTE"
         printf 'runs:    %s\n' "$RESULTS"
         printf 'elapsed: %ss\n' "$ELAPSED"
         # What the green was produced over. A reader who was not there cannot

--- a/gates/setup-godot-fork-web.sh
+++ b/gates/setup-godot-fork-web.sh
@@ -313,10 +313,11 @@ echo "== 1/3 scons: the Web template ($WANT) =="
 built_emcc="$(cat "$BUILT_STAMP" 2>/dev/null || echo '<no stamp>')"
 built_engine="$(head -1 "$BUILT_ENGINE_STAMP" 2>/dev/null || echo '<no stamp>')"
 [ -n "$built_engine" ] || built_engine='<no stamp>'
-if [ "$(godot_fork_web_template_flavor "$BUILT")" = "$WANT" ] && [ "$built_emcc" = "$EMCC_VERSION" ] \
-    && [ "$built_engine" = "$ENGINE_PROVENANCE" ] && [ "$FORCE" != 1 ]; then
+if godot_fork_web_template_fresh "$BUILT" "$WANT" "$BUILT_STAMP" \
+    "$EMCC_VERSION" "$ENGINE_PROVENANCE" && [ "$FORCE" != 1 ]; then
     echo "skip: already built ($WANT, by this emcc, from these engine sources): $BUILT"
 else
+    [ "$FORCE" = 1 ] || echo "-- $FORK_WEB_TEMPLATE_WHY"
     if [ -f "$BUILT" ] && [ "$(godot_fork_web_template_flavor "$BUILT")" = "$WANT" ] \
         && [ "$built_emcc" != "$EMCC_VERSION" ]; then
         echo "-- the $WANT zip in bin/ was not built by this emcc"

--- a/gates/setup-godot-fork.sh
+++ b/gates/setup-godot-fork.sh
@@ -30,9 +30,14 @@
 # the glue is the editor's own output, so the engine sources are its input), the
 # desktop export template on godot_fork_engine_provenance (step 5's artifact, the
 # same `<template>.provenance` line the Web and iOS zips carry), and the managed
-# assemblies + feed on tools_tree_hash (step 4). The two source sets partition the
-# fork, so the GodotTools edit-test loop rebuilds the assemblies without triggering
-# a scons run, and an engine edit does the reverse.
+# assemblies + feed on godot_fork_tools_hash (step 4). The two source sets
+# partition the fork, so the GodotTools edit-test loop rebuilds the assemblies
+# without triggering a scons run, and an engine edit does the reverse.
+#
+# godot_fork_cache_fresh (gates/_godot_fork.sh) reads exactly those stamps, which
+# is what lets an export gate and gates/pre-merge.sh tell a current cache from a
+# stale one WITHOUT running this script — the question this script answers by
+# doing the work.
 #
 # Why no engine rebuild in the common case
 # ----------------------------------------
@@ -162,9 +167,10 @@ SCONS="$(godot_fork_scons "$PY")"
 
 EDITOR_REL="bin/godot.$SCONS_PLATFORM.editor.$ARCH.mono$FORK_EXE"
 TEMPLATE_REL="bin/godot.$SCONS_PLATFORM.template_release.$ARCH.mono$FORK_EXE"
-GLUE_MARKER=modules/mono/glue/GodotSharp/GodotSharp/Generated/GeneratedIncludes.props
-API_RELEASE_REL=bin/GodotSharp/Api/Release/GodotSharp.dll
-TOOLCHAIN_MARKER=bin/GodotSharp/Dn2Cpp/manifest.json
+# The three stamped products are FORK_GLUE_MARKER / FORK_API_RELEASE_REL /
+# FORK_TOOLCHAIN_MARKER (gates/_godot_fork.sh), not local names: this script
+# WRITES the stamps and godot_fork_cache_fresh READS them, and a second spelling
+# of one of those paths is a predicate that quietly answers about nothing.
 
 echo "== 0/6 Verifying the fork =="
 if [ ! -e "$FORK/.git" ]; then
@@ -225,56 +231,13 @@ echo "interop ABI fingerprints OK (fork is drop-in compatible)"
 ENGINE_HASH="$(godot_fork_engine_hash)"
 CACHE="$ROOT/bin-cache/$ENGINE_HASH"
 
-# The COMPLEMENT of FORK_OWNED: the managed trees step 4's build_assemblies.py
-# compiles, which is exactly what the engine hash excludes so that the fork's
-# edit-test loop does not trigger a scons run. The two hashes partition the fork's
-# sources by which product they describe — this one keys GodotSharp/{Tools,Api,
-# Dn2Cpp} and the local nuget feed, the engine one keys the two engine binaries.
-#
-# Derived from what build_assemblies.py's build_all actually reads, not from the
-# exclusion list: generate_sdk_package_versions (version.py -> the gitignored
-# SdkPackageVersions.props), build_godot_api (the GodotSharp glue sources ->
-# Api/Release/GodotSharp.dll), GodotTools.sln (-> Tools/GodotTools.dll) and
-# Godot.NET.Sdk (-> the nupkgs pushed to the feed). So it is a superset of the
-# complement: version.py and modules/mono/glue/GodotSharp are FORK_OWNED too, and
-# feed BOTH hashes, because they feed both products.
-#
-# `modules/mono/editor` is deliberately NOT taken whole — that directory also
-# holds engine C++ (editor_internal_calls.cpp, bindings_generator.cpp), which is
-# the engine hash's and whose change already forces a scons build.
-TOOLS_OWNED=(
-    'version.py'
-    'modules/mono/build_scripts'
-    'modules/mono/editor/GodotTools'
-    'modules/mono/editor/Godot.NET.Sdk'
-    'modules/mono/glue/GodotSharp'
-)
-
-# tools_tree_hash — godot_fork_engine_hash's twin over TOOLS_OWNED, same rules and for
-# the same reasons: content rather than git state (so staging or committing a
-# GodotTools edit is not a rebuild, and reaching the same sources from another
-# branch is not either), --binary so a modified binary file is fingerprinted by
-# content, and untracked files hashed in. Everything build_assemblies.py *writes*
-# is gitignored (bin/, obj/, SdkPackageVersions.props, the generated glue and
-# source-generator constants), so its own products cannot feed the hash that keys
-# them — which is what keeps the stamp from moving on every build.
-tools_tree_hash() {
-    (
-        cd "$FORK"
-        printf 'base %s\n' "$BASE_COMMIT"
-        git diff --no-ext-diff --no-textconv --no-color --no-renames --binary \
-            "$BASE_COMMIT" -- "${TOOLS_OWNED[@]}"
-        # Not `xargs`, for godot_fork_engine_hash's reason: with no untracked
-        # file GNU xargs still runs shasum, which hashes its own stdin, and the
-        # same tree would then key a different cache entry per host flavour.
-        git ls-files --others --exclude-standard -z -- "${TOOLS_OWNED[@]}" \
-            | while IFS= read -r -d '' f; do shasum -a 256 "$f"; done
-    ) | shasum -a 256 | cut -c1-16
-}
-TOOLS_HASH="$(tools_tree_hash)"
-# Beside the tree it describes, under the fork's gitignored bin/ — the same
-# placement and the same rule as an engine binary's .engine-hash stamp.
-TOOLS_STAMP="$FORK/bin/GodotSharp/.tools-hash"
+# TOOLS_OWNED (the managed complement of FORK_OWNED) and godot_fork_tools_hash
+# were written here too, and moved to gates/_godot_fork.sh for the same reason:
+# godot_fork_cache_fresh there answers "does this cache describe the fork as it
+# is now" for the export gates and for gates/pre-merge.sh, and it must ask the
+# question this step keys its work on — not a second spelling of it.
+TOOLS_HASH="$(godot_fork_tools_hash)"
+TOOLS_STAMP="$(godot_fork_tools_stamp)"
 
 engine_drift="$(
     git -C "$FORK" diff --name-only "$BASE_COMMIT" -- "${FORK_OWNED[@]}"
@@ -380,19 +343,19 @@ echo "== 2/6 Mono glue =="
 # ENGINE_HASH nor TOOLS_HASH (both hash only tracked deltas and *non-ignored*
 # untracked files), which is what keeps a stamp from moving the hash that keys
 # it. Same placement rule as an engine binary's .engine-hash.
-GLUE_STAMP="$FORK/$GLUE_MARKER.engine-hash"
-if [ -f "$FORK/$GLUE_MARKER" ] && [ -f "$GLUE_STAMP" ] \
+GLUE_STAMP="$FORK/$FORK_GLUE_MARKER.engine-hash"
+if [ -f "$FORK/$FORK_GLUE_MARKER" ] && [ -f "$GLUE_STAMP" ] \
     && [ "$(cat "$GLUE_STAMP")" = "$ENGINE_HASH" ]; then
-    echo "skip: glue already generated from these engine sources: $FORK/$GLUE_MARKER"
+    echo "skip: glue already generated from these engine sources: $FORK/$FORK_GLUE_MARKER"
 else
-    if [ -f "$FORK/$GLUE_MARKER" ]; then
+    if [ -f "$FORK/$FORK_GLUE_MARKER" ]; then
         echo "-- the glue in the fork predates the current engine sources"
     fi
     # Removed before the run and written after it, for install_binary's reason: an
     # interrupted generation must leave a glue nothing calls current.
     rm -f "$GLUE_STAMP"
     (cd "$FORK" && "./$EDITOR_REL" --headless --generate-mono-glue modules/mono/glue)
-    [ -f "$FORK/$GLUE_MARKER" ] || { echo "error: glue generation produced no $GLUE_MARKER" >&2; exit 1; }
+    [ -f "$FORK/$FORK_GLUE_MARKER" ] || { echo "error: glue generation produced no $FORK_GLUE_MARKER" >&2; exit 1; }
     printf '%s\n' "$ENGINE_HASH" > "$GLUE_STAMP"
 fi
 
@@ -423,17 +386,24 @@ echo "== 4/6 Managed assemblies + nuget feed + toolchain install =="
 # The dn2cpp bundle installed by --bundle-dn2cpp is NOT in this hash — it is a
 # dn2cpp-side product, and the gates re-package and re-stage it every run
 # (stage_editor_toolchain), so this stamp has no business claiming it is current.
-if compgen -G "$ROOT/nuget/Godot.NET.Sdk.*.nupkg" >/dev/null && [ -f "$FORK/$API_RELEASE_REL" ] \
-    && [ -f "$FORK/$TOOLCHAIN_MARKER" ] \
+if godot_fork_managed_feed_fresh && [ -f "$FORK/$FORK_API_RELEASE_REL" ] \
+    && [ -f "$FORK/$FORK_TOOLCHAIN_MARKER" ] \
     && [ -f "$TOOLS_STAMP" ] && [ "$(cat "$TOOLS_STAMP")" = "$TOOLS_HASH" ]; then
     echo "skip: assemblies + feed + toolchain already built from these managed sources: $FORK/bin/GodotSharp"
 else
-    if [ -f "$FORK/$API_RELEASE_REL" ] && [ -f "$TOOLS_STAMP" ] \
+    if [ -f "$FORK/$FORK_API_RELEASE_REL" ] && [ -f "$TOOLS_STAMP" ] \
         && [ "$(cat "$TOOLS_STAMP")" != "$TOOLS_HASH" ]; then
         echo "-- the assemblies in the fork predate the current managed sources"
         echo "   stamped $(cat "$TOOLS_STAMP") != $TOOLS_HASH"
     fi
     mkdir -p "$ROOT/nuget"
+    # The feed is one coherent build, not an archive across pins. Retaining the
+    # old packages makes an `any nupkg` guard pass after the current SDK package
+    # is deleted and lets NuGet resolve siblings from different Godot versions.
+    rm -f "$ROOT"/nuget/Godot.NET.Sdk.*.nupkg \
+          "$ROOT"/nuget/Godot.SourceGenerators.*.nupkg \
+          "$ROOT"/nuget/GodotSharp.*.nupkg "$ROOT"/nuget/GodotSharp.*.snupkg \
+          "$ROOT"/nuget/GodotSharpEditor.*.nupkg "$ROOT"/nuget/GodotSharpEditor.*.snupkg
     # $PY, never a bare `python3` — see resolve_python at the top of this file for
     # what that name resolves to on a stock Windows box.
     # shellcheck disable=SC2086
@@ -442,8 +412,9 @@ else
         --godot-platform="$SCONS_PLATFORM" \
         --push-nupkgs-local "$ROOT/nuget" \
         --bundle-dn2cpp "$LAYOUT")
-    [ -f "$FORK/$API_RELEASE_REL" ] || { echo "error: build_assemblies produced no $API_RELEASE_REL" >&2; exit 1; }
-    [ -f "$FORK/$TOOLCHAIN_MARKER" ] || { echo "error: --bundle-dn2cpp installed no $TOOLCHAIN_MARKER" >&2; exit 1; }
+    [ -f "$FORK/$FORK_API_RELEASE_REL" ] || { echo "error: build_assemblies produced no $FORK_API_RELEASE_REL" >&2; exit 1; }
+    [ -f "$FORK/$FORK_TOOLCHAIN_MARKER" ] || { echo "error: --bundle-dn2cpp installed no $FORK_TOOLCHAIN_MARKER" >&2; exit 1; }
+    godot_fork_managed_feed_fresh || { echo "error: $FORK_MANAGED_FEED_WHY" >&2; exit 1; }
     # Written LAST, after both products are asserted, for the same reason
     # install_binary stamps last: an interrupted build must not leave a stamp
     # standing behind a half-written GodotSharp tree.
@@ -566,7 +537,7 @@ echo "template:      $FORK_ABS/$TEMPLATE_REL (recorded in $ROOT/template.txt)"
 echo "desktop tmpl:  $TEMPLATE_ARTIFACT"
 echo "GodotSharp:    $FORK_ABS/bin/GodotSharp (beside the editor)"
 echo "fork clone:    $ROOT/clone.txt ($FORK_ABS)"
-echo "toolchain:     $FORK/$TOOLCHAIN_MARKER"
+echo "toolchain:     $FORK/$FORK_TOOLCHAIN_MARKER"
 echo "nuget feed:    $ROOT/nuget (${sdk_nupkg:-Godot.NET.Sdk nupkg MISSING})"
 echo "base pin:      $ROOT/pin.txt ($BASE_COMMIT)"
 echo "fork head:     $ROOT/fork_head.txt ($FORK_HEAD)"


### PR DESCRIPTION
## 概要

- fork の engine/managed source hash と各生成物の stamp を比較し、古い cache を gate cache より前で拒否します。
- managed feed は Godot.NET.Sdk、Godot.SourceGenerators、GodotSharp、GodotSharpEditor の4パッケージが同一の現行versionで揃っていることを検証し、再生成時に旧packageを除去します。
- pre-merge gate が必要時だけ desktop cache と stock/CRI Web template を再生成し、setup成功後にfreshnessを再検証して receipt へ実際に使用するforkのhashを記録します。
- pre-merge gate はツールチェインの一部を欠くホスト（Windows など）でも完走し、確認できるゲートを全て走らせます。欠けた面は最終 verdict に赤として列挙され、receipt は書かれません。

## 背景

GodotTools.dll はgateの検査対象であると同時にcache keyの入力でもあるため、未コンパイルのGodotTools変更ではkeyが動かず、古いexporterに対するwarm greenを再利用できました。source treeと生成物stampを直接比較し、suite開始前に必要なrefreshを行います。

レビューでは、旧版と現行版が混在した実feedから旧SDKが選ばれる状態も確認しました。builderとconsumerでWeb/iOSのreadiness predicateを共有し、desktop artifact、Web flavor/emcc/構造、iOS arm64 simulator slice、managed feed全体を同じ条件で判定します。

### ホスト前提の欠落と pre-merge の完走

従来は Xcode の無いホストでは iOS template の probe で suite 前に `exit 2`、emcc の無いホストでは suite が not-run になり、Windows では pre-merge が一度も suite に到達できませんでした。not-ready を3種に分けます。

| 状況 | 挙動 |
|---|---|
| Xcode あり・`ios_template.zip` が無い/古い（artifact） | 従来どおり suite 前に `exit 2`（数分で直せる作業を数時間後に知らせない） |
| Xcode なし（host prerequisite） | `forkios=RED` を記録して継続。両 suite を実行 |
| mutable emcc なし（provisionable） | `gates/setup-emsdk.sh` を実行して再 probe、Web template を焼く。失敗時のみ赤 |

verdict と suite 実行可否を分離しました。`OVERALL` が verdict、`INPUTS_RED` は suite の入力（culture / self-host binary / fork cache / bake）が壊れた時だけ suite を抑止します。赤の suite が他方の config を抑止するのは、失敗のいずれかが `gate_skip` の REQUIRE_ALL 変換以外の本物の失敗である時だけで、`premerge_verdict` が各ゲートのログ内の `gate_skip` マーカーで分類します。CRI 系ゲートもこの分類に入るため、Windows では iOS/CRI 由来の失敗だけなら Release/Debug 両方が走り、最終 verdict に `host prerequisites absent here: ...` として列挙されます。

`gates/setup-emsdk.sh` を pre-merge が呼ぶことは、ヘッダーの採用条件（suite が拒否するファイルを生成する aid）に合致します。ピン留めアーカイブの取得・展開のみで冪等、`windows-x64` arm を持ち、`dist/release-run.sh` が既に通常ステップとして呼んでいます。

## 検証

- `bash -n gates/_common.sh gates/_godot_fork.sh gates/build-and-run-godot-editor-export-ios.sh gates/pre-merge.sh gates/setup-godot-fork.sh gates/setup-godot-fork-web.sh`
- `DN2CPP_PREMERGE_SELFTEST=1 bash gates/pre-merge.sh`（Windows: 153 passed, 2 failed — 残る2件は `zip` コマンド不在で fixture を作れない既存の失敗で、変更前 baseline でも同じ2件。新規ケース `forkios-no-xcode` / `forkios-stale-artifact` / `forkweb-provision` / `forkweb-provision-red` / `red-release-prereq-only` / `red-release-mixed` は全て PASS）
- `./gates/build-and-run-doc-claims.sh`（83 claims）
- `bash gates/pre-merge.sh --dry-run`（Windows: iOS 行が「this run would continue, and the iOS gates go red at the verdict」）
- `git diff --check origin/main...HEAD`

`./gates/pre-merge.sh` 本体はhuman-onlyのため実行していません。
