### PR TITLE
Make Godot gates hermetic

### DIFF
--- a/.github/workflows/windows-smoke.yml
+++ b/.github/workflows/windows-smoke.yml
@@ -188,9 +188,9 @@ jobs:
 
       # Normal mode on purpose. DN2CPP_REQUIRE_ALL=1 would fail on the
       # cross-toolchain gates this runner cannot satisfy — see the header.
-      # Keep two gate workers on the hosted Windows image. The wide ISA build
-      # has a large temporary footprint, and running it beside every available
-      # MSVC worker can exhaust the runner while a native probe is writing.
+      # Keep one gate worker on the hosted Windows image. The wide ISA build
+      # has a large temporary footprint, and memory pressure from even one
+      # concurrent MSVC gate can terminate its native probe mid-write.
       #
       # openssl: Git for Windows ships openssl.exe under usr/bin, which this
       # bash step's PATH should resolve — but that is unverified as of this
@@ -198,7 +198,7 @@ jobs:
       # openssl as a hard failure, not a gate_skip (see its command -v check),
       # so this is the first thing to look at if suite-smoke goes red here.
       - name: Run the non-Godot suite
-        run: JOBS=2 SKIP_GODOT=1 ./gates/run-all-gates.sh
+        run: JOBS=1 SKIP_GODOT=1 ./gates/run-all-gates.sh
 
       # Before the log upload so a lingering build-server handle on a log file
       # cannot make the upload step see a partially-flushed file.

--- a/gates/_common.sh
+++ b/gates/_common.sh
@@ -267,12 +267,23 @@ resolve_net10_corelib() {
 }
 
 # invoke_cli ARGS... — run the dn2cpp CLI. `dotnet exec` on DN2CPP_CLI_DLL when
-# set (skips MSBuild), else `dotnet run --project`.
+# set (skips MSBuild), else build once without a parallel restore graph and run
+# that DLL. Some SDKs can fail a parallel graph build without reporting an
+# MSBuild error, so standalone gates use the same explicit artifact as the suite.
 invoke_cli() {
     if [ -n "${DN2CPP_CLI_DLL:-}" ]; then
         dotnet exec "${DN2CPP_CLI_DLL}" "$@"
     else
-        dotnet run --project src/Dn2Cpp.Cli -c "${CONFIG}" -- "$@"
+        dotnet build src/Dn2Cpp.Cli/Dn2Cpp.Cli.csproj -c "${CONFIG}" \
+            --nologo -v q -p:BuildInParallel=false || return 1
+        local cli_dll="$PWD/src/Dn2Cpp.Cli/bin/$CONFIG/$TFM/dn2cpp.dll"
+        if [ ! -f "$cli_dll" ]; then
+            echo "error: CLI build produced no $cli_dll" >&2
+            return 1
+        fi
+        DN2CPP_CLI_DLL="$cli_dll"
+        export DN2CPP_CLI_DLL
+        dotnet exec "$DN2CPP_CLI_DLL" "$@"
     fi
 }
 
