### PR TITLE
Fix Apple RNG imports on Web

### DIFF
--- a/gates/build-and-run-godot-editor-export-web.sh
+++ b/gates/build-and-run-godot-editor-export-web.sh
@@ -645,11 +645,13 @@ else
         "DN2CPP_EXPORT_INTEROP resizeOk=True sized=True" \
         "DN2CPP_EXPORT_SIGNAL awaited=True" \
         "DN2CPP_EXPORT_CLOCK ticks=True elapsed=True" \
+        "DN2CPP_EXPORT_CSPRNG native=True directEntropy=True publicEntropy=True" \
         "DN2CPP_EXPORT_DONE"; do
         grep -qF "$marker" "$LOG" || { echo "FAIL: missing marker: $marker" >&2; exit 1; }
     done
     for once in "DN2CPP_EXPORT_READY" "DN2CPP_EXPORT_GDPRINT" "DN2CPP_EXPORT_PROCESS" "DN2CPP_EXPORT_GC" \
-        "DN2CPP_EXPORT_INTEROP" "DN2CPP_EXPORT_SIGNAL" "DN2CPP_EXPORT_CLOCK" "DN2CPP_EXPORT_DONE"; do
+        "DN2CPP_EXPORT_INTEROP" "DN2CPP_EXPORT_SIGNAL" "DN2CPP_EXPORT_CLOCK" "DN2CPP_EXPORT_CSPRNG" \
+        "DN2CPP_EXPORT_DONE"; do
         n="$(grep -c "$once" "$LOG" || true)"
         [ "$n" -eq 1 ] || { echo "FAIL: marker $once appeared $n times (expected exactly 1)" >&2; exit 1; }
     done

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -845,10 +845,15 @@ else()
             list(APPEND DN2CPP_PLATFORM_SRCS ${DN2CPP_PLATFORM_POSIX_REST})
         endif()
     elseif(EMSCRIPTEN)
-        # WASM PAL, plus the POSIX mmap unit as-is: Emscripten's musl provides
-        # open/fstat/mmap/msync against MEMFS, so that TU needs no port.
+        # WASM PAL, plus two portable POSIX-directory adapters. The mmap unit
+        # uses Emscripten's musl open/fstat/mmap/msync against MEMFS. The Apple
+        # crypto random adapter depends only on the SystemNative entropy ABI,
+        # whose wasm implementation is backed by getentropy; it uses no POSIX
+        # platform API despite its source-tree location.
         file(GLOB DN2CPP_PLATFORM_SRCS CONFIGURE_DEPENDS "${DN2CPP_ROOT}/runtime/core/platform/wasm/*.cpp")
-        list(APPEND DN2CPP_PLATFORM_SRCS "${DN2CPP_ROOT}/runtime/core/platform/posix/dn2cpp_mmap_posix.cpp")
+        list(APPEND DN2CPP_PLATFORM_SRCS
+            "${DN2CPP_ROOT}/runtime/core/platform/posix/dn2cpp_mmap_posix.cpp"
+            "${DN2CPP_ROOT}/runtime/core/platform/posix/dn2cpp_apple_crypto_random.cpp")
     elseif(WIN32)
         # Win32/CRT PAL, including dn2cpp_mmap_windows.cpp
         # (CreateFileMappingA/MapViewOfFile instead of POSIX mmap) — picked up

--- a/runtime/core/platform/posix/dn2cpp_apple_crypto_random.cpp
+++ b/runtime/core/platform/posix/dn2cpp_apple_crypto_random.cpp
@@ -1,8 +1,9 @@
 // dn2cpp_apple_crypto_random.cpp — AppleCryptoNative_GetRandomBytes, the
 // entropy source behind System.Security.Cryptography.RandomNumberGenerator
 // on the Apple flavor of the real BCL (which does NOT route through
