### PR TITLE
Keep Apple RNG probe Web-only

### DIFF
--- a/gates/build-and-run-godot-editor-export-ios.sh
+++ b/gates/build-and-run-godot-editor-export-ios.sh
@@ -335,6 +335,7 @@ for marker in \
     "DN2CPP_EXPORT_INTEROP resizeOk=True sized=True" \
     "DN2CPP_EXPORT_SIGNAL awaited=True" \
     "DN2CPP_EXPORT_CLOCK ticks=True elapsed=True" \
+    "DN2CPP_EXPORT_CSPRNG publicEntropy=True" \
     "DN2CPP_EXPORT_DONE"; do
     n="$(grep -cF "$marker" "$SIM_LOG" || true)"
     [ "$n" -eq 1 ] || { echo "FAIL: marker \"$marker\" appeared $n times (expected exactly 1)" >&2; exit 1; }

--- a/gates/build-and-run-godot-editor-export.sh
+++ b/gates/build-and-run-godot-editor-export.sh
@@ -366,11 +366,13 @@ assert_export_artifact_and_run() {
         "DN2CPP_EXPORT_INTEROP resizeOk=True sized=True" \
         "DN2CPP_EXPORT_SIGNAL awaited=True" \
         "DN2CPP_EXPORT_CLOCK ticks=True elapsed=True" \
+        "DN2CPP_EXPORT_CSPRNG publicEntropy=True" \
         "DN2CPP_EXPORT_DONE"; do
         grep -qF "$marker" "$LOG" || { echo "FAIL: missing marker: $marker" >&2; exit 1; }
     done
     for once in "DN2CPP_EXPORT_READY" "DN2CPP_EXPORT_GDPRINT" "DN2CPP_EXPORT_PROCESS" "DN2CPP_EXPORT_GC" \
-        "DN2CPP_EXPORT_INTEROP" "DN2CPP_EXPORT_SIGNAL" "DN2CPP_EXPORT_CLOCK" "DN2CPP_EXPORT_DONE"; do
+        "DN2CPP_EXPORT_INTEROP" "DN2CPP_EXPORT_SIGNAL" "DN2CPP_EXPORT_CLOCK" "DN2CPP_EXPORT_CSPRNG" \
+        "DN2CPP_EXPORT_DONE"; do
         n="$(grep -c "$once" "$LOG" || true)"
         [ "$n" -eq 1 ] || { echo "FAIL: marker $once appeared $n times (expected exactly 1)" >&2; exit 1; }
     done

--- a/samples/godot-dotnet/EditorExportSample/ExportProbe.cs
+++ b/samples/godot-dotnet/EditorExportSample/ExportProbe.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Diagnostics;
+#if GODOT_WEB
 using System.Runtime.InteropServices;
+#endif
 using System.Threading;
 using System.Threading.Tasks;
 using Godot;
@@ -11,8 +13,10 @@ using Godot;
 // packaged runs inside a real exported .app with no .NET runtime beside it.
 public partial class ExportProbe : Node
 {
+#if GODOT_WEB
     [DllImport("libSystem.Security.Cryptography.Native.Apple", EntryPoint = "AppleCryptoNative_GetRandomBytes")]
     private static extern unsafe int AppleCryptoNativeGetRandomBytes(byte* buffer, int length, int* status);
+#endif
 
     // Overridden by the scene: reaching the C# instance through the engine's Set
     // bridge proves the script instance is tied to the native object.
@@ -54,12 +58,13 @@ public partial class ExportProbe : Node
         _ = ProbeSignalAsync();
     }
 
-    // The direct call pins the exact native ABI that the Apple flavor of the real
-    // BCL imports. The public calls prove RandomNumberGenerator reaches the same
-    // real-entropy path. Report only derived properties so the log is deterministic.
+    // The Web-only direct call pins the exact native ABI that its POSIX-flavoured
+    // BCL imports. The public calls prove each target's RandomNumberGenerator reaches
+    // a real-entropy path. Report only derived properties so the log is deterministic.
     private static unsafe void ProbeCsprng()
     {
         const int Length = 32;
+#if GODOT_WEB
         byte* directFirst = stackalloc byte[Length];
         byte* directSecond = stackalloc byte[Length];
         int firstStatus = -1;
@@ -72,6 +77,7 @@ public partial class ExportProbe : Node
         bool directEntropy = HasNonZeroByte(directFirst, Length)
             && HasNonZeroByte(directSecond, Length)
             && !BuffersEqual(directFirst, directSecond, Length);
+#endif
 
         byte[] publicFirst = System.Security.Cryptography.RandomNumberGenerator.GetBytes(Length);
         byte[] publicSecond = System.Security.Cryptography.RandomNumberGenerator.GetBytes(Length);
@@ -79,9 +85,14 @@ public partial class ExportProbe : Node
             && HasNonZeroByte(publicSecond)
             && !publicFirst.AsSpan().SequenceEqual(publicSecond);
 
+#if GODOT_WEB
         Console.WriteLine($"DN2CPP_EXPORT_CSPRNG native={native} directEntropy={directEntropy} publicEntropy={publicEntropy}");
+#else
+        Console.WriteLine($"DN2CPP_EXPORT_CSPRNG publicEntropy={publicEntropy}");
+#endif
     }
 
+#if GODOT_WEB
     private static unsafe bool HasNonZeroByte(byte* buffer, int length)
     {
         for (int i = 0; i < length; i++)
@@ -91,6 +102,7 @@ public partial class ExportProbe : Node
         }
         return false;
     }
+#endif
 
     private static bool HasNonZeroByte(byte[] buffer)
     {
@@ -102,6 +114,7 @@ public partial class ExportProbe : Node
         return false;
     }
 
+#if GODOT_WEB
     private static unsafe bool BuffersEqual(byte* left, byte* right, int length)
     {
         for (int i = 0; i < length; i++)
@@ -111,6 +124,7 @@ public partial class ExportProbe : Node
         }
         return true;
     }
+#endif
 
     // Both calls below return the engine's `Error` — int-width in C++, `: long`
     // in C# because the bindings generator widens every core enum. wasm32 checks


### PR DESCRIPTION
## Summary

- compile the direct AppleCrypto RNG ABI probe only for Godot Web exports
- keep RandomNumberGenerator entropy coverage on every runnable editor-export target
- assert the platform-neutral RNG marker in desktop and iOS gates

## Tests

- bash gates/build-and-run-godot-editor-export.sh
- bash gates/build-and-run-godot-editor-export-web.sh
- bash -n gates/build-and-run-godot-editor-export.sh gates/build-and-run-godot-editor-export-ios.sh gates/build-and-run-godot-editor-export-web.sh

The iOS runtime gate was not run because this is a Windows host.