@@ -481,6 +492,35 @@ godot_editor_config_dir() {
                 /*) config_home="$XDG_CONFIG_HOME" ;;
             esac
             printf '%s\n' "$config_home/godot"
+            ;;
+    esac
+}
+
+# run_godot_isolated ROOT COMMAND... — keep editor state and user:// writes below
+# ROOT. The isolated environment reaches COMMAND and its descendants without
+# leaking into the calling shell. Godot has no command-line override for it.
+run_godot_isolated() {
+    local root="$1"
+    shift
+    mkdir -p "$root"
+    case "$DN2CPP_OS" in
+        macos)
+            mkdir -p "$root/home"
+            HOME="$root/home" "$@"
+            ;;
+        windows)
+            local appdata localappdata tempdir
+            appdata=$(native_path "$root/appdata")
+            localappdata=$(native_path "$root/localappdata")
+            tempdir=$(native_path "$root/temp")
+            mkdir -p "$root/appdata" "$root/localappdata" "$root/temp"
+            APPDATA="$appdata" LOCALAPPDATA="$localappdata" \
+                TEMP="$tempdir" TMP="$tempdir" "$@"
+            ;;
+        *)
+            mkdir -p "$root/data" "$root/config" "$root/cache"
+            XDG_DATA_HOME="$root/data" XDG_CONFIG_HOME="$root/config" \
+                XDG_CACHE_HOME="$root/cache" "$@"
             ;;
     esac
 }
@@ -1138,10 +1178,20 @@ resolve_python() {
 # Console output with the console code page. Force 65001 so oracles match.
 [ "$DN2CPP_OS" = windows ] && chcp.com 65001 >/dev/null 2>&1
 
-# _ccache_pch_env — pch_defines + time_macros sloppiness, ccache's requirement
-# for PCH (DN2CPP_PCH); without them every PCH compile is a miss. Appends,
-# idempotent. CCACHE_PCH_EXTSUM stays unset: CMake drops no .sum for it.
+# _ccache_pch_env — keep the default cache below the writable build tree, then
+# set ccache's PCH sloppiness requirements. An explicit CCACHE_DIR wins. Windows
+# ccache is native and therefore receives a native path. Appends, idempotent.
+# CCACHE_PCH_EXTSUM stays unset: CMake drops no .sum for it.
 _ccache_pch_env() {
+    if [ -z "${CCACHE_DIR:-}" ]; then
+        mkdir -p "$PWD/artifacts/.ccache"
+        if [ "$DN2CPP_OS" = windows ]; then
+            CCACHE_DIR=$(native_path "$PWD/artifacts/.ccache")
+        else
+            CCACHE_DIR="$PWD/artifacts/.ccache"
+        fi
+        export CCACHE_DIR
+    fi
     case ",${CCACHE_SLOPPINESS:-}," in
         *,pch_defines,*) ;;
         *) export CCACHE_SLOPPINESS="${CCACHE_SLOPPINESS:+${CCACHE_SLOPPINESS},}pch_defines,time_macros" ;;

--- a/gates/build-and-run-godot-sample.sh
+++ b/gates/build-and-run-godot-sample.sh
@@ -6,6 +6,14 @@ OUT=artifacts/godot
 GODOT=${GODOT:-godot}
 PROJECT=samples/godot/godot-project
 
+# This gate writes through user:// and may run where the real user profile is
+# read-only. Keep all engine-owned state process-private on every host.
+GODOT_USER_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/dn2cpp-godot-sample.XXXXXX")
+godot_sample_cleanup() {
+    rm -rf "$GODOT_USER_ROOT"
+}
+gate_add_exit_hook godot_sample_cleanup
+
 echo "== 1/7 Building sample C# assembly =="
 build_proj samples/godot/GodotSample/GodotSample.csproj
 
@@ -23,7 +31,7 @@ invoke_cli \
 # input dlls, the engine version, and the Godot project unchanged since the
 # last green pass, the compile and both engine runs would only repeat it.
 if gate_cache_check "$OUT" \
-        "godot-sample|godot=$(or_none "$(first_line "$("$GODOT" --version 2>/dev/null)")")" \
+        "godot-sample|godot=$(or_none "$(first_line "$(run_godot_isolated "$GODOT_USER_ROOT" "$GODOT" --version 2>/dev/null)")")" \
         "samples/godot/GodotSample/bin/$CONFIG/$TFM/GodotSample.dll" \
         "samples/godot/GodotSample/bin/$CONFIG/$TFM/GodotSharp.dll" \
         "$PROJECT"; then
@@ -38,11 +46,13 @@ compile_gdextension "$OUT" "$PROJECT/bin/$(lib_name "$DN2CPP_GDEXT_LIB")"
 echo "== 4/7 Importing Godot project (registers the extension) =="
 # Note: the first import may abort during editor teardown (Godot headless
 # doc-gen bug; harmless — .godot/extension_list.cfg is already written).
-run_with_watchdog 300 "$GODOT" --headless --path "$PROJECT" --import >/dev/null 2>&1 || true
+run_with_watchdog 300 run_godot_isolated "$GODOT_USER_ROOT" \
+    "$GODOT" --headless --path "$PROJECT" --import >/dev/null 2>&1 || true
 
 echo "== 5/7 Running inside Godot (headless, GDScript -> C#) =="
 rc=0
-SCRIPT_OUT=$(run_with_watchdog 120 "$GODOT" --headless --path "$PROJECT" --script res://test.gd 2>&1) || rc=$?
+SCRIPT_OUT=$(run_with_watchdog 120 run_godot_isolated "$GODOT_USER_ROOT" \
+    "$GODOT" --headless --path "$PROJECT" --script res://test.gd 2>&1) || rc=$?
 echo "$SCRIPT_OUT"
 if [ "$rc" -ne 0 ]; then
     echo "FAIL: script run exited with $rc (137 = watchdog kill — a hung run)" >&2
@@ -174,7 +184,8 @@ grep -qE "SCRIPT ERROR|Parse Error" <<<"$SCRIPT_OUT" \
 
 echo "== 6/7 Running scene with a C# node (_Ready/_Process bridge) =="
 rc=0
-SCENE_OUT=$(run_with_watchdog 120 "$GODOT" --headless --path "$PROJECT" main.tscn --quit-after 3 2>&1) || rc=$?
+SCENE_OUT=$(run_with_watchdog 120 run_godot_isolated "$GODOT_USER_ROOT" \
+    "$GODOT" --headless --path "$PROJECT" main.tscn --quit-after 3 2>&1) || rc=$?
 echo "$SCENE_OUT"
 if [ "$rc" -ne 0 ]; then
     echo "FAIL: scene run exited with $rc (137 = watchdog kill — a hung run)" >&2

--- a/gates/build-and-run-hotupdate-godot.sh
+++ b/gates/build-and-run-hotupdate-godot.sh
@@ -52,6 +52,12 @@ OUT=artifacts/hotupdate-godot
 GODOT=${GODOT:-godot}
 PROJECT=samples/godot/godot-project-hotupdate
 
+HOTUPDATE_GODOT_USER_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/dn2cpp-hotupdate-godot.XXXXXX")
+hotupdate_godot_cleanup() {
+    rm -rf "$HOTUPDATE_GODOT_USER_ROOT"
+}
+gate_add_exit_hook hotupdate_godot_cleanup
+
 echo "== 1/7 Building base + patch C# assemblies =="
 build_proj samples/godot/HotUpdateGodotSample/HotUpdateGodotSample.csproj
 build_proj samples/dotnet/HotUpdateGodotPatch/HotUpdateGodotPatch.csproj
@@ -74,7 +80,7 @@ grep -q dn2cpp_base_image_abi_hash "$OUT/generated.cpp" \
 # them after this point — unchanged inputs mean the compile, both bakes, and
 # both engine runs would only repeat the last green result.
 if gate_cache_check "$OUT" \
-        "hotupdate-godot|godot=$(or_none "$(first_line "$("$GODOT" --version 2>/dev/null)")")" \
+        "hotupdate-godot|godot=$(or_none "$(first_line "$(run_godot_isolated "$HOTUPDATE_GODOT_USER_ROOT" "$GODOT" --version 2>/dev/null)")")" \
         "$base_app" "$patch_app" "$badmathf_app" \
         samples/godot/HotUpdateGodotSample/hotupdate-refs.txt \
         "$PROJECT"; then
@@ -107,11 +113,13 @@ cp "$OUT/HotUpdateGodotBadPatchMathf.bpi" "$OUT/patches-mathf/mathf.bpi"
 echo "== 5/7 Importing Godot project (registers the extension) =="
 # Note: the first import may abort during editor teardown (Godot headless
 # doc-gen bug; harmless — .godot/extension_list.cfg is already written).
-run_with_watchdog 300 "$GODOT" --headless --path "$PROJECT" --import >/dev/null 2>&1 || true
+run_with_watchdog 300 run_godot_isolated "$HOTUPDATE_GODOT_USER_ROOT" \
+    "$GODOT" --headless --path "$PROJECT" --import >/dev/null 2>&1 || true
 
 echo "== 6/7 Running the scene (deploy from _Ready, observe on _Process frames) =="
 rc=0
-SCENE_OUT=$(run_with_watchdog 120 env DN2CPP_HOTPATCH_DIR="$PWD/$OUT/patches" \
+SCENE_OUT=$(run_with_watchdog 120 run_godot_isolated "$HOTUPDATE_GODOT_USER_ROOT" \
+    env DN2CPP_HOTPATCH_DIR="$PWD/$OUT/patches" \
     "$GODOT" --headless --path "$PROJECT" main.tscn --quit-after 6 2>&1) || rc=$?
 echo "$SCENE_OUT"
 if [ "$rc" -ne 0 ]; then
@@ -188,7 +196,8 @@ echo "== 7/7 Negative deployment: a patch importing a placeholder shim body =="
 # unresolved-import bind failure (caught + surfaced by the base), the patch
 # entry must never run, and the engine keeps running unpatched.
 rc=0
-NEG_OUT=$(run_with_watchdog 120 env DN2CPP_HOTPATCH_DIR="$PWD/$OUT/patches-mathf" \
+NEG_OUT=$(run_with_watchdog 120 run_godot_isolated "$HOTUPDATE_GODOT_USER_ROOT" \
+    env DN2CPP_HOTPATCH_DIR="$PWD/$OUT/patches-mathf" \
     "$GODOT" --headless --path "$PROJECT" main.tscn --quit-after 6 2>&1) || rc=$?
 echo "$NEG_OUT"
 if [ "$rc" -ne 0 ]; then

--- a/gates/build-and-run-sdk-sample.sh
+++ b/gates/build-and-run-sdk-sample.sh
@@ -10,6 +10,12 @@ GODOT=${GODOT:-godot}
 PROJECT=samples/godot/godot-project-sdk
 SAMPLE=samples/godot/SdkSample
 
+SDK_GODOT_USER_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/dn2cpp-sdk-sample.XXXXXX")
+sdk_sample_cleanup() {
+    rm -rf "$SDK_GODOT_USER_ROOT"
+}
+gate_add_exit_hook sdk_sample_cleanup
+
 echo "== 1/6 Building sample C# assembly (against the GodotSharp shim) =="
 build_proj "$SAMPLE/SdkSample.csproj"
 
@@ -23,7 +29,7 @@ invoke_cli \
 # the Godot project unchanged since the last green pass, the compile and the
 # engine run would only repeat that result.
 if gate_cache_check "$OUT" \
-        "sdk-sample|godot=$(or_none "$(first_line "$("$GODOT" --version 2>/dev/null)")")" \
+        "sdk-sample|godot=$(or_none "$(first_line "$(run_godot_isolated "$SDK_GODOT_USER_ROOT" "$GODOT" --version 2>/dev/null)")")" \
         "$SAMPLE/bin/$CONFIG/$TFM/SdkSample.dll" \
         "$SAMPLE/bin/$CONFIG/$TFM/GodotSharp.dll" \
         "$PROJECT"; then
@@ -38,8 +44,10 @@ compile_gdextension "$OUT" "$PROJECT/bin/$(lib_name "$DN2CPP_GDEXT_LIB")"
 echo "== 4/6 Importing Godot project (registers the extension) =="
 # The first import may abort during editor teardown (Godot headless doc-gen bug;
 # harmless — .godot/extension_list.cfg is already written).
-"$GODOT" --headless --path "$PROJECT" --import >/dev/null 2>&1 || true
+run_godot_isolated "$SDK_GODOT_USER_ROOT" \
+    "$GODOT" --headless --path "$PROJECT" --import >/dev/null 2>&1 || true
 
 echo "== 5/6 Running inside Godot (headless, GDScript -> standard C# node) =="
-"$GODOT" --headless --path "$PROJECT" --script res://test.gd
+run_godot_isolated "$SDK_GODOT_USER_ROOT" \
+    "$GODOT" --headless --path "$PROJECT" --script res://test.gd
 gate_cache_commit

--- a/gates/run-all-gates.sh
+++ b/gates/run-all-gates.sh
@@ -278,7 +278,8 @@ gate_name() {
 header "Phase 1/5 — Building CLI"
 T_SUITE=$(now)
 T_PHASE=$T_SUITE
-dotnet build src/Dn2Cpp.Cli/Dn2Cpp.Cli.csproj -c "$CONFIG" --nologo -v q
+dotnet build src/Dn2Cpp.Cli/Dn2Cpp.Cli.csproj -c "$CONFIG" --nologo -v q \
+    -p:BuildInParallel=false
 
 CLI_DLL="$(pwd)/src/Dn2Cpp.Cli/bin/$CONFIG/$TFM/dn2cpp.dll"
 if [ ! -f "$CLI_DLL" ]; then

--- a/src/GodotSharpShim/GodotSharp.csproj
+++ b/src/GodotSharpShim/GodotSharp.csproj
@@ -27,7 +27,7 @@
 
   <Target Name="GenerateGodotBindings" BeforeTargets="BeforeCompile"
           Inputs="$(GodotApiJson)" Outputs="$(GodotShims)">
-    <Exec Command="dotnet run --project $(MSBuildThisFileDirectory)../Dn2Cpp.Cli -- --generate-bindings &quot;$(GodotApiJson)&quot; &quot;$(GodotShims)&quot;" />
+    <Exec Command="dotnet run --project $(MSBuildThisFileDirectory)../Dn2Cpp.Cli -p:BuildInParallel=false -- --generate-bindings &quot;$(GodotApiJson)&quot; &quot;$(GodotShims)&quot;" />
   </Target>
 
 </Project>


### PR DESCRIPTION
## 概要

- standalone gate と Godot shim 生成の CLI を直列 restore graph でビルドし、失敗時や成果物欠落時は stale DLL を実行せず fail closed にする
- 通常版 Godot を使う sample、SDK sample、hot-update gate の editor state と `user://` を実行ごとの scratch root に隔離する
- ccache の既定ディレクトリを ignored かつ書き込み可能な `artifacts/.ccache` に置き、明示的な `CCACHE_DIR` は保持する

## 検証

- `dotnet build src/Dn2Cpp.Cli -c Release --no-restore -v:minimal`
- `env -u DN2CPP_CLI_DLL -u CCACHE_DIR DN2CPP_NO_MACHINE_LOCK=1 DN2CPP_GATE_CACHE=0 ./gates/build-and-run-sdk-sample.sh`
- `DN2CPP_SKIP_BUILD=1 DN2CPP_GATE_CACHE=0 ./gates/build-and-run-godot-sample.sh`（検証済み CLI DLL を明示）
- `DN2CPP_SKIP_BUILD=1 DN2CPP_GATE_CACHE=0 ./gates/build-and-run-hotupdate-godot.sh`（検証済み CLI DLL を明示）
- `./gates/build-and-run-doc-claims.sh`
- `bash -n gates/_common.sh gates/build-and-run-godot-sample.sh gates/build-and-run-sdk-sample.sh gates/build-and-run-hotupdate-godot.sh gates/run-all-gates.sh`
- `xmllint --noout src/GodotSharpShim/GodotSharp.csproj`
- `git diff --check`
- fake `dotnet` と stale DLL を使い、build failure / DLL 欠落時に `dotnet exec` へ進まないことを確認
- Linux、macOS、Windows の `run_godot_isolated` 分岐を subshell で実行し、呼出元へ環境変数が漏れないことを確認

`gates/pre-merge.sh` は human-only のため実行していません。