-// SystemNative_*). Backed by the same real-entropy backend Stage 1 added for
-// Guid.NewGuid (pal_random.c mirror in dn2cpp_system_native.cpp).
+// SystemNative_* itself). This adapter depends only on the portable
+// SystemNative_GetCryptographicallySecureRandomBytes ABI, not on a POSIX API,
+// so the Emscripten source set reuses it with the wasm getentropy backend.
 //
 // ABI (decoded from the real net10 System.Security.Cryptography.dll):
 //   int32_t AppleCryptoNative_GetRandomBytes(uint8_t* buf, int32_t num,

--- a/runtime/core/platform/wasm/dn2cpp_system_native_wasm.cpp
+++ b/runtime/core/platform/wasm/dn2cpp_system_native_wasm.cpp
@@ -86,10 +86,12 @@ uint32_t SystemNative_InterfaceNameToIndex(char* interfaceName)
 }
 
 // pal_random.c SystemNative_GetCryptographicallySecureRandomBytes: the entropy
-// source behind Guid.NewGuid / RandomNumberGenerator. Returns 0 on success, -1 on
-// failure — the managed forwarder (Interop.GetCryptographicallySecureRandomBytes)
-// throws CryptographicException on nonzero. The contract is the POSIX one,
-// verbatim; only the backend differs.
+// source behind Guid.NewGuid / RandomNumberGenerator. The portable
+// dn2cpp_apple_crypto_random.cpp adapter also consumes this ABI when the real
+// BCL reaches RandomNumberGenerator through AppleCryptoNative_GetRandomBytes.
+// Returns 0 on success, -1 on failure — the managed forwarder
+// (Interop.GetCryptographicallySecureRandomBytes) throws CryptographicException
+// on nonzero. The contract is the POSIX one, verbatim; only the backend differs.
 //
 // Real randomness is required, and Emscripten supplies it: its musl getentropy
 // is backed by the host CSPRNG (crypto.getRandomValues in a browser,

--- a/samples/godot-dotnet/EditorExportSample/EditorExportSample.csproj
+++ b/samples/godot-dotnet/EditorExportSample/EditorExportSample.csproj
@@ -7,5 +7,6 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <EnableDynamicLoading>true</EnableDynamicLoading>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 </Project>

--- a/samples/godot-dotnet/EditorExportSample/ExportProbe.cs
+++ b/samples/godot-dotnet/EditorExportSample/ExportProbe.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Godot;
@@ -10,6 +11,9 @@ using Godot;
 // packaged runs inside a real exported .app with no .NET runtime beside it.
 public partial class ExportProbe : Node
 {
+    [DllImport("libSystem.Security.Cryptography.Native.Apple", EntryPoint = "AppleCryptoNative_GetRandomBytes")]
+    private static extern unsafe int AppleCryptoNativeGetRandomBytes(byte* buffer, int length, int* status);
+
     // Overridden by the scene: reaching the C# instance through the engine's Set
     // bridge proves the script instance is tied to the native object.
     [Export]
@@ -45,8 +49,67 @@ public partial class ExportProbe : Node
         _tickAtReady = System.Environment.TickCount64;
         _stampAtReady = Stopwatch.GetTimestamp();
 
+        ProbeCsprng();
         ProbeInterop();
         _ = ProbeSignalAsync();
+    }
+
+    // The direct call pins the exact native ABI that the Apple flavor of the real
+    // BCL imports. The public calls prove RandomNumberGenerator reaches the same
+    // real-entropy path. Report only derived properties so the log is deterministic.
+    private static unsafe void ProbeCsprng()
+    {
+        const int Length = 32;
+        byte* directFirst = stackalloc byte[Length];
+        byte* directSecond = stackalloc byte[Length];
+        int firstStatus = -1;
+        int secondStatus = -1;
+        int firstResult = AppleCryptoNativeGetRandomBytes(directFirst, Length, &firstStatus);
+        int secondResult = AppleCryptoNativeGetRandomBytes(directSecond, Length, &secondStatus);
+
+        bool native = firstResult == 1 && secondResult == 1
+            && firstStatus == 0 && secondStatus == 0;
+        bool directEntropy = HasNonZeroByte(directFirst, Length)
+            && HasNonZeroByte(directSecond, Length)
+            && !BuffersEqual(directFirst, directSecond, Length);
+
+        byte[] publicFirst = System.Security.Cryptography.RandomNumberGenerator.GetBytes(Length);
+        byte[] publicSecond = System.Security.Cryptography.RandomNumberGenerator.GetBytes(Length);
+        bool publicEntropy = HasNonZeroByte(publicFirst)
+            && HasNonZeroByte(publicSecond)
+            && !publicFirst.AsSpan().SequenceEqual(publicSecond);
+
+        Console.WriteLine($"DN2CPP_EXPORT_CSPRNG native={native} directEntropy={directEntropy} publicEntropy={publicEntropy}");
+    }
+
+    private static unsafe bool HasNonZeroByte(byte* buffer, int length)
+    {
+        for (int i = 0; i < length; i++)
+        {
+            if (buffer[i] != 0)
+                return true;
+        }
+        return false;
+    }
+
+    private static bool HasNonZeroByte(byte[] buffer)
+    {
+        for (int i = 0; i < buffer.Length; i++)
+        {
+            if (buffer[i] != 0)
+                return true;
+        }
+        return false;
+    }
+
+    private static unsafe bool BuffersEqual(byte* left, byte* right, int length)
+    {
+        for (int i = 0; i < length; i++)
+        {
+            if (left[i] != right[i])
+                return false;
+        }
+        return true;
     }
 
     // Both calls below return the engine's `Error` — int-width in C++, `: long`

