### PR TITLE
Support Thrive Windows exports

### DIFF
--- a/gates/build-and-run-file-real.sh
+++ b/gates/build-and-run-file-real.sh
@@ -25,7 +25,8 @@
 #   FileAsyncEnumSubset File.ReadLinesAsync — IAsyncEnumerable<string>, `await foreach`
 #   PalIdentitySubset   the same PAL BEYOND file I/O: process id and the passwd
 #                       lookup (Environment.ProcessId / Environment.UserName ->
-#                       SystemNative_{GetPid,GetEUid,GetPwUidR}), plus
+#                       SystemNative_{GetPid,GetEUid,GetPwUidR} on Unix and
+#                       GetCurrentProcessId/GetUserNameExW on Windows), plus
 #                       System.Diagnostics.Process for the two entries no
 #                       CoreLib-only closure can name (HasExited ->
 #                       SystemNative_Kill, SessionId -> SystemNative_GetSid).
@@ -220,17 +221,19 @@ undefined_syms="$out/pal-undefined-syms.txt"
 dump_object_symbols_undefined "$out/.cmake" > "$undefined_syms"
 if [ "$DN2CPP_OS" = windows ]; then
     # Interop.Sys IS the Unix PAL — on Windows the same CoreLib properties bind to
-    # different modules entirely, so there is no SystemNative_* symbol to look for
-    # and the defined half below has no object to read (the Windows PAL is
-    # platform/windows/, and dn2cpp_system_native.cpp is not in that build). The
-    # step still asserts rather than stepping aside: Environment.ProcessId is the
-    # one half that IS portable, lowering to kernel32's GetCurrentProcessId, so
-    # this arm checks that. The passwd half is compiled out of the sample on this
-    # host (FileReal.csproj) because secur32.dll has no lowering at all.
-    grep -qE '^_?GetCurrentProcessId$' "$undefined_syms" || {
-        echo "FAIL: no app object references GetCurrentProcessId — PalIdentitySubset stopped reaching Environment.ProcessId" >&2
+    # kernel32 and secur32 directly, so there is no SystemNative_* symbol to look for
+    # and the defined half below has no object to read. Assert both Windows entry
+    # points from the generated objects.
+    for sym in GetCurrentProcessId GetUserNameExW; do
+        grep -qE "^_?$sym\$" "$undefined_syms" || {
+            echo "FAIL: no app object references $sym — PalIdentitySubset stopped reaching the Windows identity PAL" >&2
+            exit 1; }
+    done
+    grep -q -- '/bigobj' "$out/.cmake/build.ninja" || {
+        echo "FAIL: the MSVC app compile lost /bigobj — large generated registry objects can exceed COFF's section limit" >&2
         exit 1; }
-    echo "OK: the app names GetCurrentProcessId (Interop.Sys is Unix-only; nothing else to assert here)"
+    echo "OK: the app names GetCurrentProcessId and GetUserNameExW"
+    echo "OK: MSVC app objects compile with /bigobj"
 else
     # Non-vacuity first: an empty dump would pass every check below while proving
     # nothing (a stripped artifact, changed mangling, the wrong directory).

--- a/gates/build-and-run-marshal-pinning.sh
+++ b/gates/build-and-run-marshal-pinning.sh
@@ -5,6 +5,7 @@
 # read/write through the raw pointer aliasing the managed backing store (byte[],
 # int[], double[], struct[]); Alloc(obj)/Target/IsAllocated; Marshal native-heap
 # struct marshalling (AllocHGlobal + StructureToPtr/PtrToStructure round-trip,
+# HRESULT conversion (successful values return null; failures preserve HResult),
 # generic and non-generic Type-based forms, mutate-through-buffer = real memcpy);
 # SizeOf/OffsetOf exactly matching real .NET (including the
 # [StructLayout(Size=N)] floor rows — Size is never rounded up to the alignment,

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -913,7 +913,7 @@ else()
         # set (Windows-MSVC.cmake / Windows-GNU.cmake set
         # CMAKE_C_STANDARD_LIBRARIES_INIT to kernel32 user32 gdi32 winspool shell32
         # ole32 oleaut32 uuid comdlg32 advapi32 — so kernel32/ole32/advapi32 need no
-        # explicit link, but ws2_32 and iphlpapi do), and without these the lowered
+        # explicit link, but ws2_32, iphlpapi and secur32 do), and without these the lowered
         # call sites fail at link time with unresolved imports and nothing naming
         # the owning library as the cause. ntdll and BCrypt are outside that
         # default set too: they are on IsRuntimeProvidedPInvokeModule's allowlist
@@ -921,10 +921,11 @@ else()
         # has needed the link yet — a reachable one would fail here exactly as
         # winsock did.
         # PUBLIC so the app's generated*.cpp — whose lowered P/Invoke call sites
-        # reference the platform symbols directly — inherit the link. iphlpapi is
+        # reference the platform symbols directly — inherit the link. secur32 supplies
+        # CoreLib's Environment.UserName primitive GetUserNameExW. iphlpapi is
         # not allowed to arrive incidentally through the optional libcurl target:
         # named IPv6 scopes remain supported with DN2CPP_USE_CURL=OFF.
-        target_link_libraries(dn2cpp_runtime PUBLIC ws2_32 iphlpapi)
+        target_link_libraries(dn2cpp_runtime PUBLIC ws2_32 iphlpapi secur32)
     endif()
     if(DN2CPP_USE_GC)
         # PUBLIC so the app's generated*.cpp inherit the GC define + gc.h include too.
@@ -1201,6 +1202,11 @@ if(DN2CPP_APP_DIR)
         endif()
     endif()
     _dn2cpp_compile_options_warn(${DN2CPP_APP_NAME})
+    # The registry/metadata TU can contain enough COMDAT sections to exceed the
+    # default COFF object limit even though method bodies are split across TUs.
+    if(MSVC)
+        target_compile_options(${DN2CPP_APP_NAME} PRIVATE /bigobj)
+    endif()
     # generated.h lives next to the sources; dn2cpp.h comes from the runtime include
     # dir (also carried transitively, but listed for the from-source build too).
     target_include_directories(${DN2CPP_APP_NAME} PRIVATE

--- a/runtime/core/dn2cpp_core.h
+++ b/runtime/core/dn2cpp_core.h
@@ -2219,6 +2219,9 @@ extern const Dn2CppTypeInfo dn2cpp_exception_type;
 extern Dn2CppTypeInfo dn2cpp_overflow_exception_type;
 extern Dn2CppTypeInfo dn2cpp_index_out_of_range_exception_type;
 extern Dn2CppTypeInfo dn2cpp_argument_exception_type;
+// System.Runtime.InteropServices.COMException. Marshal.GetExceptionForHR uses
+// this for HRESULT failures that have no more specific managed exception.
+extern Dn2CppTypeInfo dn2cpp_com_exception_type;
 extern Dn2CppTypeInfo dn2cpp_argument_out_of_range_exception_type;
 extern Dn2CppTypeInfo dn2cpp_argument_null_exception_type;
 extern Dn2CppTypeInfo dn2cpp_invalid_operation_exception_type;
@@ -2300,6 +2303,11 @@ extern const Dn2CppTypeInfo dn2cpp_aggregate_exception_type;
 // enum, because dn2cpp_resolve_interface_walk consults the base chain and the
 // per-enum type-infos deliberately carry no rows of their own.
 extern Dn2CppTypeInfo dn2cpp_enum_type;
+// SafeHandle's stable runtime handle receives its emitted metadata at startup. The
+// SafeWaitHandle wrapper's intermediate base has the same binding posture, preserving
+// the complete SafeWaitHandle -> SafeHandleZeroOrMinusOneIsInvalid -> SafeHandle chain.
+extern Dn2CppTypeInfo dn2cpp_safehandle_type;
+extern Dn2CppTypeInfo dn2cpp_safehandle_zero_or_minus_one_type;
 // Installs the shared boxed-enum interface-dispatch map (IComparable/IFormattable/
 // IConvertible/ISpanFormattable rows whose slots are System.Enum's transpiled impls —
 // the model makes System.Enum a reference type, so they take the box pointer directly).
@@ -4783,10 +4791,14 @@ Dn2CppObject* dn2cpp_event_new(int32_t initial, int32_t manualReset, const Dn2Cp
 Dn2CppObject* dn2cpp_safewaithandle_new(intptr_t handle, int32_t ownsHandle);
 Dn2CppObject* dn2cpp_waithandle_get_safe(Dn2CppObject* waitHandle);
 void dn2cpp_waithandle_set_safe(Dn2CppObject* waitHandle, Dn2CppObject* safeHandle);
+void dn2cpp_waithandle_close(Dn2CppObject* waitHandle);
 intptr_t dn2cpp_safewaithandle_get(Dn2CppObject* safeHandle);
 int32_t dn2cpp_safewaithandle_is_invalid(Dn2CppObject* safeHandle);
 int32_t dn2cpp_safewaithandle_is_closed(Dn2CppObject* safeHandle);
 void dn2cpp_safewaithandle_close(Dn2CppObject* safeHandle);
+void dn2cpp_safewaithandle_set_invalid(Dn2CppObject* safeHandle);
+int32_t dn2cpp_safewaithandle_addref(Dn2CppObject* safeHandle);
+void dn2cpp_safewaithandle_release(Dn2CppObject* safeHandle);
 void dn2cpp_event_set(Dn2CppObject* e);                      // Set()
 void dn2cpp_event_reset(Dn2CppObject* e);                    // Reset()
 int32_t dn2cpp_event_wait(Dn2CppObject* e);                  // WaitOne()/Wait() (returns 1)

--- a/runtime/core/dn2cpp_core.h
+++ b/runtime/core/dn2cpp_core.h
@@ -2167,6 +2167,7 @@ extern const Dn2CppTypeInfo dn2cpp_event_type;
 extern const Dn2CppTypeInfo dn2cpp_manualresetevent_type;
 extern const Dn2CppTypeInfo dn2cpp_autoresetevent_type;
 extern const Dn2CppTypeInfo dn2cpp_manualreseteventslim_type;
+extern const Dn2CppTypeInfo dn2cpp_safewaithandle_type;
 extern const Dn2CppTypeInfo dn2cpp_array_i4_type;
 extern const Dn2CppTypeInfo dn2cpp_array_ref_type;
 extern const Dn2CppTypeInfo dn2cpp_array_n_type;
@@ -3149,6 +3150,7 @@ struct Dn2CppShadowFrame
 // approximation, since .NET's per-derived-type defaults live in resource strings
 // dn2cpp never reads.
 Dn2CppObject* dn2cpp_exception_new(const Dn2CppTypeInfo* ti, Dn2CppString* message, Dn2CppObject* inner);
+Dn2CppObject* dn2cpp_exception_for_hresult(int32_t hresult);
 // System.Exception.get_Message on an object dn2cpp_exception_new produced, with virtual
 // dispatch: calls a derived get_Message override through the vtable
 // (dn2cpp_exception_get_message_slot) when one is present, else the stored message. This
@@ -4778,6 +4780,13 @@ int32_t dn2cpp_semaphore_count(Dn2CppObject* s);             // SemaphoreSlim.Cu
 // the worker pool and the task completes when a Release hands over a token.
 Dn2CppTask* dn2cpp_semaphore_wait_async(Dn2CppObject* s);
 Dn2CppObject* dn2cpp_event_new(int32_t initial, int32_t manualReset, const Dn2CppTypeInfo* ti);
+Dn2CppObject* dn2cpp_safewaithandle_new(intptr_t handle, int32_t ownsHandle);
+Dn2CppObject* dn2cpp_waithandle_get_safe(Dn2CppObject* waitHandle);
+void dn2cpp_waithandle_set_safe(Dn2CppObject* waitHandle, Dn2CppObject* safeHandle);
+intptr_t dn2cpp_safewaithandle_get(Dn2CppObject* safeHandle);
+int32_t dn2cpp_safewaithandle_is_invalid(Dn2CppObject* safeHandle);
+int32_t dn2cpp_safewaithandle_is_closed(Dn2CppObject* safeHandle);
+void dn2cpp_safewaithandle_close(Dn2CppObject* safeHandle);
 void dn2cpp_event_set(Dn2CppObject* e);                      // Set()
 void dn2cpp_event_reset(Dn2CppObject* e);                    // Reset()
 int32_t dn2cpp_event_wait(Dn2CppObject* e);                  // WaitOne()/Wait() (returns 1)

--- a/runtime/core/dn2cpp_exceptions.cpp
+++ b/runtime/core/dn2cpp_exceptions.cpp
@@ -649,8 +649,16 @@ Dn2CppObject* dn2cpp_exception_for_hresult(int32_t hresult)
 {
     if (hresult >= 0)
         return nullptr;
+
+    const Dn2CppTypeInfo* ti = &dn2cpp_com_exception_type;
+    switch (static_cast<uint32_t>(hresult))
+    {
+        case 0x80070057u: ti = &dn2cpp_argument_exception_type; break;
+        case 0x8007000Eu: ti = &dn2cpp_out_of_memory_exception_type; break;
+        case 0x80070005u: ti = &dn2cpp_unauthorized_access_exception_type; break;
+    }
     auto* ex = reinterpret_cast<Dn2CppExceptionObject*>(
-        dn2cpp_exception_new(&dn2cpp_exception_type, nullptr, nullptr));
+        dn2cpp_exception_new(ti, dn2cpp_default_message(ti), nullptr));
     ex->hresult = hresult;
     return ex;
 }

--- a/runtime/core/dn2cpp_exceptions.cpp
+++ b/runtime/core/dn2cpp_exceptions.cpp
@@ -645,6 +645,16 @@ Dn2CppObject* dn2cpp_exception_new(const Dn2CppTypeInfo* ti, Dn2CppString* messa
     return e;
 }
 
+Dn2CppObject* dn2cpp_exception_for_hresult(int32_t hresult)
+{
+    if (hresult >= 0)
+        return nullptr;
+    auto* ex = reinterpret_cast<Dn2CppExceptionObject*>(
+        dn2cpp_exception_new(&dn2cpp_exception_type, nullptr, nullptr));
+    ex->hresult = hresult;
+    return ex;
+}
+
 // Exception.get_InnerException on an object dn2cpp_exception_new produced.
 Dn2CppObject* dn2cpp_exception_inner(Dn2CppObject* ex)
 {
@@ -1534,4 +1544,3 @@ Dn2CppArrayRef* dn2cpp_aggregate_inner_exceptions(Dn2CppObject* ex, const Dn2Cpp
         a->type = arrTi;
     return a;
 }
-

--- a/runtime/core/dn2cpp_threading.cpp
+++ b/runtime/core/dn2cpp_threading.cpp
@@ -735,7 +735,7 @@ const Dn2CppTypeInfo dn2cpp_manualreseteventslim_type =
 const Dn2CppType dn2cpp_manualreseteventslim_type_obj = { { &dn2cpp_type_type }, &dn2cpp_manualreseteventslim_type };
 extern const Dn2CppType dn2cpp_safewaithandle_type_obj;
 const Dn2CppTypeInfo dn2cpp_safewaithandle_type =
-    dn2cpp_ti_with_typeobject({ "Microsoft.Win32.SafeHandles.SafeWaitHandle", nullptr, 0, nullptr, nullptr, 0, nullptr, nullptr, nullptr, DN2CPP_TF_NO_SHALLOW_CLONE }, &dn2cpp_safewaithandle_type_obj);
+    dn2cpp_ti_with_typeobject({ "Microsoft.Win32.SafeHandles.SafeWaitHandle", &dn2cpp_safehandle_zero_or_minus_one_type, 0, nullptr, nullptr, 0, nullptr, nullptr, nullptr, DN2CPP_TF_NO_SHALLOW_CLONE }, &dn2cpp_safewaithandle_type_obj);
 const Dn2CppType dn2cpp_safewaithandle_type_obj = { { &dn2cpp_type_type }, &dn2cpp_safewaithandle_type };
 
 struct Dn2CppSemaphore : Dn2CppObject
@@ -752,14 +752,17 @@ struct Dn2CppEvent : Dn2CppObject
     std::condition_variable cv;
     bool signaled;
     bool manualReset;
+    bool closed;
 };
 
 struct Dn2CppSafeWaitHandle : Dn2CppObject
 {
+    std::mutex m;
     intptr_t handle;
     bool ownsHandle;
     bool managedEvent;
     bool closed;
+    uint32_t dangerousRefs;
 };
 
 static std::mutex g_wait_handle_mutex;
@@ -861,6 +864,7 @@ Dn2CppObject* dn2cpp_event_new(int32_t initial, int32_t manualReset, const Dn2Cp
     e->type = ti != nullptr ? ti : &dn2cpp_event_type;
     e->signaled = initial != 0;
     e->manualReset = manualReset != 0;
+    e->closed = false;
     return e;
 }
 
@@ -879,6 +883,15 @@ Dn2CppObject* dn2cpp_safewaithandle_new(intptr_t handle, int32_t ownsHandle)
     safe->ownsHandle = ownsHandle != 0;
     safe->managedEvent = false;
     safe->closed = false;
+    safe->dangerousRefs = 0;
+    return safe;
+}
+
+static Dn2CppSafeWaitHandle* dn2cpp_managed_event_safe(Dn2CppObject* waitHandle)
+{
+    auto* safe = static_cast<Dn2CppSafeWaitHandle*>(
+        dn2cpp_safewaithandle_new(reinterpret_cast<intptr_t>(waitHandle), 0));
+    safe->managedEvent = true;
     return safe;
 }
 
@@ -890,9 +903,7 @@ Dn2CppObject* dn2cpp_waithandle_get_safe(Dn2CppObject* waitHandle)
     auto it = g_wait_safe_handles.find(waitHandle);
     if (it == g_wait_safe_handles.end())
     {
-        auto* safe = static_cast<Dn2CppSafeWaitHandle*>(
-            dn2cpp_safewaithandle_new(reinterpret_cast<intptr_t>(waitHandle), 0));
-        safe->managedEvent = true;
+        auto* safe = dn2cpp_managed_event_safe(waitHandle);
         it = g_wait_safe_handles.emplace(waitHandle, safe).first;
     }
     return it->second;
@@ -903,12 +914,18 @@ void dn2cpp_waithandle_set_safe(Dn2CppObject* waitHandle, Dn2CppObject* safeHand
     if (waitHandle == nullptr)
         dn2cpp_throw_null_reference();
     std::lock_guard<std::mutex> lk(g_wait_handle_mutex);
-    g_wait_safe_handles[waitHandle] = safeHandle;
+    // SafeWaitHandle's nullable setter uses null to clear the OS handle. The next
+    // getter returns a real invalid wrapper rather than null; retaining a null map
+    // value would make every event operation dereference it.
+    g_wait_safe_handles[waitHandle] = safeHandle != nullptr
+        ? safeHandle : dn2cpp_safewaithandle_new(0, 0);
 }
 
 intptr_t dn2cpp_safewaithandle_get(Dn2CppObject* safeHandle)
 {
-    return dn2cpp_as_safe_handle(safeHandle)->handle;
+    auto* safe = dn2cpp_as_safe_handle(safeHandle);
+    std::lock_guard<std::mutex> lk(safe->m);
+    return safe->handle;
 }
 
 int32_t dn2cpp_safewaithandle_is_invalid(Dn2CppObject* safeHandle)
@@ -916,26 +933,117 @@ int32_t dn2cpp_safewaithandle_is_invalid(Dn2CppObject* safeHandle)
     if (safeHandle == nullptr)
         return 1;
     auto* safe = static_cast<Dn2CppSafeWaitHandle*>(safeHandle);
+    std::lock_guard<std::mutex> lk(safe->m);
     return safe->handle == 0 || safe->handle == static_cast<intptr_t>(-1) ? 1 : 0;
 }
 
 int32_t dn2cpp_safewaithandle_is_closed(Dn2CppObject* safeHandle)
 {
-    return dn2cpp_as_safe_handle(safeHandle)->closed ? 1 : 0;
+    auto* safe = dn2cpp_as_safe_handle(safeHandle);
+    std::lock_guard<std::mutex> lk(safe->m);
+    return safe->closed ? 1 : 0;
+}
+
+static void dn2cpp_safewaithandle_release_locked(Dn2CppSafeWaitHandle* safe)
+{
+    if (safe->handle == 0 || safe->handle == static_cast<intptr_t>(-1))
+        return;
+    if (safe->managedEvent)
+    {
+        auto* e = reinterpret_cast<Dn2CppEvent*>(safe->handle);
+        {
+            std::lock_guard<std::mutex> lk(e->m);
+            e->closed = true;
+        }
+        e->cv.notify_all();
+    }
+#ifdef _WIN32
+    else if (safe->ownsHandle)
+        ::CloseHandle(reinterpret_cast<HANDLE>(safe->handle));
+#endif
 }
 
 void dn2cpp_safewaithandle_close(Dn2CppObject* safeHandle)
 {
     auto* safe = dn2cpp_as_safe_handle(safeHandle);
+    std::lock_guard<std::mutex> lk(safe->m);
     if (safe->closed)
         return;
-#ifdef _WIN32
-    if (safe->ownsHandle && !safe->managedEvent && safe->handle != 0
-        && safe->handle != static_cast<intptr_t>(-1))
-        ::CloseHandle(reinterpret_cast<HANDLE>(safe->handle));
-#endif
     safe->closed = true;
-    safe->handle = 0;
+    // Close becomes visible immediately, but an OS handle protected by
+    // DangerousAddRef stays live until the matching DangerousRelease.
+    if (safe->dangerousRefs == 0)
+        dn2cpp_safewaithandle_release_locked(safe);
+}
+
+void dn2cpp_safewaithandle_set_invalid(Dn2CppObject* safeHandle)
+{
+    auto* safe = dn2cpp_as_safe_handle(safeHandle);
+    std::lock_guard<std::mutex> lk(safe->m);
+    // SafeHandle.SetHandleAsInvalid suppresses release without changing the raw
+    // handle. IsClosed becomes true immediately; IsInvalid remains a property of
+    // the handle value (zero or minus one for SafeWaitHandle).
+    safe->closed = true;
+    safe->ownsHandle = false;
+    safe->managedEvent = false;
+}
+
+int32_t dn2cpp_safewaithandle_addref(Dn2CppObject* safeHandle)
+{
+    auto* safe = dn2cpp_as_safe_handle(safeHandle);
+    std::lock_guard<std::mutex> lk(safe->m);
+    if (safe->closed)
+        dn2cpp_throw_object_disposed();
+    safe->dangerousRefs++;
+    return 1;
+}
+
+void dn2cpp_safewaithandle_release(Dn2CppObject* safeHandle)
+{
+    auto* safe = dn2cpp_as_safe_handle(safeHandle);
+    std::lock_guard<std::mutex> lk(safe->m);
+    if (safe->dangerousRefs == 0)
+        dn2cpp_throw_invalid_operation();
+    safe->dangerousRefs--;
+    if (safe->closed && safe->dangerousRefs == 0)
+        dn2cpp_safewaithandle_release_locked(safe);
+}
+
+void dn2cpp_waithandle_close(Dn2CppObject* waitHandle)
+{
+    if (waitHandle == nullptr)
+        dn2cpp_throw_null_reference();
+    Dn2CppSafeWaitHandle* safe = nullptr;
+    bool runtimeEvent = waitHandle->type == &dn2cpp_event_type
+        || waitHandle->type == &dn2cpp_manualresetevent_type
+        || waitHandle->type == &dn2cpp_autoresetevent_type;
+    {
+        std::lock_guard<std::mutex> lk(g_wait_handle_mutex);
+        auto it = g_wait_safe_handles.find(waitHandle);
+        if (it != g_wait_safe_handles.end())
+        {
+            safe = static_cast<Dn2CppSafeWaitHandle*>(it->second);
+            // A managed WaitHandle subclass can borrow another runtime event's
+            // SafeWaitHandle. Disposing the borrower detaches that alias; it must not
+            // close the donor event that still owns the condition variable.
+            if (!runtimeEvent)
+            {
+                std::lock_guard<std::mutex> slk(safe->m);
+                if (safe->managedEvent)
+                {
+                    it->second = dn2cpp_safewaithandle_new(0, 0);
+                    safe = nullptr;
+                }
+            }
+        }
+        else if (runtimeEvent)
+        {
+            safe = dn2cpp_managed_event_safe(waitHandle);
+            g_wait_safe_handles.emplace(waitHandle, safe);
+        }
+    }
+    if (safe != nullptr)
+        dn2cpp_safewaithandle_close(safe);
 }
 
 static Dn2CppEvent* dn2cpp_event_from_operand(Dn2CppObject* o,
@@ -946,8 +1054,15 @@ static Dn2CppEvent* dn2cpp_event_from_operand(Dn2CppObject* o,
     if (o->type == &dn2cpp_safewaithandle_type)
     {
         auto* safe = static_cast<Dn2CppSafeWaitHandle*>(o);
+        std::lock_guard<std::mutex> lk(safe->m);
+        if (safe->closed)
+            dn2cpp_throw_object_disposed();
         if (safe->managedEvent)
+        {
+            if (safe->handle == 0)
+                dn2cpp_throw_object_disposed();
             return reinterpret_cast<Dn2CppEvent*>(safe->handle);
+        }
         *external = safe;
         return nullptr;
     }
@@ -957,8 +1072,15 @@ static Dn2CppEvent* dn2cpp_event_from_operand(Dn2CppObject* o,
         if (it != g_wait_safe_handles.end())
         {
             auto* safe = static_cast<Dn2CppSafeWaitHandle*>(it->second);
+            std::lock_guard<std::mutex> slk(safe->m);
+            if (safe->closed)
+                dn2cpp_throw_object_disposed();
             if (safe->managedEvent)
+            {
+                if (safe->handle == 0)
+                    dn2cpp_throw_object_disposed();
                 return reinterpret_cast<Dn2CppEvent*>(safe->handle);
+            }
             *external = safe;
             return nullptr;
         }
@@ -973,8 +1095,11 @@ static Dn2CppEvent* dn2cpp_event_from_operand(Dn2CppObject* o,
 static int32_t dn2cpp_external_wait(Dn2CppSafeWaitHandle* safe, int32_t ms)
 {
 #ifdef _WIN32
+    dn2cpp_safewaithandle_addref(safe);
+    intptr_t raw = dn2cpp_safewaithandle_get(safe);
     DWORD timeout = ms < 0 ? INFINITE : static_cast<DWORD>(ms);
-    DWORD result = ::WaitForSingleObject(reinterpret_cast<HANDLE>(safe->handle), timeout);
+    DWORD result = ::WaitForSingleObject(reinterpret_cast<HANDLE>(raw), timeout);
+    dn2cpp_safewaithandle_release(safe);
     if (result == WAIT_OBJECT_0)
         return 1;
     if (result == WAIT_TIMEOUT)
@@ -994,7 +1119,11 @@ void dn2cpp_event_set(Dn2CppObject* o)
     if (external != nullptr)
     {
 #ifdef _WIN32
-        if (::SetEvent(reinterpret_cast<HANDLE>(external->handle)) == 0)
+        dn2cpp_safewaithandle_addref(external);
+        intptr_t raw = dn2cpp_safewaithandle_get(external);
+        BOOL result = ::SetEvent(reinterpret_cast<HANDLE>(raw));
+        dn2cpp_safewaithandle_release(external);
+        if (result == 0)
             dn2cpp_throw_invalid_operation();
         return;
 #else
@@ -1003,6 +1132,8 @@ void dn2cpp_event_set(Dn2CppObject* o)
     }
     {
         std::lock_guard<std::mutex> lk(e->m);
+        if (e->closed)
+            dn2cpp_throw_object_disposed();
         e->signaled = true;
     }
     // A manual-reset event releases all waiters; an auto-reset event releases one.
@@ -1019,7 +1150,11 @@ void dn2cpp_event_reset(Dn2CppObject* o)
     if (external != nullptr)
     {
 #ifdef _WIN32
-        if (::ResetEvent(reinterpret_cast<HANDLE>(external->handle)) == 0)
+        dn2cpp_safewaithandle_addref(external);
+        intptr_t raw = dn2cpp_safewaithandle_get(external);
+        BOOL result = ::ResetEvent(reinterpret_cast<HANDLE>(raw));
+        dn2cpp_safewaithandle_release(external);
+        if (result == 0)
             dn2cpp_throw_invalid_operation();
         return;
 #else
@@ -1027,6 +1162,8 @@ void dn2cpp_event_reset(Dn2CppObject* o)
 #endif
     }
     std::lock_guard<std::mutex> lk(e->m);
+    if (e->closed)
+        dn2cpp_throw_object_disposed();
     e->signaled = false;
 }
 
@@ -1037,7 +1174,9 @@ int32_t dn2cpp_event_wait(Dn2CppObject* o)
     if (external != nullptr)
         return dn2cpp_external_wait(external, -1);
     std::unique_lock<std::mutex> lk(e->m);
-    e->cv.wait(lk, [e] { return e->signaled; });
+    e->cv.wait(lk, [e] { return e->signaled || e->closed; });
+    if (e->closed)
+        dn2cpp_throw_object_disposed();
     if (!e->manualReset)
         e->signaled = false; // auto-reset consumes the signal on release
     return 1;                // WaitOne()/Wait() report success (signaled)
@@ -1055,8 +1194,11 @@ int32_t dn2cpp_event_wait_timeout(Dn2CppObject* o, int32_t ms)
     if (external != nullptr)
         return dn2cpp_external_wait(external, ms);
     std::unique_lock<std::mutex> lk(e->m);
-    if (!e->cv.wait_for(lk, std::chrono::milliseconds(ms), [e] { return e->signaled; }))
+    if (!e->cv.wait_for(lk, std::chrono::milliseconds(ms),
+            [e] { return e->signaled || e->closed; }))
         return 0;
+    if (e->closed)
+        dn2cpp_throw_object_disposed();
     if (!e->manualReset)
         e->signaled = false;
     return 1;
@@ -1066,15 +1208,33 @@ int32_t dn2cpp_event_is_set(Dn2CppObject* o)
 {
     auto* e = static_cast<Dn2CppEvent*>(o);
     std::lock_guard<std::mutex> lk(e->m);
+    if (e->closed)
+        dn2cpp_throw_object_disposed();
     return e->signaled ? 1 : 0;
 }
 
+static int32_t dn2cpp_event_try_wait(Dn2CppObject* o)
+{
+    Dn2CppSafeWaitHandle* external = nullptr;
+    auto* e = dn2cpp_event_from_operand(o, &external);
+    if (external != nullptr)
+        return dn2cpp_external_wait(external, 0);
+    std::lock_guard<std::mutex> lk(e->m);
+    if (e->closed)
+        dn2cpp_throw_object_disposed();
+    if (!e->signaled)
+        return 0;
+    if (!e->manualReset)
+        e->signaled = false;
+    return 1;
+}
+
 // WaitHandle.WaitAny(WaitHandle[]): block until ANY handle is signaled, returning its
-// index. Each handle is a native Dn2CppEvent (ManualResetEvent/AutoResetEvent, both
-// derive WaitHandle). A round-robin non-blocking scan checks each event's signaled flag —
-// consuming it for an auto-reset event, exactly like a single dn2cpp_event_wait — and
-// returns the first ready index; when none is ready it sleeps briefly and retries (a
-// polling wait: there is no shared condition variable to block on across the whole set).
+// index. A round-robin non-blocking scan resolves each operand through the same
+// SafeWaitHandle mapping as WaitOne, then consumes an auto-reset signal exactly once.
+// Windows OS handles use WaitForSingleObject(0); runtime events use their mutex. When
+// none is ready the loop sleeps briefly and retries (there is no shared condition
+// variable across the heterogeneous set).
 // Argument checks match real .NET: a null array or a null element throws
 // ArgumentNullException, an empty array throws ArgumentException. The timed
 // WaitAny(..., int/TimeSpan) overloads stay unmapped.
@@ -1091,14 +1251,8 @@ int32_t dn2cpp_event_wait_any(Dn2CppArrayRef* handles)
     {
         for (int32_t i = 0; i < handles->length; i++)
         {
-            auto* e = static_cast<Dn2CppEvent*>(handles->data[i]);
-            std::lock_guard<std::mutex> lk(e->m);
-            if (e->signaled)
-            {
-                if (!e->manualReset)
-                    e->signaled = false; // auto-reset consumes the signal, like dn2cpp_event_wait
+            if (dn2cpp_event_try_wait(handles->data[i]))
                 return i;
-            }
         }
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }

--- a/runtime/core/dn2cpp_threading.cpp
+++ b/runtime/core/dn2cpp_threading.cpp
@@ -733,6 +733,10 @@ extern const Dn2CppType dn2cpp_manualreseteventslim_type_obj;
 const Dn2CppTypeInfo dn2cpp_manualreseteventslim_type =
     dn2cpp_ti_with_typeobject({ "System.Threading.ManualResetEventSlim", nullptr, 0, nullptr, nullptr, 0, nullptr, nullptr, nullptr, DN2CPP_TF_NO_SHALLOW_CLONE }, &dn2cpp_manualreseteventslim_type_obj);
 const Dn2CppType dn2cpp_manualreseteventslim_type_obj = { { &dn2cpp_type_type }, &dn2cpp_manualreseteventslim_type };
+extern const Dn2CppType dn2cpp_safewaithandle_type_obj;
+const Dn2CppTypeInfo dn2cpp_safewaithandle_type =
+    dn2cpp_ti_with_typeobject({ "Microsoft.Win32.SafeHandles.SafeWaitHandle", nullptr, 0, nullptr, nullptr, 0, nullptr, nullptr, nullptr, DN2CPP_TF_NO_SHALLOW_CLONE }, &dn2cpp_safewaithandle_type_obj);
+const Dn2CppType dn2cpp_safewaithandle_type_obj = { { &dn2cpp_type_type }, &dn2cpp_safewaithandle_type };
 
 struct Dn2CppSemaphore : Dn2CppObject
 {
@@ -749,6 +753,17 @@ struct Dn2CppEvent : Dn2CppObject
     bool signaled;
     bool manualReset;
 };
+
+struct Dn2CppSafeWaitHandle : Dn2CppObject
+{
+    intptr_t handle;
+    bool ownsHandle;
+    bool managedEvent;
+    bool closed;
+};
+
+static std::mutex g_wait_handle_mutex;
+static std::unordered_map<Dn2CppObject*, Dn2CppObject*> g_wait_safe_handles;
 
 Dn2CppObject* dn2cpp_semaphore_new(int32_t initial, int32_t maxCount)
 {
@@ -849,9 +864,143 @@ Dn2CppObject* dn2cpp_event_new(int32_t initial, int32_t manualReset, const Dn2Cp
     return e;
 }
 
+static Dn2CppSafeWaitHandle* dn2cpp_as_safe_handle(Dn2CppObject* o)
+{
+    if (o == nullptr)
+        dn2cpp_throw_null_reference();
+    return static_cast<Dn2CppSafeWaitHandle*>(o);
+}
+
+Dn2CppObject* dn2cpp_safewaithandle_new(intptr_t handle, int32_t ownsHandle)
+{
+    auto* safe = new Dn2CppSafeWaitHandle();
+    safe->type = &dn2cpp_safewaithandle_type;
+    safe->handle = handle;
+    safe->ownsHandle = ownsHandle != 0;
+    safe->managedEvent = false;
+    safe->closed = false;
+    return safe;
+}
+
+Dn2CppObject* dn2cpp_waithandle_get_safe(Dn2CppObject* waitHandle)
+{
+    if (waitHandle == nullptr)
+        dn2cpp_throw_null_reference();
+    std::lock_guard<std::mutex> lk(g_wait_handle_mutex);
+    auto it = g_wait_safe_handles.find(waitHandle);
+    if (it == g_wait_safe_handles.end())
+    {
+        auto* safe = static_cast<Dn2CppSafeWaitHandle*>(
+            dn2cpp_safewaithandle_new(reinterpret_cast<intptr_t>(waitHandle), 0));
+        safe->managedEvent = true;
+        it = g_wait_safe_handles.emplace(waitHandle, safe).first;
+    }
+    return it->second;
+}
+
+void dn2cpp_waithandle_set_safe(Dn2CppObject* waitHandle, Dn2CppObject* safeHandle)
+{
+    if (waitHandle == nullptr)
+        dn2cpp_throw_null_reference();
+    std::lock_guard<std::mutex> lk(g_wait_handle_mutex);
+    g_wait_safe_handles[waitHandle] = safeHandle;
+}
+
+intptr_t dn2cpp_safewaithandle_get(Dn2CppObject* safeHandle)
+{
+    return dn2cpp_as_safe_handle(safeHandle)->handle;
+}
+
+int32_t dn2cpp_safewaithandle_is_invalid(Dn2CppObject* safeHandle)
+{
+    if (safeHandle == nullptr)
+        return 1;
+    auto* safe = static_cast<Dn2CppSafeWaitHandle*>(safeHandle);
+    return safe->handle == 0 || safe->handle == static_cast<intptr_t>(-1) ? 1 : 0;
+}
+
+int32_t dn2cpp_safewaithandle_is_closed(Dn2CppObject* safeHandle)
+{
+    return dn2cpp_as_safe_handle(safeHandle)->closed ? 1 : 0;
+}
+
+void dn2cpp_safewaithandle_close(Dn2CppObject* safeHandle)
+{
+    auto* safe = dn2cpp_as_safe_handle(safeHandle);
+    if (safe->closed)
+        return;
+#ifdef _WIN32
+    if (safe->ownsHandle && !safe->managedEvent && safe->handle != 0
+        && safe->handle != static_cast<intptr_t>(-1))
+        ::CloseHandle(reinterpret_cast<HANDLE>(safe->handle));
+#endif
+    safe->closed = true;
+    safe->handle = 0;
+}
+
+static Dn2CppEvent* dn2cpp_event_from_operand(Dn2CppObject* o,
+    Dn2CppSafeWaitHandle** external)
+{
+    if (o == nullptr)
+        dn2cpp_throw_null_reference();
+    if (o->type == &dn2cpp_safewaithandle_type)
+    {
+        auto* safe = static_cast<Dn2CppSafeWaitHandle*>(o);
+        if (safe->managedEvent)
+            return reinterpret_cast<Dn2CppEvent*>(safe->handle);
+        *external = safe;
+        return nullptr;
+    }
+    {
+        std::lock_guard<std::mutex> lk(g_wait_handle_mutex);
+        auto it = g_wait_safe_handles.find(o);
+        if (it != g_wait_safe_handles.end())
+        {
+            auto* safe = static_cast<Dn2CppSafeWaitHandle*>(it->second);
+            if (safe->managedEvent)
+                return reinterpret_cast<Dn2CppEvent*>(safe->handle);
+            *external = safe;
+            return nullptr;
+        }
+    }
+    if (o->type == &dn2cpp_waithandle_type)
+    {
+        dn2cpp_throw_invalid_operation();
+    }
+    return static_cast<Dn2CppEvent*>(o);
+}
+
+static int32_t dn2cpp_external_wait(Dn2CppSafeWaitHandle* safe, int32_t ms)
+{
+#ifdef _WIN32
+    DWORD timeout = ms < 0 ? INFINITE : static_cast<DWORD>(ms);
+    DWORD result = ::WaitForSingleObject(reinterpret_cast<HANDLE>(safe->handle), timeout);
+    if (result == WAIT_OBJECT_0)
+        return 1;
+    if (result == WAIT_TIMEOUT)
+        return 0;
+    dn2cpp_throw_invalid_operation();
+#else
+    (void)safe;
+    (void)ms;
+    dn2cpp_throw_platform_not_supported("OS-backed WaitHandle is only available on Windows");
+#endif
+}
+
 void dn2cpp_event_set(Dn2CppObject* o)
 {
-    auto* e = static_cast<Dn2CppEvent*>(o);
+    Dn2CppSafeWaitHandle* external = nullptr;
+    auto* e = dn2cpp_event_from_operand(o, &external);
+    if (external != nullptr)
+    {
+#ifdef _WIN32
+        if (::SetEvent(reinterpret_cast<HANDLE>(external->handle)) == 0)
+            dn2cpp_throw_invalid_operation();
+        return;
+#else
+        dn2cpp_throw_platform_not_supported("OS-backed WaitHandle is only available on Windows");
+#endif
+    }
     {
         std::lock_guard<std::mutex> lk(e->m);
         e->signaled = true;
@@ -865,14 +1014,28 @@ void dn2cpp_event_set(Dn2CppObject* o)
 
 void dn2cpp_event_reset(Dn2CppObject* o)
 {
-    auto* e = static_cast<Dn2CppEvent*>(o);
+    Dn2CppSafeWaitHandle* external = nullptr;
+    auto* e = dn2cpp_event_from_operand(o, &external);
+    if (external != nullptr)
+    {
+#ifdef _WIN32
+        if (::ResetEvent(reinterpret_cast<HANDLE>(external->handle)) == 0)
+            dn2cpp_throw_invalid_operation();
+        return;
+#else
+        dn2cpp_throw_platform_not_supported("OS-backed WaitHandle is only available on Windows");
+#endif
+    }
     std::lock_guard<std::mutex> lk(e->m);
     e->signaled = false;
 }
 
 int32_t dn2cpp_event_wait(Dn2CppObject* o)
 {
-    auto* e = static_cast<Dn2CppEvent*>(o);
+    Dn2CppSafeWaitHandle* external = nullptr;
+    auto* e = dn2cpp_event_from_operand(o, &external);
+    if (external != nullptr)
+        return dn2cpp_external_wait(external, -1);
     std::unique_lock<std::mutex> lk(e->m);
     e->cv.wait(lk, [e] { return e->signaled; });
     if (!e->manualReset)
@@ -887,7 +1050,10 @@ int32_t dn2cpp_event_wait_timeout(Dn2CppObject* o, int32_t ms)
 {
     if (ms < 0)
         return dn2cpp_event_wait(o);
-    auto* e = static_cast<Dn2CppEvent*>(o);
+    Dn2CppSafeWaitHandle* external = nullptr;
+    auto* e = dn2cpp_event_from_operand(o, &external);
+    if (external != nullptr)
+        return dn2cpp_external_wait(external, ms);
     std::unique_lock<std::mutex> lk(e->m);
     if (!e->cv.wait_for(lk, std::chrono::milliseconds(ms), [e] { return e->signaled; }))
         return 0;

--- a/runtime/core/dn2cpp_typeinfo.cpp
+++ b/runtime/core/dn2cpp_typeinfo.cpp
@@ -559,6 +559,19 @@ Dn2CppTypeInfo dn2cpp_enum_type =
     dn2cpp_ti_with_typeobject({ "System.Enum", nullptr, 0, nullptr, nullptr, 0 }, &dn2cpp_enum_type_obj);
 const Dn2CppType dn2cpp_enum_type_obj = { { &dn2cpp_type_type }, &dn2cpp_enum_type };
 
+// SafeWaitHandle is runtime-allocated, but its inherited SafeHandle methods and
+// reflection metadata are emitted from CoreLib. Keep one stable base handle and let
+// dn2cpp_type_binds replace this stub with that complete emitted metadata at startup.
+extern const Dn2CppType dn2cpp_safehandle_type_obj;
+Dn2CppTypeInfo dn2cpp_safehandle_type =
+    dn2cpp_ti_with_typeobject({ "System.Runtime.InteropServices.SafeHandle", nullptr, 0, nullptr, nullptr, 0 }, &dn2cpp_safehandle_type_obj);
+const Dn2CppType dn2cpp_safehandle_type_obj = { { &dn2cpp_type_type }, &dn2cpp_safehandle_type };
+extern const Dn2CppType dn2cpp_safehandle_zero_or_minus_one_type_obj;
+Dn2CppTypeInfo dn2cpp_safehandle_zero_or_minus_one_type =
+    dn2cpp_ti_with_typeobject({ "Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid", &dn2cpp_safehandle_type, 0, nullptr, nullptr, 0 }, &dn2cpp_safehandle_zero_or_minus_one_type_obj);
+const Dn2CppType dn2cpp_safehandle_zero_or_minus_one_type_obj =
+    { { &dn2cpp_type_type }, &dn2cpp_safehandle_zero_or_minus_one_type };
+
 void dn2cpp_enum_set_interfaces(const Dn2CppInterfaceEntry* entries, int32_t count)
 {
     dn2cpp_enum_type.interfaces = entries;
@@ -583,6 +596,10 @@ extern const Dn2CppType dn2cpp_argument_exception_type_obj;
 Dn2CppTypeInfo dn2cpp_argument_exception_type =
     dn2cpp_ti_with_typeobject({ "System.ArgumentException", &dn2cpp_exception_type, 0, nullptr, nullptr, 0 }, &dn2cpp_argument_exception_type_obj);
 const Dn2CppType dn2cpp_argument_exception_type_obj = { { &dn2cpp_type_type }, &dn2cpp_argument_exception_type };
+extern const Dn2CppType dn2cpp_com_exception_type_obj;
+Dn2CppTypeInfo dn2cpp_com_exception_type =
+    dn2cpp_ti_with_typeobject({ "System.Runtime.InteropServices.COMException", &dn2cpp_exception_type, 0, nullptr, nullptr, 0 }, &dn2cpp_com_exception_type_obj);
+const Dn2CppType dn2cpp_com_exception_type_obj = { { &dn2cpp_type_type }, &dn2cpp_com_exception_type };
 extern const Dn2CppType dn2cpp_argument_out_of_range_exception_type_obj;
 Dn2CppTypeInfo dn2cpp_argument_out_of_range_exception_type =
     dn2cpp_ti_with_typeobject({ "System.ArgumentOutOfRangeException", &dn2cpp_argument_exception_type, 0, nullptr, nullptr, 0 }, &dn2cpp_argument_out_of_range_exception_type_obj);

--- a/samples/dotnet/FileReal/FileReal.csproj
+++ b/samples/dotnet/FileReal/FileReal.csproj
@@ -9,15 +9,12 @@
     <DebugType>none</DebugType>
   </PropertyGroup>
 
-  <!-- PalIdentitySubset's passwd half is Interop.Sys, which exists only on Unix.
-       On Windows the same Environment.UserName property is Interop.Secur32's
-       GetUserNameExW, and secur32.dll is not in
-       Compilation.IsRuntimeProvidedPInvokeModule — so the call has no IL body and
-       no lowering, and the TRANSPILE fails rather than the link. A runtime
-       OperatingSystem.IsWindows() test would not help: reachability is static and
-       dn2cpp does not fold that predicate, so the unreachable branch is still
-       decoded. Hence a compile-time constant, keyed on the build host, which is
-       also the run host for every gate. -->
+  <!-- PalIdentitySubset's System.Diagnostics.Process half is Interop.Sys and
+       libproc-specific. A runtime OperatingSystem.IsWindows() test would not help:
+       reachability is static and dn2cpp does not fold that predicate, so the
+       unreachable branch is still decoded. Keep that half behind a compile-time
+       constant keyed on the build host, which is also the run host for every gate.
+       Environment.UserName itself runs on every host. -->
   <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
     <DefineConstants>$(DefineConstants);DN2CPP_HOST_WINDOWS</DefineConstants>
   </PropertyGroup>

--- a/samples/dotnet/FileReal/PalIdentitySubset.cs
+++ b/samples/dotnet/FileReal/PalIdentitySubset.cs
@@ -1,12 +1,11 @@
 #nullable enable
 using System;
 
-// The libSystem.Native PAL beyond file I/O — process and passwd identity
-// (SystemNative_GetPid, GetEUid, GetPwUidR, plus GetSid and Kill through
-// System.Diagnostics.Process). Nothing on this path is intercepted: Environment.UserName
-// is `GetUserNameFromPasswd(GetEUid())`, verbatim real CoreLib IL over a
-// [DllImport("libSystem.Native")] lowered to dn2cpp's shim in
-// runtime/core/platform/posix/dn2cpp_system_native.cpp.
+// The platform identity PAL beyond file I/O. Nothing on this path is intercepted:
+// Environment.UserName runs verbatim real CoreLib IL over either libSystem.Native's
+// GetEUid/GetPwUidR or secur32's GetUserNameExW. The Unix symbols lower to dn2cpp's
+// shim in runtime/core/platform/posix/dn2cpp_system_native.cpp; the Windows symbol
+// direct-links to the OS import library.
 //
 // A regression here is a C++ LINK error rather than wrong output, so a section that merely
 // REACHES these symbols is already an assertion.
@@ -32,15 +31,7 @@ static class Program
         Console.WriteLine("positive: " + (pid > 0));
         Console.WriteLine("stable: " + (pid == Environment.ProcessId));
 
-#if DN2CPP_HOST_WINDOWS
-        // Environment.ProcessId above is portable — on Windows it lowers to
-        // kernel32's GetCurrentProcessId, a module dn2cpp does provide. The passwd
-        // lookup is not: see FileReal.csproj for why this is a compile-time arm and
-        // not a runtime one. Real .NET prints this same line, so the diff holds.
-        Console.WriteLine("-- Environment.UserName: Interop.Sys is Unix-only, not exercised here --");
-        Console.WriteLine("-- System.Diagnostics.Process: the Unix PAL entries, not exercised here --");
-#else
-        Console.WriteLine("-- Environment.UserName (SystemNative_GetEUid + GetPwUidR) --");
+        Console.WriteLine("-- Environment.UserName (platform identity PAL) --");
         string user = Environment.UserName;
         Console.WriteLine("UserName: " + user);
         Console.WriteLine("non-empty: " + (user.Length > 0));
@@ -53,7 +44,7 @@ static class Program
         bool clean = user.Length > 0;
         foreach (char c in user)
         {
-            if (char.IsControl(c) || c == '/')
+            if (char.IsControl(c) || c == '/' || c == '\\')
             {
                 clean = false;
             }
@@ -61,6 +52,9 @@ static class Program
 
         Console.WriteLine("printable, no separator: " + clean);
 
+#if DN2CPP_HOST_WINDOWS
+        Console.WriteLine("-- System.Diagnostics.Process: the Unix PAL entries, not exercised here --");
+#else
         // ---- System.Diagnostics.Process: SystemNative_Kill and SystemNative_GetSid ----
         // The two PAL entries no CoreLib-only closure can name (they are declared in
         // System.Diagnostics.Process.dll). This is a real round-trip, not a symbol probe:

--- a/samples/dotnet/MarshalPinning/MarshalHResultSubset.cs
+++ b/samples/dotnet/MarshalPinning/MarshalHResultSubset.cs
@@ -6,27 +6,51 @@ namespace MarshalHResultSubset;
 
 internal static class Program
 {
+    private static void Probe(string label, int hresult)
+    {
+        Exception? converted = Marshal.GetExceptionForHR(hresult);
+        Console.WriteLine(label + " type=" + converted?.GetType()
+            + " hresult=" + converted?.HResult.ToString("X8"));
+
+        try
+        {
+            Marshal.ThrowExceptionForHR(hresult);
+            Console.WriteLine(label + " catch=NOTHROW");
+        }
+        catch (ArgumentException)
+        {
+            Console.WriteLine(label + " catch=ArgumentException");
+        }
+        catch (OutOfMemoryException)
+        {
+            Console.WriteLine(label + " catch=OutOfMemoryException");
+        }
+        catch (UnauthorizedAccessException)
+        {
+            Console.WriteLine(label + " catch=UnauthorizedAccessException");
+        }
+        catch (COMException)
+        {
+            Console.WriteLine(label + " catch=COMException");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine(label + " catch=" + ex.GetType());
+        }
+    }
+
     internal static void __GateEntry()
     {
         Console.WriteLine("== marshal hresult ==");
 
         Console.WriteLine("success null=" + (Marshal.GetExceptionForHR(0) is null));
-
-        int failure = unchecked((int)0x80004005);
-        Exception? converted = Marshal.GetExceptionForHR(failure);
-        Console.WriteLine("failure present=" + (converted is not null)
-            + " hresult=" + converted?.HResult.ToString("X8"));
-
         Marshal.ThrowExceptionForHR(0);
         Console.WriteLine("throw success=returned");
-        try
-        {
-            Marshal.ThrowExceptionForHR(failure);
-            Console.WriteLine("throw failure=NOTHROW");
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine("throw failure=" + ex.HResult.ToString("X8"));
-        }
+
+        Probe("E_FAIL", unchecked((int)0x80004005));
+        Probe("unknown", unchecked((int)0x81234567));
+        Probe("E_INVALIDARG", unchecked((int)0x80070057));
+        Probe("E_OUTOFMEMORY", unchecked((int)0x8007000E));
+        Probe("E_ACCESSDENIED", unchecked((int)0x80070005));
     }
 }

--- a/samples/dotnet/MarshalPinning/MarshalHResultSubset.cs
+++ b/samples/dotnet/MarshalPinning/MarshalHResultSubset.cs
@@ -1,0 +1,32 @@
+#nullable enable
+using System;
+using System.Runtime.InteropServices;
+
+namespace MarshalHResultSubset;
+
+internal static class Program
+{
+    internal static void __GateEntry()
+    {
+        Console.WriteLine("== marshal hresult ==");
+
+        Console.WriteLine("success null=" + (Marshal.GetExceptionForHR(0) is null));
+
+        int failure = unchecked((int)0x80004005);
+        Exception? converted = Marshal.GetExceptionForHR(failure);
+        Console.WriteLine("failure present=" + (converted is not null)
+            + " hresult=" + converted?.HResult.ToString("X8"));
+
+        Marshal.ThrowExceptionForHR(0);
+        Console.WriteLine("throw success=returned");
+        try
+        {
+            Marshal.ThrowExceptionForHR(failure);
+            Console.WriteLine("throw failure=NOTHROW");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine("throw failure=" + ex.HResult.ToString("X8"));
+        }
+    }
+}

--- a/samples/dotnet/MarshalPinning/Program.cs
+++ b/samples/dotnet/MarshalPinning/Program.cs
@@ -26,6 +26,7 @@ namespace MarshalPinning
             StructMarshalOffsetOfSubset.Program.__GateEntry();
             AlignedAllocSubset.Program.__GateEntry();   // was aligned-alloc-subset
             MarshalNullFaultSubset.Program.__GateEntry();
+            MarshalHResultSubset.Program.__GateEntry();
             NativeMemoryOverflowSubset.Program.__GateEntry();
             // GCHandlePinSubset stays LAST: its sections 13 and 17 assert
             // aggregate heap facts and storm the allocator, so nothing may

--- a/samples/dotnet/ThreadingPrimitives/EventTypeIdentity.cs
+++ b/samples/dotnet/ThreadingPrimitives/EventTypeIdentity.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading;
+using Microsoft.Win32.SafeHandles;
 
 // Type identity across the four CLR event types the runtime serves with one Dn2CppEvent.
 // Each needs its own type-info: they stand in a real inheritance relation (MRE/ARE are
@@ -70,5 +71,19 @@ internal static class Program
         Console.WriteLine("work slim initial=" + s.IsSet);
         s.Set();
         Console.WriteLine("work slim after-set=" + s.IsSet);
+
+        // SafeWaitHandle is a distinct object even when it aliases this runtime's
+        // condition-variable event. Reattaching that alias must redirect the target
+        // WaitHandle to the donor's signal, as the OS-handle property does on .NET.
+        SafeWaitHandle safe = m.SafeWaitHandle;
+        Console.WriteLine("safe type=" + safe.GetType()
+            + " invalid=" + safe.IsInvalid + " closed=" + safe.IsClosed);
+        Console.WriteLine("safe stable=" + ReferenceEquals(safe, m.SafeWaitHandle)
+            + " raw=" + (safe.DangerousGetHandle() != IntPtr.Zero));
+        SafeWaitHandle emptySafe = Activator.CreateInstance<SafeWaitHandle>();
+        Console.WriteLine("safe activator invalid=" + emptySafe.IsInvalid);
+        var donor = new ManualResetEvent(true);
+        var attached = new ManualResetEvent(false) { SafeWaitHandle = donor.SafeWaitHandle };
+        Console.WriteLine("safe attached=" + attached.WaitOne(0));
     }
 }

--- a/samples/dotnet/ThreadingPrimitives/EventTypeIdentity.cs
+++ b/samples/dotnet/ThreadingPrimitives/EventTypeIdentity.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.Win32.SafeHandles;
 
@@ -11,6 +12,21 @@ namespace EventTypeIdentity;
 
 internal static class Program
 {
+    private sealed class AttachedWaitHandle : WaitHandle
+    {
+        internal AttachedWaitHandle(SafeWaitHandle handle)
+        {
+            SafeWaitHandle = handle;
+        }
+
+        protected override void Dispose(bool explicitDisposing)
+        {
+            if (explicitDisposing)
+                SafeWaitHandle = null;
+            base.Dispose(explicitDisposing);
+        }
+    }
+
     private static void Probe(string label, object o)
     {
         Console.WriteLine($"{label} type={o.GetType()}");
@@ -85,5 +101,73 @@ internal static class Program
         var donor = new ManualResetEvent(true);
         var attached = new ManualResetEvent(false) { SafeWaitHandle = donor.SafeWaitHandle };
         Console.WriteLine("safe attached=" + attached.WaitOne(0));
+
+        // Put the donor beside its alias. The runtime must resolve the alias before
+        // scanning the donor itself: returning index 1 proves WaitAny read the target
+        // object's stale local event instead of its attached SafeWaitHandle.
+        var anyDonor = new ManualResetEvent(true);
+        var anyAttached = new ManualResetEvent(false) { SafeWaitHandle = anyDonor.SafeWaitHandle };
+        Console.WriteLine("safe waitany attached="
+            + WaitHandle.WaitAny(new WaitHandle[] { anyAttached, anyDonor }));
+
+        // The nullable setter clears the association. Its getter lazily supplies an
+        // invalid wrapper rather than returning null, and that wrapper remains a normal
+        // SafeHandle for close/ref-count operations.
+        anyAttached.SafeWaitHandle = null!;
+        SafeWaitHandle cleared = anyAttached.SafeWaitHandle!;
+        Console.WriteLine("safe cleared nonnull=" + (cleared is not null)
+            + " invalid=" + cleared!.IsInvalid + " closed=" + cleared.IsClosed);
+        bool addRef = false;
+        cleared.DangerousAddRef(ref addRef);
+        cleared.DangerousRelease();
+        Console.WriteLine("safe addref=" + addRef);
+        cleared.Close();
+        Console.WriteLine("safe close invalid=" + cleared.IsInvalid
+            + " closed=" + cleared.IsClosed);
+
+        // WaitHandle.Dispose owns the attached SafeWaitHandle lifetime. This is
+        // observable without waiting on a disposed primitive (which would throw).
+        var disposed = new ManualResetEvent(false);
+        SafeWaitHandle disposedSafe = disposed.SafeWaitHandle;
+        disposed.Dispose();
+        Console.WriteLine("safe wait dispose closed=" + disposedSafe.IsClosed);
+
+        // A managed WaitHandle subclass borrows the donor's managed-event alias.
+        // Disposing the borrower detaches it; the donor remains independently usable.
+        var subclassDonor = new ManualResetEvent(true);
+        var subclass = new AttachedWaitHandle(subclassDonor.SafeWaitHandle);
+        subclass.Dispose();
+        Console.WriteLine("safe subclass dispose keeps donor=" + subclassDonor.WaitOne(0));
+
+        object boxedSafe = donor.SafeWaitHandle;
+        Console.WriteLine("safe boxed is base=" + (boxedSafe is SafeHandle));
+        Console.WriteLine("safe boxed is zero-minus="
+            + (boxedSafe is SafeHandleZeroOrMinusOneIsInvalid));
+        Console.WriteLine("safe runtime base=" + donor.SafeWaitHandle.GetType().BaseType);
+        SafeHandle baseSafe = donor.SafeWaitHandle;
+        Console.WriteLine("safe base raw="
+            + (baseSafe.DangerousGetHandle() == donor.SafeWaitHandle.DangerousGetHandle()));
+        bool baseAddRef = false;
+        baseSafe.DangerousAddRef(ref baseAddRef);
+        baseSafe.DangerousRelease();
+        Console.WriteLine("safe base addref=" + baseAddRef);
+
+        var closedRaw = new SafeWaitHandle((IntPtr)123, ownsHandle: false);
+        SafeHandle closedRawBase = closedRaw;
+        closedRawBase.Close();
+        Console.WriteLine("safe base close raw=" + closedRawBase.DangerousGetHandle().ToInt64()
+            + " closed=" + closedRawBase.IsClosed + " invalid=" + closedRawBase.IsInvalid);
+
+        var invalidated = new SafeWaitHandle((IntPtr)124, ownsHandle: false);
+        SafeHandle invalidatedBase = invalidated;
+        bool invalidatedAddRef = false;
+        invalidatedBase.DangerousAddRef(ref invalidatedAddRef);
+        invalidatedBase.SetHandleAsInvalid();
+        invalidatedBase.DangerousRelease();
+        Console.WriteLine("safe base invalidated raw="
+            + invalidatedBase.DangerousGetHandle().ToInt64()
+            + " closed=" + invalidatedBase.IsClosed
+            + " invalid=" + invalidatedBase.IsInvalid
+            + " addref=" + invalidatedAddRef);
     }
 }

--- a/src/Dn2Cpp.Transpiler/Compilation.cs
+++ b/src/Dn2Cpp.Transpiler/Compilation.cs
@@ -5718,7 +5718,9 @@ internal sealed partial class Compilation
     /// <c>gethostname</c> primitive Dns.GetHostName bottoms out in, behind
     /// Interop.Winsock's WSAStartup init; the Windows counterpart of the POSIX
     /// PAL's <c>SystemNative_GetHostName</c>). <c>iphlpapi.dll</c> supplies the
-    /// interface-name-to-index conversion used by named IPv6 scope parsing. Each string
+    /// interface-name-to-index conversion used by named IPv6 scope parsing, and
+    /// <c>secur32.dll</c> supplies <c>Environment.UserName</c>'s
+    /// <c>GetUserNameExW</c>. Each string
     /// is the exact
     /// <c>ModuleRef</c> spelling — matched case-sensitively, so <c>BCrypt.dll</c> is
     /// not lowercase — as it appears in the win-x64 assembly that declares the
@@ -5729,7 +5731,7 @@ internal sealed partial class Compilation
     /// <c>ntdll</c> and
     /// <c>BCrypt</c> are outside CMake's default Windows link set (which covers
     /// <c>kernel32</c>/<c>ole32</c>), so <c>runtime/CMakeLists.txt</c> links
-    /// <c>ws2_32</c> and <c>iphlpapi</c> explicitly on the WIN32 arm — without that
+    /// <c>ws2_32</c>, <c>iphlpapi</c> and <c>secur32</c> explicitly on the WIN32 arm — without that
     /// the lowered call sites resolve here and then fail at C++ link time. Nothing
     /// reaches an <c>ntdll</c> / <c>BCrypt</c> call today; one that did would need
     /// the same explicit link.
@@ -5795,7 +5797,7 @@ internal sealed partial class Compilation
             or "libSystem.Security.Cryptography.Native.OpenSsl"
             or "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation"
             or "kernel32.dll" or "ntdll.dll" or "ole32.dll" or "BCrypt.dll"
-            or "ws2_32.dll" or "advapi32.dll" or "iphlpapi.dll"
+            or "ws2_32.dll" or "advapi32.dll" or "iphlpapi.dll" or "secur32.dll"
             or "System.IO.Compression.Native"
             // The libcurl-backed HTTP transport (runtime/core/intrinsics/dn2cpp_http2_stream.cpp,
             // under DN2CPP_USE_CURL): the DnHttp shim's [DllImport("dn2cpp_http")] direct-links

--- a/src/Dn2Cpp.Transpiler/CoreIntrinsics.cs
+++ b/src/Dn2Cpp.Transpiler/CoreIntrinsics.cs
@@ -320,14 +320,11 @@ internal static partial class CoreIntrinsics
         "System.Threading.AutoResetEvent",
         "System.Threading.EventWaitHandle",
         "System.Threading.WaitHandle",
-        // The handle OF one of the above, and in this model it IS one of the above: the
-        // WaitHandle family is backed by an opaque runtime mutex+condvar object, never by
-        // an OS handle, so the safe handle maps to the very same Dn2CppObject* and
-        // WaitHandle.SafeWaitHandle is the identity. Transpiling the real type does not
-        // stay small: ReleaseHandle is Interop.Kernel32.CloseHandle over a Win32 HANDLE
-        // this runtime never mints, and the base SafeHandle drags its
-        // CriticalFinalizerObject refcount state machine in to guard a resource that does
-        // not exist.
+        // The handle OF one of the above. Runtime-created events wrap their native event
+        // object, while WaitHandle.set_SafeWaitHandle can attach a real OS handle (the
+        // ProcessWaitHandle path). Transpiling the real type does not stay small:
+        // ReleaseHandle and the base SafeHandle refcount state machine are replaced by the
+        // runtime wrapper that distinguishes those two resources.
         "Microsoft.Win32.SafeHandles.SafeWaitHandle",
         // CountdownEvent (Signal counts down; Wait blocks until zero) and Barrier (a
         // cyclic phase barrier; each phase releases when all participants have signaled,
@@ -1093,7 +1090,8 @@ internal static partial class CoreIntrinsics
         // String.CreateStringFromEncoding — an intrinsic-type member with no mapping, i.e.
         // the UTF-8-decode + SIMD subtree.
         "System.Runtime.InteropServices.Marshal" =>
-            name is "GetLastPInvokeError" or "SetLastPInvokeError" or "PtrToStringUTF8",
+            name is "GetLastPInvokeError" or "SetLastPInvokeError" or "PtrToStringUTF8"
+                or "GetExceptionForHRInternal",
         // NativeLibrary.GetSymbol -> dn2cpp_native_library_get_symbol. Its real body is the
         // raw compiler-generated `<GetSymbol>g____PInvoke` QCall stub — module "QCall", no
         // managed implementation to link against.
@@ -1406,6 +1404,7 @@ internal static partial class CoreIntrinsics
         ["System.Threading.ManualResetEvent"] = "&dn2cpp_manualresetevent_type",
         ["System.Threading.AutoResetEvent"] = "&dn2cpp_autoresetevent_type",
         ["System.Threading.ManualResetEventSlim"] = "&dn2cpp_manualreseteventslim_type",
+        ["Microsoft.Win32.SafeHandles.SafeWaitHandle"] = "&dn2cpp_safewaithandle_type",
     };
 
     // A nested ClassInfo.FullName is only the simple name, so runtime-owned nested types are

--- a/src/Dn2Cpp.Transpiler/CoreIntrinsics.cs
+++ b/src/Dn2Cpp.Transpiler/CoreIntrinsics.cs
@@ -483,10 +483,9 @@ internal static partial class CoreIntrinsics
         ["System.Threading.AutoResetEvent"] = "Dn2CppObject*",
         ["System.Threading.EventWaitHandle"] = "Dn2CppObject*",
         ["System.Threading.WaitHandle"] = "Dn2CppObject*",
-        // Deliberately the SAME C++ type as WaitHandle above: the safe handle and the
-        // handle it guards are one object here, which is what makes
-        // WaitHandle.get_SafeWaitHandle an identity and lets the static
-        // EventWaitHandle.Set(SafeWaitHandle) reuse the instance Set arm unchanged.
+        // Both are opaque runtime references at generated call sites, but a
+        // SafeWaitHandle is a distinct wrapper carrying either a runtime-event alias or
+        // an OS handle. The runtime helpers resolve that wrapper before operating.
         ["Microsoft.Win32.SafeHandles.SafeWaitHandle"] = "Dn2CppObject*",
         ["System.Threading.CountdownEvent"] = "Dn2CppObject*",
         ["System.Threading.Barrier"] = "Dn2CppObject*",
@@ -1197,6 +1196,10 @@ internal static partial class CoreIntrinsics
         ["System.OverflowException"] = "&dn2cpp_overflow_exception_type",
         ["System.IndexOutOfRangeException"] = "&dn2cpp_index_out_of_range_exception_type",
         ["System.ArgumentException"] = "&dn2cpp_argument_exception_type",
+        // Marshal.GetExceptionForHR's fallback for a failed HRESULT with no more
+        // specific managed mapping. The stable handle keeps catch (COMException)
+        // aligned with the object the runtime helper creates.
+        ["System.Runtime.InteropServices.COMException"] = "&dn2cpp_com_exception_type",
         ["System.ArgumentOutOfRangeException"] = "&dn2cpp_argument_out_of_range_exception_type",
         ["System.ArgumentNullException"] = "&dn2cpp_argument_null_exception_type",
         ["System.InvalidOperationException"] = "&dn2cpp_invalid_operation_exception_type",
@@ -1500,8 +1503,8 @@ internal static partial class CoreIntrinsics
             .Distinct();
 
     /// <summary>The CLR types whose runtime handle is a STUB the emitted metadata fills in
-    /// — the non-exception half of the <c>dn2cpp_type_binds</c> family. One row today:
-    /// System.Enum, whose handle every emitted enum's <c>base</c> points at while
+    /// — the non-exception half of the <c>dn2cpp_type_binds</c> family. System.Enum's
+    /// handle is where every emitted enum's <c>base</c> points while
     /// <c>typeof(Enum)</c> named the emitted <c>ti_System_Enum</c>, so
     /// <c>typeof(E).BaseType == typeof(Enum)</c> was false. Binding rather than owning is
     /// forced by which side knows more: the emitted metadata carries System.Enum's real
@@ -1509,10 +1512,15 @@ internal static partial class CoreIntrinsics
     /// none of it, so owning would DELETE an answer typeof already gives.
     /// (<c>dn2cpp_enum_set_interfaces</c> runs after <c>dn2cpp_runtime_init</c> in the
     /// generated prologue, so the interface rows it installs survive the bind's whole-struct
-    /// copy.)</summary>
+    /// copy.) SafeHandle follows the same ownership split: the runtime wrapper needs a
+    /// stable base chain through SafeHandleZeroOrMinusOneIsInvalid, while emitted CoreLib
+    /// metadata supplies both types' layout, vtable and ancestors.</summary>
     private static readonly Dictionary<string, string> s_runtimeBoundTypeInfo = new()
     {
         ["System.Enum"] = "&dn2cpp_enum_type",
+        ["System.Runtime.InteropServices.SafeHandle"] = "&dn2cpp_safehandle_type",
+        ["Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid"] =
+            "&dn2cpp_safehandle_zero_or_minus_one_type",
     };
 
     static CoreIntrinsics()

--- a/src/Dn2Cpp.Transpiler/MethodCompiler.Call.cs
+++ b/src/Dn2Cpp.Transpiler/MethodCompiler.Call.cs
@@ -410,8 +410,7 @@ internal sealed partial class MethodCompiler
             case HandleKind.MethodDefinition:
             {
                 var callee = ResolveMethodDef((MethodDefinitionHandle)handle);
-                if (TryEmitSafeWaitHandleBase(callee.DeclaringClass.FullName,
-                        callee.Name, callee.Signature))
+                if (TryEmitSafeWaitHandleBase(callee, isCallvirt))
                     return;
                 // The intra-CoreLib runtime primitives reached only via in-CoreLib MethodDef
                 // calls: GC's finalizer/collect/KeepAlive entry points, SpanHelpers.Memmove,
@@ -837,7 +836,10 @@ internal sealed partial class MethodCompiler
                 string? mrParent = _c.MemberRefParentTypeName(_module, (MemberReferenceHandle)handle);
                 MethodSignature<TypeDesc>? mrSig = null;
                 MethodSignature<TypeDesc> Sig() => mrSig ??= mr.DecodeMethodSignature(_c.SigProvider, _method.Context);
-                if (TryEmitSafeWaitHandleBase(mrParent, mrName, Sig()))
+                if (mrParent == "System.Runtime.InteropServices.SafeHandle"
+                    && TryEmitSafeWaitHandleBase(
+                        _c.ResolveMemberRefMethod(_module, (MemberReferenceHandle)handle, _method.Context),
+                        isCallvirt))
                     return;
                 // Non-generic Enum reflection statics taking a runtime Type
                 // (GetNames/GetName/IsDefined/Parse/TryParse/GetUnderlyingType/GetValues) —
@@ -1118,19 +1120,91 @@ internal sealed partial class MethodCompiler
         }
     }
 
-    private bool TryEmitSafeWaitHandleBase(string? declaringType, string name,
-        MethodSignature<TypeDesc> sig)
+    /// <summary>Routes inherited SafeHandle calls against the runtime-owned
+    /// SafeWaitHandle layout without applying that layout to SafeFileHandle or a user
+    /// subclass. The receiver is consumed once; the non-wrapper arm remains the ordinary
+    /// CoreLib body/virtual dispatch, so its reachability and layout stay unchanged.</summary>
+    private bool TryEmitSafeWaitHandleBase(MethodInfo callee, bool isCallvirt)
     {
-        if (declaringType != "System.Runtime.InteropServices.SafeHandle"
-            || name is not ("DangerousGetHandle" or "DangerousAddRef" or "DangerousRelease"
-                or "get_IsInvalid" or "get_IsClosed" or "Dispose" or "Close"))
+        string name = callee.Name;
+        int parameterCount = callee.Signature.ParameterTypes.Length;
+        if (callee.DeclaringClass.FullName != "System.Runtime.InteropServices.SafeHandle"
+            || name switch
+            {
+                "DangerousGetHandle" or "DangerousRelease" or "get_IsInvalid"
+                    or "get_IsClosed" or "Close" or "SetHandleAsInvalid" => parameterCount != 0,
+                "DangerousAddRef" => parameterCount != 1,
+                "Dispose" => parameterCount is not (0 or 1),
+                _ => true,
+            })
             return false;
-        int receiverIndex = _stack.Count - 1 - sig.ParameterTypes.Length;
-        if (receiverIndex < 0
-            || _stack[receiverIndex].StaticType is not
-                { Kind: TypeKind.Class, Class.FullName: "Microsoft.Win32.SafeHandles.SafeWaitHandle" })
+
+        int receiverIndex = _stack.Count - 1 - parameterCount;
+        if (receiverIndex >= 0 && _stack[receiverIndex].CppType == "Dn2CppMappedSafeHandle")
+            // SafeMemoryMappedViewHandle is a by-value intrinsic with its own inherited
+            // SafeBuffer/SafeHandle route below; it has no Dn2CppObject header to guard.
             return false;
-        EmitIntrinsic("Microsoft.Win32.SafeHandles.SafeWaitHandle", name, sig);
+
+        var args = PopArgs(callee, hasThis: true);
+        string receiverExpr = args[0];
+        if (isCallvirt)
+            receiverExpr = $"dn2cpp_null_check({receiverExpr})";
+        string receiver = NewTemp("Dn2CppObject*");
+        Emit($"{receiver} = (Dn2CppObject*)({receiverExpr});");
+        args[0] = $"({callee.DeclaringClass.CppStructName}*){receiver}";
+
+        string wrapperCall = name switch
+        {
+            "DangerousGetHandle" => $"dn2cpp_safewaithandle_get({receiver})",
+            "DangerousAddRef" => $"*(uint8_t*)({args[1]}) = (uint8_t)dn2cpp_safewaithandle_addref({receiver})",
+            "DangerousRelease" => $"dn2cpp_safewaithandle_release({receiver})",
+            "get_IsInvalid" => $"dn2cpp_safewaithandle_is_invalid({receiver})",
+            "get_IsClosed" => $"dn2cpp_safewaithandle_is_closed({receiver})",
+            "SetHandleAsInvalid" => $"dn2cpp_safewaithandle_set_invalid({receiver})",
+            "Dispose" or "Close" => $"dn2cpp_safewaithandle_close({receiver})",
+            _ => throw new InvalidOperationException("unreachable SafeHandle lowering"),
+        };
+
+        string fallbackCall;
+        if (isCallvirt && callee.IsVirtual)
+        {
+            if (!callee.DeclaringClass.IsValueType
+                && callee.DeclaringClass.IntrinsicCppName is null)
+                NoteReferencedType(callee.DeclaringClass);
+            NoteDispatchSignatureTypes(callee);
+            NfiWrapErasedCallArgs(callee, args);
+            fallbackCall = $"(({FnPtrType(callee)})({receiver}->type->vtable[{callee.VtableSlot}]))"
+                + $"({string.Join(", ", args)})";
+        }
+        else
+        {
+            fallbackCall = DirectCall(callee, args.ToList());
+        }
+
+        Emit($"if (dn2cpp_isinst({receiver}, &dn2cpp_safewaithandle_type) != nullptr)");
+        Emit("{");
+        if (callee.Signature.ReturnType.IsVoid)
+        {
+            Emit($"    {wrapperCall};");
+            Emit("}");
+            Emit("else");
+            Emit("{");
+            Emit($"    {fallbackCall};");
+            Emit("}");
+        }
+        else
+        {
+            string resultType = CppTypes.Of(callee.Signature.ReturnType);
+            string result = NewTemp(resultType);
+            Emit($"    {result} = {wrapperCall};");
+            Emit("}");
+            Emit("else");
+            Emit("{");
+            Emit($"    {result} = {fallbackCall};");
+            Emit("}");
+            EmitCallResult(callee, result);
+        }
+        EmitByRefSlotFixups();
         return true;
     }
 

--- a/src/Dn2Cpp.Transpiler/MethodCompiler.Call.cs
+++ b/src/Dn2Cpp.Transpiler/MethodCompiler.Call.cs
@@ -410,6 +410,9 @@ internal sealed partial class MethodCompiler
             case HandleKind.MethodDefinition:
             {
                 var callee = ResolveMethodDef((MethodDefinitionHandle)handle);
+                if (TryEmitSafeWaitHandleBase(callee.DeclaringClass.FullName,
+                        callee.Name, callee.Signature))
+                    return;
                 // The intra-CoreLib runtime primitives reached only via in-CoreLib MethodDef
                 // calls: GC's finalizer/collect/KeepAlive entry points, SpanHelpers.Memmove,
                 // Marshal's errno slot + UTF-8 decoder, NativeLibrary.GetSymbol,
@@ -834,6 +837,8 @@ internal sealed partial class MethodCompiler
                 string? mrParent = _c.MemberRefParentTypeName(_module, (MemberReferenceHandle)handle);
                 MethodSignature<TypeDesc>? mrSig = null;
                 MethodSignature<TypeDesc> Sig() => mrSig ??= mr.DecodeMethodSignature(_c.SigProvider, _method.Context);
+                if (TryEmitSafeWaitHandleBase(mrParent, mrName, Sig()))
+                    return;
                 // Non-generic Enum reflection statics taking a runtime Type
                 // (GetNames/GetName/IsDefined/Parse/TryParse/GetUnderlyingType/GetValues) —
                 // the per-enum runtime table; the generic Enum.*<T> forms are a
@@ -1111,6 +1116,22 @@ internal sealed partial class MethodCompiler
             default:
                 throw new NotSupportedException($"Call target kind {handle.Kind} is not supported");
         }
+    }
+
+    private bool TryEmitSafeWaitHandleBase(string? declaringType, string name,
+        MethodSignature<TypeDesc> sig)
+    {
+        if (declaringType != "System.Runtime.InteropServices.SafeHandle"
+            || name is not ("DangerousGetHandle" or "DangerousAddRef" or "DangerousRelease"
+                or "get_IsInvalid" or "get_IsClosed" or "Dispose" or "Close"))
+            return false;
+        int receiverIndex = _stack.Count - 1 - sig.ParameterTypes.Length;
+        if (receiverIndex < 0
+            || _stack[receiverIndex].StaticType is not
+                { Kind: TypeKind.Class, Class.FullName: "Microsoft.Win32.SafeHandles.SafeWaitHandle" })
+            return false;
+        EmitIntrinsic("Microsoft.Win32.SafeHandles.SafeWaitHandle", name, sig);
+        return true;
     }
 
     /// <summary>calli: an indirect call through a function pointer that sits on top

--- a/src/Dn2Cpp.Transpiler/MethodCompiler.EmitIntrinsic.Interop.cs
+++ b/src/Dn2Cpp.Transpiler/MethodCompiler.EmitIntrinsic.Interop.cs
@@ -507,10 +507,9 @@ internal sealed partial class MethodCompiler
     /// <c>std::memmove</c>. The managed entry's body is a hand-unrolled Unsafe.* copy loop
     /// that also calls the SpanHelpers::memmove InternalCall fallback; mapping the managed
     /// entry closes both.</item>
-    /// <item><c>System.Runtime.InteropServices.Marshal::GetLastPInvokeError</c> → the
-    /// per-thread errno slot (dn2cpp_marshal_get_last_error). The MemberRef form routes
-    /// through TryEmitMarshalIntrinsic; this routes the in-CoreLib MethodDef form the same
-    /// way.</item>
+    /// <item><c>System.Runtime.InteropServices.Marshal</c> primitives route to the same
+    /// lowering as their MemberRef forms, including the cached P/Invoke error slot and
+    /// HRESULT conversion.</item>
     /// </list></summary>
     private bool TryEmitGcMemmoveMarshalPrimitive(MethodInfo callee)
     {
@@ -627,6 +626,8 @@ internal sealed partial class MethodCompiler
             // body reaches String.CreateStringFromEncoding, the UTF-8-decode subtree).
             case ("System.Runtime.InteropServices.Marshal", "PtrToStringUTF8")
                 when callee.IsStatic:
+            case ("System.Runtime.InteropServices.Marshal", "GetExceptionForHRInternal")
+                when callee.Signature.ParameterTypes.Length == 2 && callee.IsStatic:
                 EmitIntrinsic(callee.DeclaringClass.FullName, callee.Name, callee.Signature);
                 return true;
         }
@@ -984,11 +985,20 @@ internal sealed partial class MethodCompiler
     /// unmanaged-heap allocators (AllocHGlobal/FreeHGlobal and the CoTaskMem aliases), the
     /// string encode/decode pairs, Copy (memcpy between a managed blittable array and a
     /// native pointer, both directions), the typed Read*/Write* accessors, and the
-    /// layout-dependent Type-based forms (OffsetOf/SizeOf/PtrToStructure/StructureToPtr).</summary>
+    /// layout-dependent Type-based forms (OffsetOf/SizeOf/PtrToStructure/StructureToPtr),
+    /// plus the CoreLib HRESULT-to-exception primitive.</summary>
     private bool TryEmitMarshalIntrinsic(string name, MethodSignature<TypeDesc> sig)
     {
         switch (name)
         {
+            case "GetExceptionForHRInternal" when sig.ParameterTypes.Length == 2:
+            {
+                Pop(); // errorInfo — COM IErrorInfo is not modeled
+                var hr = Pop();
+                Push(StackKind.Ref, "Dn2CppObject*",
+                    $"dn2cpp_exception_for_hresult((int32_t)({hr.Expr}))");
+                return true;
+            }
             case "AllocHGlobal": // AllocHGlobal(int cb) | AllocHGlobal(IntPtr cb) -> IntPtr
             {
                 var cb = Pop();

--- a/src/Dn2Cpp.Transpiler/MethodCompiler.EmitIntrinsic.Threading.cs
+++ b/src/Dn2Cpp.Transpiler/MethodCompiler.EmitIntrinsic.Threading.cs
@@ -430,33 +430,47 @@ internal sealed partial class MethodCompiler
                 Push(StackKind.I4, "int32_t", $"dn2cpp_event_wait_any((Dn2CppArrayRef*)({arr.Expr}))");
                 return true;
             }
+            // A managed subclass such as ProcessWaitHandle allocates its own object and
+            // attaches an OS SafeWaitHandle through the property setter. The intrinsic
+            // base has no instance fields for its constructor to initialize.
+            case ("System.Threading.WaitHandle", ".ctor"):
+            {
+                Pop(); // this
+                return true;
+            }
             // Dispose/Close on these primitives are no-ops (the native object lives for
             // the program, like the monitor table).
             case ("System.Threading.SemaphoreSlim", "Dispose"):
             case ("System.Threading.ManualResetEventSlim", "Dispose"):
             case ("System.Threading.WaitHandle", "Dispose"):
             case ("System.Threading.WaitHandle", "Close"):
-            // The safe handle is the same never-closed runtime object (see the
-            // SafeWaitHandle block below), so its Dispose/Close are the same no-op.
-            case ("Microsoft.Win32.SafeHandles.SafeWaitHandle", "Dispose"):
-            case ("Microsoft.Win32.SafeHandles.SafeWaitHandle", "Close"):
             {
                 Pop(); // this
                 return true;
             }
-            // ---- SafeWaitHandle: the handle of a WaitHandle, which here IS the WaitHandle ----
-            // dn2cpp models the WaitHandle family as an opaque runtime mutex+condvar
-            // object rather than as an OS handle, so the SafeWaitHandle wrapping one is
-            // mapped to that same Dn2CppObject* (CoreIntrinsics.s_intrinsicCppTypes) and
-            // this getter is the identity. The real getter's lazy
-            // `new SafeWaitHandle(InvalidHandle, ownsHandle: false)` fallback needs no
-            // counterpart: it exists for a WaitHandle whose _waitHandle field is null, and
-            // every WaitHandle this model can produce is built by dn2cpp_event_new
-            // (MethodCompiler.Newobj) with the object in hand.
+            case ("Microsoft.Win32.SafeHandles.SafeWaitHandle", "Dispose"):
+            case ("Microsoft.Win32.SafeHandles.SafeWaitHandle", "Close"):
+            {
+                for (int i = 0; i < sig.ParameterTypes.Length; i++)
+                    Pop();
+                var o = Pop(); // this
+                Emit($"dn2cpp_safewaithandle_close((Dn2CppObject*)({o.Expr}));");
+                return true;
+            }
+            // ---- SafeWaitHandle: runtime event alias or an attached OS handle ----
             case ("System.Threading.WaitHandle", "get_SafeWaitHandle"):
             {
                 var o = Pop(); // this
-                Push(StackKind.Ref, "Dn2CppObject*", $"((Dn2CppObject*)({o.Expr}))");
+                Push(StackKind.Ref, "Dn2CppObject*",
+                    $"dn2cpp_waithandle_get_safe((Dn2CppObject*)({o.Expr}))");
+                return true;
+            }
+            case ("System.Threading.WaitHandle", "set_SafeWaitHandle"):
+            {
+                var handle = Pop();
+                var o = Pop(); // this
+                Emit($"dn2cpp_waithandle_set_safe((Dn2CppObject*)({o.Expr}), "
+                    + $"(Dn2CppObject*)({handle.Expr}));");
                 return true;
             }
             // The raw handle value. It must be a value DISTINCT from 0 and from -1 for
@@ -467,16 +481,13 @@ internal sealed partial class MethodCompiler
             case ("Microsoft.Win32.SafeHandles.SafeWaitHandle", "DangerousGetHandle"):
             {
                 var o = Pop(); // this
-                Push(StackKind.I8, "intptr_t", $"(intptr_t)({o.Expr})");
+                Push(StackKind.I8, "intptr_t",
+                    $"dn2cpp_safewaithandle_get((Dn2CppObject*)({o.Expr}))");
                 return true;
             }
-            // DangerousAddRef(ref bool success) / DangerousRelease — the refcount that
-            // keeps an OS handle alive across a P/Invoke. There is no OS handle and the
-            // object is GC-owned for the life of the program (Dispose/Close above are
-            // already no-ops), so the count has nothing to protect: the add always
-            // succeeds and the release is a no-op — the answer a live, never-closed handle
-            // gives in real .NET too. The low-byte write mirrors Monitor.Enter's ref-bool
-            // store above.
+            // The runtime wrapper remains alive for the program, so DangerousAddRef only
+            // reports success and DangerousRelease has no reference count to update. The
+            // low-byte write mirrors Monitor.Enter's ref-bool store above.
             case ("Microsoft.Win32.SafeHandles.SafeWaitHandle", "DangerousAddRef"):
             {
                 var success = Pop(); // ref bool success
@@ -489,19 +500,19 @@ internal sealed partial class MethodCompiler
                 Pop(); // this
                 return true;
             }
-            // IsInvalid comes from SafeHandleZeroOrMinusOneIsInvalid (handle is 0 or -1);
-            // here the only unrepresentable handle is the null object. IsClosed is always
-            // false for the same reason DangerousRelease is a no-op.
+            // IsInvalid follows SafeHandleZeroOrMinusOneIsInvalid (handle is 0 or -1).
             case ("Microsoft.Win32.SafeHandles.SafeWaitHandle", "get_IsInvalid"):
             {
                 var o = Pop(); // this
-                Push(StackKind.I4, "int32_t", $"((({o.Expr}) == nullptr) ? 1 : 0)");
+                Push(StackKind.I4, "int32_t",
+                    $"dn2cpp_safewaithandle_is_invalid((Dn2CppObject*)({o.Expr}))");
                 return true;
             }
             case ("Microsoft.Win32.SafeHandles.SafeWaitHandle", "get_IsClosed"):
             {
-                Pop(); // this
-                Push(StackKind.I4, "int32_t", "0");
+                var o = Pop(); // this
+                Push(StackKind.I4, "int32_t",
+                    $"dn2cpp_safewaithandle_is_closed((Dn2CppObject*)({o.Expr}))");
                 return true;
             }
             // ---- CountdownEvent (real countdown latch) ----

--- a/src/Dn2Cpp.Transpiler/MethodCompiler.EmitIntrinsic.Threading.cs
+++ b/src/Dn2Cpp.Transpiler/MethodCompiler.EmitIntrinsic.Threading.cs
@@ -362,9 +362,8 @@ internal sealed partial class MethodCompiler
             // bool; the Slim ones return void.
             //
             // The Set arm also serves the internal STATIC EventWaitHandle.Set(SafeWaitHandle)
-            // without a case of its own: a SafeWaitHandle is the same Dn2CppObject* as the
-            // event it guards (see the SafeWaitHandle block below), so there is one operand
-            // either way and popping "the receiver" pops the handle.
+            // without a case of its own. Both shapes carry one opaque operand; the runtime
+            // resolves whether it is an event or its distinct SafeWaitHandle wrapper.
             case ("System.Threading.ManualResetEventSlim", "Set"):
             case ("System.Threading.EventWaitHandle", "Set"):
             {
@@ -438,14 +437,22 @@ internal sealed partial class MethodCompiler
                 Pop(); // this
                 return true;
             }
-            // Dispose/Close on these primitives are no-ops (the native object lives for
-            // the program, like the monitor table).
+            // The native SemaphoreSlim/Slim objects live for the program. WaitHandle
+            // disposal is different: a managed subclass can own an attached Windows
+            // HANDLE, and closing the WaitHandle must release that SafeWaitHandle.
             case ("System.Threading.SemaphoreSlim", "Dispose"):
             case ("System.Threading.ManualResetEventSlim", "Dispose"):
+            {
+                Pop(); // this
+                return true;
+            }
             case ("System.Threading.WaitHandle", "Dispose"):
             case ("System.Threading.WaitHandle", "Close"):
             {
-                Pop(); // this
+                for (int i = 0; i < sig.ParameterTypes.Length; i++)
+                    Pop();
+                var o = Pop(); // this
+                Emit($"dn2cpp_waithandle_close((Dn2CppObject*)({o.Expr}));");
                 return true;
             }
             case ("Microsoft.Win32.SafeHandles.SafeWaitHandle", "Dispose"):
@@ -485,19 +492,26 @@ internal sealed partial class MethodCompiler
                     $"dn2cpp_safewaithandle_get((Dn2CppObject*)({o.Expr}))");
                 return true;
             }
-            // The runtime wrapper remains alive for the program, so DangerousAddRef only
-            // reports success and DangerousRelease has no reference count to update. The
-            // low-byte write mirrors Monitor.Enter's ref-bool store above.
+            // Keep a closeable OS handle alive across the protected native operation.
+            // The low-byte write mirrors Monitor.Enter's ref-bool store above.
             case ("Microsoft.Win32.SafeHandles.SafeWaitHandle", "DangerousAddRef"):
             {
                 var success = Pop(); // ref bool success
-                Pop();               // this
-                Emit($"*(uint8_t*)({success.Expr}) = 1;");
+                var o = Pop();       // this
+                Emit($"*(uint8_t*)({success.Expr}) = (uint8_t)"
+                    + $"dn2cpp_safewaithandle_addref((Dn2CppObject*)({o.Expr}));");
                 return true;
             }
             case ("Microsoft.Win32.SafeHandles.SafeWaitHandle", "DangerousRelease"):
             {
-                Pop(); // this
+                var o = Pop(); // this
+                Emit($"dn2cpp_safewaithandle_release((Dn2CppObject*)({o.Expr}));");
+                return true;
+            }
+            case ("Microsoft.Win32.SafeHandles.SafeWaitHandle", "SetHandleAsInvalid"):
+            {
+                var o = Pop(); // this
+                Emit($"dn2cpp_safewaithandle_set_invalid((Dn2CppObject*)({o.Expr}));");
                 return true;
             }
             // IsInvalid follows SafeHandleZeroOrMinusOneIsInvalid (handle is 0 or -1).

--- a/src/Dn2Cpp.Transpiler/MethodCompiler.EmitIntrinsic.ValueTypes.cs
+++ b/src/Dn2Cpp.Transpiler/MethodCompiler.EmitIntrinsic.ValueTypes.cs
@@ -1998,7 +1998,7 @@ internal sealed partial class MethodCompiler
                 Push(StackKind.I8, "intptr_t", $"(intptr_t)dn2cpp_gchandle_addr({GCHVal(r)})");
                 return true;
             }
-            case "Free":
+            case "Free" or "Dispose":
             {
                 var r = Pop();
                 // A local/field receiver arrives by address (ldloca/ldflda) — free

--- a/src/Dn2Cpp.Transpiler/MethodCompiler.GenericIntrinsic.cs
+++ b/src/Dn2Cpp.Transpiler/MethodCompiler.GenericIntrinsic.cs
@@ -558,6 +558,12 @@ internal sealed partial class MethodCompiler
                         Push(StackKind.Ref, "Dn2CppStringBuilder*", "dn2cpp_sb_new()");
                         return;
                     }
+                    if (cls.FullName == "Microsoft.Win32.SafeHandles.SafeWaitHandle")
+                    {
+                        Push(StackKind.Ref, "Dn2CppObject*",
+                            "dn2cpp_safewaithandle_new((intptr_t)0, 0)");
+                        return;
+                    }
                     // No modeled parameterless construction for any other intrinsic
                     // reference type; throw at transpile rather than fall through and name
                     // the cut ctor. StringBuilder is the only one the corpus reaches;

--- a/src/Dn2Cpp.Transpiler/MethodCompiler.Newobj.cs
+++ b/src/Dn2Cpp.Transpiler/MethodCompiler.Newobj.cs
@@ -1103,6 +1103,19 @@ internal sealed partial class MethodCompiler
                 $"dn2cpp_event_new({ewhInit.Expr}, {mode.Expr}, &dn2cpp_event_type)");
             return;
         }
+        // new SafeWaitHandle(IntPtr handle, bool ownsHandle). Runtime events lazily mint
+        // an alias wrapper in get_SafeWaitHandle; this constructor is the distinct route
+        // for an OS handle later attached through WaitHandle.set_SafeWaitHandle.
+        if (NewobjTypeName(handle) == "Microsoft.Win32.SafeHandles.SafeWaitHandle"
+            && handle.Kind is HandleKind.MemberReference or HandleKind.MethodDefinition
+            && DecodeCtorSignature(handle).ParameterTypes.Length == 2)
+        {
+            var owns = Pop();
+            var raw = Pop();
+            Push(StackKind.Ref, "Dn2CppObject*",
+                $"dn2cpp_safewaithandle_new((intptr_t)({raw.Expr}), (int32_t)({owns.Expr}))");
+            return;
+        }
         // new CountdownEvent(int initialCount) — a real countdown latch (Signal counts
         // down; Wait blocks until it reaches zero). initialCount == 0 starts already set.
         //


### PR DESCRIPTION
## Summary

- support the CoreLib Windows identity and OS-backed SafeWaitHandle paths used by ProcessWaitHandle
- preserve HRESULT failure values and lower the GCHandle Dispose alias
- link secur32 and compile generated MSVC app objects with /bigobj

## Validation

- dotnet build src/Dn2Cpp.Cli -c Release --no-restore -m:1
- bash gates/selfhost-emit.sh (158-TU managed/native fixpoint)
- FileReal, ThreadingPrimitives, and MarshalPinning gates in Release and Debug
- Thrive transpile: 33 assemblies, 72,775 types, 288,742 reachable methods
- Thrive native drop-in: 718 CMake targets linked successfully
- Godot Windows Desktop export completed with exit code 0
- exported Thrive.exe headless smoke completed with exit code 0

Thrive only received local project settings and native build outputs for validation; no Thrive commit was created.