--- a/src/Dn2Cpp.Transpiler/Compilation.cs
+++ b/src/Dn2Cpp.Transpiler/Compilation.cs
@@ -5696,9 +5696,12 @@ internal sealed partial class Compilation
     /// referenced module stays on the intrinsic/throw boundary (runtime-internal QCalls,
     /// Windows-only libraries). <c>libSystem.Security.Cryptography.Native.Apple</c> is
     /// the <c>AppleCryptoNative_*</c> digest/HMAC/random surface implemented portably in
-    /// <c>runtime/core/intrinsics/dn2cpp_apple_crypto_digest.cpp</c> (+ the posix random
-    /// PAL); the CoreFoundation framework path (Interop.AppleCrypto's cctor) resolves to
-    /// the real framework via <c>-framework CoreFoundation</c>.
+    /// <c>runtime/core/intrinsics/dn2cpp_apple_crypto_digest.cpp</c> plus the
+    /// SystemNative-ABI-only random adapter in
+    /// <c>runtime/core/platform/posix/dn2cpp_apple_crypto_random.cpp</c>. The adapter is
+    /// reused on Web with the wasm entropy backend despite its source-tree location;
+    /// the CoreFoundation framework path (Interop.AppleCrypto's cctor) resolves to the
+    /// real framework via <c>-framework CoreFoundation</c> on Apple hosts.
     /// <c>libSystem.Security.Cryptography.Native.OpenSsl</c> is the same surface for the
     /// Linux RID of the assembly — the <c>CryptoNative_*</c> digest/HMAC/RNG entry points
     /// implemented over the identical portable cores in


### PR DESCRIPTION
## Summary

- include the portable Apple RNG adapter in the Emscripten runtime source set
- exercise both the AppleCryptoNative_GetRandomBytes ABI and the public RandomNumberGenerator API in the Godot Web export sample
- require the CSPRNG browser marker exactly once while preserving import-closure checks

## Verification

- dotnet build src/Dn2Cpp.Cli -c Release
- native CryptoHashCore exact diff against real .NET
- wasm CryptoHashCore exact diff under Node against real .NET
- gates/selfhost-emit.sh: 156-TU byte-for-byte fixpoint
- DN2CPP_GATE_CACHE=0 gates/build-and-run-godot-editor-export-web.sh: prebuilt runtime used, import closure empty, Chrome exit 0, CSPRNG marker reached exactly once
- DN2CPP_GATE_CACHE=0 gates/build-and-run-godot-editor-export-web-hermetic.sh: bundled read-only toolchain and empty import closure

The human pre-merge gate was not run, per repository policy.