### PR TITLE
Parallelize safe method body transpilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -652,6 +652,10 @@ under *Backends* above):
 - **Gap-inventory measurement** (`--measure`) records a body's compile
   failure as a gap row instead of aborting the run, so it can drain a whole
   real-world assembly and report what would not emit.
+- **Parallel transpilation** uses the host's logical processor count as its
+  default concurrency ceiling and adapts worker fan-out to each batch of
+  reachable method bodies, including `--measure`. Pass `--jobs <n>` to set an
+  explicit ceiling, or `--jobs 1` for serial execution.
 
 ## Optimization
 

--- a/gates/_platform_isa.sh
+++ b/gates/_platform_isa.sh
@@ -86,11 +86,12 @@ platform_isa_join() {
     printf '%s\n' "$out"
 }
 
-PLATFORM_ISA_WINDOWS_SUPPORTED_CHUNK_ROWS=8
+PLATFORM_ISA_WINDOWS_SUPPORTED_CHUNK_ROWS=1
 
 # A supported X86 probe touches a large fraction of the wide generated image.
 # Bound its Windows working-set high-water mark by giving each native process a
-# fixed slice of the selection; the oracle uses the identical slices.
+# single registry row; row costs vary too much for a wider fixed-size slice to
+# be a memory bound. The oracle uses the identical slices.
 platform_isa_supported_chunks() {
     local csv="$1" limit="$PLATFORM_ISA_WINDOWS_SUPPORTED_CHUNK_ROWS"
     local rest="$csv" item chunk="" count=0
@@ -330,7 +331,7 @@ _platform_isa_native_plan_self_check() {
     flattened=${chunks//$'\n'/,}
     [ "$flattened" = 'a,b,c,d,e,f,g,h,i' ] \
         || { echo "FAIL: platform-ISA supported-run chunks changed selection order" >&2; return 1; }
-    [ "$(grep -c . <<<"$chunks" || true)" -eq 2 ] \
+    [ "$(grep -c . <<<"$chunks" || true)" -eq 9 ] \
         || { echo "FAIL: platform-ISA supported-run chunk bound is not enforced" >&2; return 1; }
     for arch in x86 arm; do
         rows=$(platform_isa_table_rows "$arch") || return 1

--- a/gates/build-and-run-cli-args.sh
+++ b/gates/build-and-run-cli-args.sh
@@ -14,7 +14,7 @@
 # CLI arg handling: it transpiles (never compiles), so it needs no C++/Godot/
 # Emscripten/NDK toolchain and always RUNS (never gate_skip).
 #
-# Four assertions, one flag apart:
+# Assertions, one flag family apart:
 #   1. Baseline — the same input with correct flags transpiles and exits 0. The
 #      regression guard that keeps the unknown-arg check from over-rejecting valid
 #      flags (a check that rejected everything would pass 2-4 while being useless).
@@ -31,13 +31,19 @@
 #      was accepted as a no-op would leave the shim injected while the caller
 #      believed it had been declined — the same silent-ignore failure shape the
 #      whole gate exists to prevent, one flag later.
+#   7. Both frontends accept `--jobs 1` and `--jobs 2`.
+#   8. Both frontends reject a missing, zero, negative, or non-numeric jobs value.
 source "$(dirname "$0")/_common.sh"
 
 PROJECT=HelloWorld
 
 echo "== Building the sample assembly =="
 build_proj "samples/dotnet/$PROJECT/$PROJECT.csproj"
+build_proj src/Dn2Cpp.Cli.Console/Dn2Cpp.Cli.Console.csproj
 APP="samples/dotnet/$PROJECT/bin/$CONFIG/$TFM/$PROJECT.dll"
+CONSOLE_CLI="src/Dn2Cpp.Cli.Console/bin/$CONFIG/$TFM/dn2cpp-console.dll"
+[ -f "$CONSOLE_CLI" ] \
+    || { echo "FAIL: console CLI not built: $CONSOLE_CLI" >&2; exit 1; }
 CORELIB=$(locate_corelib)
 echo "corelib: $CORELIB"
 
@@ -56,19 +62,30 @@ rm -rf "$OUT"; mkdir -p "$OUT"
 # transpile into an abort, strict/assert modes, drain order) must move the
 # context explicitly, or a warm hit would replay a green a live run cannot give.
 tenv="tenv:${DN2CPP_MAX_GENERIC_DEPTH:-}/${DN2CPP_MAX_INSTANTIATIONS:-}/${DN2CPP_MAX_HEAP_MB:-}/${DN2CPP_SHARED_ASSERT:-}/${DN2CPP_STRICT_COMPLETION:-}/${DN2CPP_SPEC_DRAIN:-}"
-if gate_cache_check "$OUT" "cli-args|cli:$(_gate_cli_hash)|$CORELIB|$tenv" "$APP"; then
+if gate_cache_check "$OUT" "cli-args|cli:$(_gate_cli_hash)|$CORELIB|$tenv" \
+        "$APP" "$CONSOLE_CLI"; then
     gate_cache_hit_msg
     exit 0
 fi
 
-# assert_rejected LABEL NEEDLE -- CLI-ARGS...
+# run_frontend FRONTEND -- CLI-ARGS...
+run_frontend() {
+    local frontend="$1"; shift
+    case "$frontend" in
+        full) invoke_cli "$@" ;;
+        console) dotnet exec "$CONSOLE_CLI" "$@" ;;
+        *) echo "FAIL: unknown CLI frontend '$frontend'" >&2; return 2 ;;
+    esac
+}
+
+# assert_rejected LABEL NEEDLE FRONTEND -- CLI-ARGS...
 # Run the CLI with the given args; the run must exit NONZERO and its stderr must
 # contain NEEDLE (the offending token).
 assert_rejected() {
-    local label="$1" needle="$2"; shift 2
+    local label="$1" needle="$2" frontend="$3"; shift 3
     local err rc
     set +e
-    err=$(invoke_cli "$@" 2>&1 >/dev/null)
+    err=$(run_frontend "$frontend" "$@" 2>&1 >/dev/null)
     rc=$?
     set -e
     if [ "$rc" -eq 0 ]; then
@@ -85,15 +102,15 @@ assert_rejected() {
     printf '%s\n' "$err" | LC_ALL=C sed 's/^/    /'
 }
 
-# assert_accepted LABEL -- CLI-ARGS...
+# assert_accepted LABEL FRONTEND -- CLI-ARGS...
 # The mirror of assert_rejected: the run must exit ZERO. Guards against an
 # over-rejecting arg loop, which would pass every rejection assertion above while
 # being useless.
 assert_accepted() {
-    local label="$1"; shift
+    local label="$1" frontend="$2"; shift 2
     local err rc
     set +e
-    err=$(invoke_cli "$@" 2>&1 >/dev/null)
+    err=$(run_frontend "$frontend" "$@" 2>&1 >/dev/null)
     rc=$?
     set -e
     if [ "$rc" -ne 0 ]; then
@@ -105,7 +122,7 @@ assert_accepted() {
 }
 
 # ── Assertion 1: baseline — valid flags must still transpile (exit 0) ──────────
-echo "== 1/6 baseline: valid input + flags transpiles and exits 0 =="
+echo "== 1/10 baseline: valid input + flags transpiles and exits 0 =="
 set +e
 invoke_cli "$APP" -r "$CORELIB" -o "$OUT" >/dev/null 2>&1
 base_rc=$?
@@ -119,20 +136,20 @@ fi
 echo "OK: valid transpile exit 0, emitted generated.cpp"
 
 # ── Assertion 2: a bogus flag is a hard error naming the token ─────────────────
-echo "== 2/6 an unrecognized flag must fail loudly =="
-assert_rejected "bogus flag" "--bogus-flag" "$APP" -r "$CORELIB" -o "$OUT" --bogus-flag
+echo "== 2/10 an unrecognized flag must fail loudly =="
+assert_rejected "bogus flag" "--bogus-flag" full "$APP" -r "$CORELIB" -o "$OUT" --bogus-flag
 
 # ── Assertion 3: a near-miss typo of a real flag is rejected, not dropped ───────
 # The concrete failure: `--tirm-reflection` (transposed) must NOT be silently
 # ignored and leave reflection metadata IN while the caller believes it was stripped.
-echo "== 3/6 a typo of a real flag must fail loudly, not be silently dropped =="
-assert_rejected "typo flag" "--tirm-reflection" "$APP" -r "$CORELIB" -o "$OUT" --tirm-reflection
+echo "== 3/10 a typo of a real flag must fail loudly, not be silently dropped =="
+assert_rejected "typo flag" "--tirm-reflection" full "$APP" -r "$CORELIB" -o "$OUT" --tirm-reflection
 
 # ── Assertion 4: a second positional is a hard error ───────────────────────────
 # `extra.dll` need not exist: the arg loop rejects the extra positional before any
 # file access, so this stays a pure, deterministic arg-loop check.
-echo "== 4/6 an extra positional argument must fail loudly =="
-assert_rejected "extra positional" "extra.dll" "$APP" extra.dll -o "$OUT"
+echo "== 4/10 an extra positional argument must fail loudly =="
+assert_rejected "extra positional" "extra.dll" full "$APP" extra.dll -o "$OUT"
 
 # ── Assertion 5: --no-default-ref with a KNOWN name is accepted ────────────────
 # HelloWorld references no System.IO.Compression, so nothing would have been
@@ -140,15 +157,35 @@ assert_rejected "extra positional" "extra.dll" "$APP" extra.dll -o "$OUT"
 # terms, whether or not the shim it declines was ever in play; a name-set check
 # that ran only when the shim was live would let a typo through on every other
 # program.
-echo "== 5/6 --no-default-ref with a known shim name must be accepted (exit 0) =="
-assert_accepted "no-default-ref known" "$APP" -r "$CORELIB" -o "$OUT" --no-default-ref DnZlib
+echo "== 5/10 --no-default-ref with a known shim name must be accepted (exit 0) =="
+assert_accepted "no-default-ref known" full "$APP" -r "$CORELIB" -o "$OUT" --no-default-ref DnZlib
 
 # ── Assertion 6: --no-default-ref with an UNKNOWN name is a hard error ─────────
 # A silently-accepted typo is the worst outcome available here: the caller
 # believes the shim was declined, the shim is injected anyway, and the only
 # symptom is a backend they did not choose.
-echo "== 6/6 --no-default-ref with an unknown name must fail loudly =="
-assert_rejected "no-default-ref unknown" "DnBogus" "$APP" -r "$CORELIB" -o "$OUT" --no-default-ref DnBogus
+echo "== 6/10 --no-default-ref with an unknown name must fail loudly =="
+assert_rejected "no-default-ref unknown" "DnBogus" full "$APP" -r "$CORELIB" -o "$OUT" --no-default-ref DnBogus
+
+echo "== 7/10 full CLI accepts explicit sequential and parallel worker counts =="
+assert_accepted "full jobs 1" full "$APP" -r "$CORELIB" -o "$OUT" --jobs 1
+assert_accepted "full jobs 2" full "$APP" -r "$CORELIB" -o "$OUT" --jobs 2
+
+echo "== 8/10 console CLI accepts explicit sequential and parallel worker counts =="
+assert_accepted "console jobs 1" console "$APP" -r "$CORELIB" -o "$OUT" --jobs 1
+assert_accepted "console jobs 2" console "$APP" -r "$CORELIB" -o "$OUT" --jobs 2
+
+echo "== 9/10 full CLI rejects malformed worker counts =="
+assert_rejected "full jobs missing" "--jobs" full "$APP" -r "$CORELIB" -o "$OUT" --jobs
+assert_rejected "full jobs zero" "0" full "$APP" -r "$CORELIB" -o "$OUT" --jobs 0
+assert_rejected "full jobs negative" "-2" full "$APP" -r "$CORELIB" -o "$OUT" --jobs -2
+assert_rejected "full jobs non-numeric" "many" full "$APP" -r "$CORELIB" -o "$OUT" --jobs many
+
+echo "== 10/10 console CLI rejects malformed worker counts =="
+assert_rejected "console jobs missing" "--jobs" console "$APP" -r "$CORELIB" -o "$OUT" --jobs
+assert_rejected "console jobs zero" "0" console "$APP" -r "$CORELIB" -o "$OUT" --jobs 0
+assert_rejected "console jobs negative" "-2" console "$APP" -r "$CORELIB" -o "$OUT" --jobs -2
+assert_rejected "console jobs non-numeric" "many" console "$APP" -r "$CORELIB" -o "$OUT" --jobs many
 
 gate_cache_commit
-echo "PASS: unrecognized options, extra positionals and unknown --no-default-ref names are hard errors; valid flags still transpile"
+echo "PASS: both CLIs accept positive --jobs counts and reject malformed values; other invalid arguments remain hard errors"

--- a/gates/build-and-run-emit-order-stability.sh
+++ b/gates/build-and-run-emit-order-stability.sh
@@ -35,12 +35,19 @@
 # mode makes that walk throw instead of decoding, so this gate can hold the discipline: the
 # corpus must transpile clean under it, and emit the same bytes with it on and off (it
 # changes nothing that reaches the output — if it did, the deferral would not be sound).
+#
+# The worker-count and drain-order axes are isolated with three corners: jobs=1/FIFO,
+# jobs=2/FIFO and jobs=2/LIFO. Thus one comparison proves scheduling cannot perturb
+# emitted bytes and the other independently preserves the original discovery-order
+# proof. A known P/Invoke gap also runs through measure with both worker counts; its
+# report and summary keep the same order. The dedicated parallel-bodies gate proves
+# actual worker overlap on a host with at least two logical processors.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 # shellcheck source=gates/_common.sh
 . gates/_common.sh
 
-echo "== 1/4 Locating the real CoreLib =="
+echo "== 1/5 Locating the real CoreLib =="
 corelib=$(locate_corelib)
 bcl=$(dirname "$corelib")
 echo "corlib: $corelib"
@@ -56,10 +63,11 @@ SAMPLES=(
     "ArrayCore|"
 )
 
-echo "== 2/4 Building app assemblies =="
+echo "== 2/5 Building app assemblies =="
 for entry in "${SAMPLES[@]}"; do
     build_proj "samples/dotnet/${entry%%|*}/${entry%%|*}.csproj"
 done
+build_proj samples/dotnet/PInvokeByValTStrBad/PInvokeByValTStrBad.csproj
 
 # The whole gate is transpiler BEHAVIOR — byte-identity across drain orders and
 # strict-completion cleanliness; its dozen-plus transpiles ARE the work and much
@@ -70,15 +78,16 @@ done
 # ambient DN2CPP_SPEC_DRAIN/STRICT_COMPLETION (this gate's own levers!) or a
 # cap/assert knob changes what the runs below do, with no surface to catch it.
 tenv="tenv:${DN2CPP_MAX_GENERIC_DEPTH:-}/${DN2CPP_MAX_INSTANTIATIONS:-}/${DN2CPP_MAX_HEAP_MB:-}/${DN2CPP_SHARED_ASSERT:-}/${DN2CPP_STRICT_COMPLETION:-}/${DN2CPP_SPEC_DRAIN:-}"
-if gate_cache_check "$OUT" "emit-order-stability|cli:$(_gate_cli_hash)|$corelib|$tenv" \
+if gate_cache_check "$OUT" "emit-order-stability|jobs:1,2|measure-jobs:1,2|cli:$(_gate_cli_hash)|$corelib|$tenv" \
         "samples/dotnet/ReflectTypes/bin/$CONFIG/$TFM/ReflectTypes.dll" \
         "samples/dotnet/StringCore/bin/$CONFIG/$TFM/StringCore.dll" \
-        "samples/dotnet/ArrayCore/bin/$CONFIG/$TFM/ArrayCore.dll"; then
+        "samples/dotnet/ArrayCore/bin/$CONFIG/$TFM/ArrayCore.dll" \
+        "samples/dotnet/PInvokeByValTStrBad/bin/$CONFIG/$TFM/PInvokeByValTStrBad.dll"; then
     gate_cache_hit_msg
     exit 0
 fi
 
-echo "== 3/4 Transpiling each FIFO and LIFO, comparing bytes =="
+echo "== 3/5 Isolating worker-count and drain-order byte stability =="
 for entry in "${SAMPLES[@]}"; do
     proj=${entry%%|*}
     extras=${entry#*|}
@@ -100,26 +109,37 @@ for entry in "${SAMPLES[@]}"; do
         [ "$sharing" = off ] && share_flag="--no-shared-generics"
 
         fifo="$OUT/$proj-$sharing-fifo"
+        parallel_fifo="$OUT/$proj-$sharing-jobs2-fifo"
         lifo="$OUT/$proj-$sharing-lifo"
-        rm -rf "$fifo" "$lifo"
+        rm -rf "$fifo" "$parallel_fifo" "$lifo"
 
         # shellcheck disable=SC2086  # $share_flag is one flag or empty, deliberately
-        invoke_cli "$app" "${refs[@]}" $share_flag -o "$fifo" >/dev/null
+        invoke_cli "$app" "${refs[@]}" $share_flag --jobs 1 -o "$fifo" >/dev/null
         # shellcheck disable=SC2086
-        DN2CPP_SPEC_DRAIN=lifo invoke_cli "$app" "${refs[@]}" $share_flag -o "$lifo" >/dev/null
+        invoke_cli "$app" "${refs[@]}" $share_flag --jobs 2 -o "$parallel_fifo" >/dev/null
 
-        if ! diff -r "$fifo" "$lifo" >/dev/null 2>&1; then
+        # shellcheck disable=SC2086
+        DN2CPP_SPEC_DRAIN=lifo \
+            invoke_cli "$app" "${refs[@]}" $share_flag --jobs 2 -o "$lifo" >/dev/null
+
+        if ! diff -r "$fifo" "$parallel_fifo" >/dev/null 2>&1; then
+            echo "FAIL: $proj (shared generics $sharing) — the emitted C++ depends on"
+            echo "      the body worker count. The diff says where:"
+            head -20 <<<"$(diff -r "$fifo" "$parallel_fifo")"
+            exit 1
+        fi
+        if ! diff -r "$parallel_fifo" "$lifo" >/dev/null 2>&1; then
             echo "FAIL: $proj (shared generics $sharing) — the emitted C++ depends on"
             echo "      the specialization drain order. Emission is reading discovery"
             echo "      order somewhere; the diff says where:"
-            head -20 <<<"$(diff -r "$fifo" "$lifo")"
+            head -20 <<<"$(diff -r "$parallel_fifo" "$lifo")"
             exit 1
         fi
-        echo "OK: $proj (shared generics $sharing) — byte-identical across drain orders"
+        echo "OK: $proj (shared generics $sharing) — each isolated axis is byte-identical"
     done
 done
 
-echo "== 4/4 Every member read is one somebody asked for (DN2CPP_STRICT_COMPLETION=1) =="
+echo "== 4/5 Every member read is one somebody asked for (DN2CPP_STRICT_COMPLETION=1) =="
 for entry in "${SAMPLES[@]}"; do
     proj=${entry%%|*}
     extras=${entry#*|}
@@ -145,7 +165,8 @@ for entry in "${SAMPLES[@]}"; do
 
         rc=0
         # shellcheck disable=SC2086
-        err=$(DN2CPP_STRICT_COMPLETION=1 invoke_cli "$app" "${refs[@]}" $share_flag -o "$strict" 2>&1 >/dev/null) || rc=$?
+        err=$(DN2CPP_STRICT_COMPLETION=1 \
+            invoke_cli "$app" "${refs[@]}" $share_flag --jobs 2 -o "$strict" 2>&1 >/dev/null) || rc=$?
         if [ "$rc" -ne 0 ]; then
             echo "FAIL: $proj (shared generics $sharing) read a specialization's members without"
             echo "      asking for them. That is not a wrong answer — the accessor decodes them —"
@@ -169,6 +190,54 @@ for entry in "${SAMPLES[@]}"; do
     done
 done
 
+echo "== 5/5 --measure reports and summaries are stable across worker counts =="
+measure_app="samples/dotnet/PInvokeByValTStrBad/bin/$CONFIG/$TFM/PInvokeByValTStrBad.dll"
+measure_j1="$OUT/measure-jobs1"
+measure_j2="$OUT/measure-jobs2"
+rm -rf "$measure_j1" "$measure_j2"
+
+set +e
+DN2CPP_TIME=0 invoke_cli "$measure_app" -r "$corelib" --measure --jobs 1 -o "$measure_j1" \
+    >"$OUT/measure-jobs1.stdout" 2>"$OUT/measure-jobs1.stderr"
+measure_rc1=$?
+DN2CPP_TIME=1 invoke_cli "$measure_app" -r "$corelib" --measure --jobs 2 -o "$measure_j2" \
+    >"$OUT/measure-jobs2.stdout" 2>"$OUT/measure-jobs2.stderr"
+measure_rc2=$?
+set -e
+
+if [ "$measure_rc1" -ne 0 ] || [ "$measure_rc2" -ne 0 ]; then
+    echo "FAIL: --measure must exit 0 after recording the known gap; jobs=1 returned" \
+        "$measure_rc1 and jobs=2 returned $measure_rc2" >&2
+    exit 1
+fi
+[ -s "$measure_j1/s0-gaps.tsv" ] \
+    || { echo "FAIL: the known-gap fixture produced no jobs=1 gap row" >&2; exit 1; }
+[ -s "$measure_j2/s0-gaps.tsv" ] \
+    || { echo "FAIL: the known-gap fixture produced no jobs=2 gap row" >&2; exit 1; }
+
+if ! diff -r "$measure_j1" "$measure_j2" >/dev/null 2>&1; then
+    echo "FAIL: --measure sidecars depend on the worker count:" >&2
+    head -20 <<<"$(diff -r "$measure_j1" "$measure_j2")" >&2
+    exit 1
+fi
+
+# The summary names its output directory; normalize only that path before the
+# byte comparison. Stderr is compared too, preserving diagnostic order.
+sed "s|$measure_j1|MEASURE_OUT|g" "$OUT/measure-jobs1.stdout" \
+    >"$OUT/measure-jobs1.stdout.normalized"
+sed "s|$measure_j2|MEASURE_OUT|g" "$OUT/measure-jobs2.stdout" \
+    >"$OUT/measure-jobs2.stdout.normalized"
+sed "s|$measure_j1|MEASURE_OUT|g" "$OUT/measure-jobs1.stderr" \
+    >"$OUT/measure-jobs1.stderr.normalized"
+sed -e '/^dn2cpp-time:/d' -e "s|$measure_j2|MEASURE_OUT|g" "$OUT/measure-jobs2.stderr" \
+    >"$OUT/measure-jobs2.stderr.normalized"
+cmp -s "$OUT/measure-jobs1.stdout.normalized" "$OUT/measure-jobs2.stdout.normalized" \
+    || { echo "FAIL: --measure summary order depends on the worker count" >&2; exit 1; }
+cmp -s "$OUT/measure-jobs1.stderr.normalized" "$OUT/measure-jobs2.stderr.normalized" \
+    || { echo "FAIL: --measure diagnostic order depends on the worker count" >&2; exit 1; }
+echo "OK: --measure exit, sidecars, summary and diagnostics are identical for jobs=1 and jobs=2"
+
 gate_cache_commit
 echo "OK: emitted C++ is a function of the input, not of discovery order — and every"
-echo "    specialization whose members were decoded is one something asked for"
+echo "    specialization whose members were decoded is one something asked for; body"
+echo "    scheduling also preserves emit and measure output"

--- a/gates/build-and-run-http-get.sh
+++ b/gates/build-and-run-http-get.sh
@@ -1005,9 +1005,19 @@ grep -qi 'certificate' "$tlsdir/untrusted.err" && grep -qi 'trusted CA' "$tlsdir
     echo "FAIL: the transport's error does not name the certificate and the trust anchors:" >&2
     cat "$tlsdir/untrusted.err" >&2; exit 1; }
 # Corroboration from the other end of the wire, and the tightest form of "verification ran":
-# the server recorded a FAILED handshake and served nothing. With CURLOPT_SSL_VERIFYPEER at 0
-# the handshake would complete and this would be a `served` line instead.
-grep -q '^handshake-failed ' "$tlsdir/tls.log" || {
+# the server recorded a FAILED handshake and served nothing. The client can finish handling
+# its alert before the server's accept thread catches and logs the peer's alert, so wait for
+# that independent observation instead of racing it. With CURLOPT_SSL_VERIFYPEER at 0 the
+# handshake would complete and this would be a `served` line instead.
+handshake_failed=
+for _ in $(seq 1 50); do
+    if grep -q '^handshake-failed ' "$tlsdir/tls.log"; then
+        handshake_failed=1
+        break
+    fi
+    sleep 0.1
+done
+[ -n "$handshake_failed" ] || {
     echo "FAIL: the TLS server recorded no failed handshake — the client did not reject the certificate" >&2
     cat "$tlsdir/tls.log" >&2; exit 1; }
 servedafter="$(grep -c '^served ' "$tlsdir/tls.log" || true)"

--- a/gates/build-and-run-parallel-bodies.sh
+++ b/gates/build-and-run-parallel-bodies.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Parallel method-body scheduling: a jobs=2 measure run must put two proven-pure
+# bodies in flight concurrently. The fixture deliberately reaches exactly two
+# static scalar bodies and one non-pure Main body. One scalar body carries a raw
+# LOCAL_SIG and ldloc/stloc instructions, so the exact eligible/serial census also
+# holds the primitive-local classifier rather than merely observing unrelated BCL
+# work. The known P/Invoke marshalling gap keeps the run in measure mode without
+# adding a managed call edge. Shared generics are disabled here so the census is
+# one scheduling pass: the default two-pass protocol is covered by emit-order.
+source "$(dirname "$0")/_common.sh"
+
+echo "== 1/3 Locating the real CoreLib =="
+corelib=$(locate_corelib)
+echo "corlib: $corelib"
+
+echo "== 2/3 Building the primitive-local scheduling fixture =="
+PROJECT=PInvokeByValTStrBad
+build_proj "samples/dotnet/$PROJECT/$PROJECT.csproj"
+app="samples/dotnet/$PROJECT/bin/$CONFIG/$TFM/$PROJECT.dll"
+
+OUT=artifacts/parallel-bodies
+rm -rf "$OUT"
+mkdir -p "$OUT"
+
+# This gate measures transpiler behavior directly, so the CLI hash stands in for
+# the implementation. The generic/heap/assert knobs can change whether the body
+# fixpoint reaches the scheduler and therefore belong to the cache context.
+tenv="tenv:${DN2CPP_MAX_GENERIC_DEPTH:-}/${DN2CPP_MAX_INSTANTIATIONS:-}/${DN2CPP_MAX_HEAP_MB:-}/${DN2CPP_SHARED_ASSERT:-}/${DN2CPP_STRICT_COMPLETION:-}/${DN2CPP_SPEC_DRAIN:-}"
+if gate_cache_check "$OUT" "parallel-bodies|jobs:2|sharing:off|cli:$(_gate_cli_hash)|$corelib|$tenv" \
+        "$app"; then
+    gate_cache_hit_msg
+    exit 0
+fi
+
+echo "== 3/3 Proving primitive-local bodies overlap on two workers =="
+measure_out="$OUT/measure"
+set +e
+timing=$(DN2CPP_TIME=1 \
+    invoke_cli "$app" -r "$corelib" --measure --jobs 2 --no-shared-generics \
+    -o "$measure_out" \
+    2>&1 >/dev/null)
+rc=$?
+set -e
+if [ "$rc" -ne 0 ]; then
+    echo "FAIL: the jobs=2 measure transpile exited $rc:" >&2
+    printf '%s\n' "$timing" >&2
+    exit 1
+fi
+
+worker_line=$(grep '^dn2cpp-time: parallel-bodies ' <<<"$timing" || true)
+if grep -Eq '^dn2cpp-time: parallel-bodies requested 2 effective 1( |$)' \
+        <<<"$worker_line"; then
+    gate_skip "Environment.ProcessorCount < 2; two body workers cannot run concurrently"
+fi
+if ! grep -Eq '^dn2cpp-time: parallel-bodies requested 2 effective 2 peak 2 retries [0-9]+ eligible 2 serial 1$' \
+        <<<"$worker_line"; then
+    echo "FAIL: jobs=2 did not run exactly the two scalar fixture bodies concurrently" >&2
+    printf 'worker stats: %s\n' "${worker_line:-<missing>}" >&2
+    exit 1
+fi
+[ -s "$measure_out/s0-gaps.tsv" ] \
+    || { echo "FAIL: the measure fixture produced no known P/Invoke gap row" >&2; exit 1; }
+
+printf '%s\n' "$worker_line"
+gate_cache_commit
+echo "OK: two primitive scalar bodies overlapped; the raw LOCAL_SIG body was eligible"

--- a/gates/build-and-run-sync-primitives.sh
+++ b/gates/build-and-run-sync-primitives.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Blocking synchronization primitives on real threads — SemaphoreSlim (N consumers
 # wait, producer releases N), ManualResetEventSlim (gate N workers, one Set releases all,
-# IsSet), AutoResetEvent (strict ping-pong, 3 turns each), Monitor condition signaling,
+# IsSet), AutoResetEvent (strict ping-pong, 3 turns each), Monitor condition signaling
+# (Pulse/PulseAll preserve the wait-set identity),
 # CountdownEvent (N workers Signal, main Wait), and Barrier (N threads run P phases,
 # with a post-phase action). MethodImplSubset.cs adds MethodImplAttribute:
 # [MethodImpl(Synchronized)] instance/static/recursive/throwing bodies hammered

--- a/gates/measure-transpile-parallel.sh
+++ b/gates/measure-transpile-parallel.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# Transpile parallelism measurement aid. This is NOT a regression gate: wall
+# time and peak RSS depend on the machine and its load, so this script prints
+# observations and never enforces a speedup. The `measure-*` name keeps it out
+# of run-all-gates.sh's `build-and-run-*` discovery glob.
+#
+# The full managed CLI transpiles itself at jobs=1,2,4 and the automatic default.
+# DN2CPP_TIME supplies planning/body durations and worker/retry counts; the host
+# time utility supplies end-to-end wall time and peak RSS. Every repetition gets
+# a fresh output directory so stale chunks and filesystem reuse cannot change
+# the workload.
+#
+#   ./gates/measure-transpile-parallel.sh
+#   DN2CPP_PARALLEL_REPS=5 ./gates/measure-transpile-parallel.sh
+#   DN2CPP_PARALLEL_OUT=artifacts/my-run ./gates/measure-transpile-parallel.sh
+source "$(dirname "$0")/_common.sh"
+
+OUT_ROOT="${DN2CPP_PARALLEL_OUT:-artifacts/transpile-parallel}"
+REPS="${DN2CPP_PARALLEL_REPS:-3}"
+RESULTS="$OUT_ROOT/runs.tsv"
+
+case "$OUT_ROOT" in
+    ''|/|.|..) echo "error: refusing unsafe DN2CPP_PARALLEL_OUT '$OUT_ROOT'" >&2; exit 1 ;;
+esac
+case "$REPS" in
+    ''|*[!0-9]*|0) echo "error: DN2CPP_PARALLEL_REPS must be a positive integer" >&2; exit 1 ;;
+esac
+
+echo "== 1/3 Building the full CLI =="
+build_proj src/Dn2Cpp.Cli/Dn2Cpp.Cli.csproj
+BIN="src/Dn2Cpp.Cli/bin/$CONFIG/$TFM"
+CLI="$BIN/dn2cpp.dll"
+[ -f "$CLI" ] || { echo "error: CLI not built: $CLI" >&2; exit 1; }
+
+echo "== 2/3 Locating the net10 CoreLib and self-host references =="
+corelib=$(resolve_net10_corelib)
+bcl=$(dirname "$corelib")
+refs=()
+add_ref() { [ -f "$1" ] && refs+=(-r "$1"); return 0; }
+add_ref "$BIN/Dn2Cpp.Transpiler.dll"
+add_ref "$BIN/Dn2Cpp.Godot.dll"
+add_ref "$BIN/Dn2Cpp.DotnetModule.dll"
+add_ref "$corelib"
+add_ref "$bcl/System.Text.Json.dll"
+for dep in System.Linq System.Reflection.Metadata System.Collections.Immutable System.Collections \
+        System.Runtime System.Memory System.Console System.Linq.Expressions \
+        System.Text.Encodings.Web System.Threading System.Threading.Tasks; do
+    add_ref "$bcl/$dep.dll"
+done
+
+mkdir -p "$OUT_ROOT"
+printf 'jobs\trep\ttotal_ms\tplanning_ms\tcompile_bodies_ms\tpeak_rss_bytes\trequested\teffective\tpeak_workers\tretries\n' \
+    > "$RESULTS"
+
+TIME_BIN=/usr/bin/time
+case "$(uname -s)" in
+    Darwin) TIME_FLAG=-l ;;
+    *) TIME_FLAG=-v ;;
+esac
+
+elapsed_ms() {
+    case "$(uname -s)" in
+        Darwin)
+            awk '$2 == "real" { printf "%.0f\n", $1 * 1000; exit }' "$1"
+            ;;
+        *)
+            awk '/Elapsed \(wall clock\)/ {
+                fields=split($0, f, /[[:space:]]+/); value=f[fields]; n=split(value, p, ":");
+                if (n == 3) seconds=p[1] * 3600 + p[2] * 60 + p[3];
+                else if (n == 2) seconds=p[1] * 60 + p[2];
+                else seconds=p[1];
+                printf "%.0f\n", seconds * 1000; exit
+            }' "$1"
+            ;;
+    esac
+}
+
+rss_bytes() {
+    case "$(uname -s)" in
+        Darwin) awk '/maximum resident set size/ { print $1; exit }' "$1" ;;
+        *) awk -F: '/Maximum resident set size/ { gsub(/ /, "", $2); print $2 * 1024; exit }' "$1" ;;
+    esac
+}
+
+phase_ms() {
+    local phase="$1" log="$2"
+    awk -v phase="$phase" '$1 == "dn2cpp-time:" && $2 == phase { print $3; exit }' "$log"
+}
+
+echo "== 3/3 Measuring jobs=1,2,4,auto ($REPS repetitions each) =="
+for jobs in 1 2 4 auto; do
+    for rep in $(seq 1 "$REPS"); do
+        out="$OUT_ROOT/jobs-$jobs-rep-$rep"
+        log="$OUT_ROOT/jobs-$jobs-rep-$rep.log"
+        rm -rf "$out"
+        mkdir -p "$out"
+
+        set +e
+        if [ "$jobs" = auto ]; then
+            DN2CPP_TIME=1 "$TIME_BIN" "$TIME_FLAG" dotnet exec "$CLI" "$CLI" \
+                "${refs[@]}" --auto-ref -o "$out" > /dev/null 2> "$log"
+        else
+            DN2CPP_TIME=1 "$TIME_BIN" "$TIME_FLAG" dotnet exec "$CLI" "$CLI" \
+                "${refs[@]}" --auto-ref --jobs "$jobs" -o "$out" \
+                > /dev/null 2> "$log"
+        fi
+        rc=$?
+        set -e
+        if [ "$rc" -ne 0 ]; then
+            echo "error: jobs=$jobs repetition $rep exited $rc; see $log" >&2
+            exit "$rc"
+        fi
+
+        total=$(elapsed_ms "$log")
+        planning=$(phase_ms plan-bodies "$log")
+        bodies=$(phase_ms compile-bodies "$log")
+        rss=$(rss_bytes "$log")
+        worker_line=$(sed -n 's/^dn2cpp-time: parallel-bodies requested \([0-9][0-9]*\) effective \([0-9][0-9]*\) peak \([0-9][0-9]*\) retries \([0-9][0-9]*\).*$/\1\t\2\t\3\t\4/p' "$log")
+        worker_line=${worker_line:-$'?\t?\t?\t?'}
+        printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+            "$jobs" "$rep" "${total:-?}" "${planning:-?}" "${bodies:-?}" \
+            "${rss:-?}" "$worker_line" | tee -a "$RESULTS"
+    done
+done
+
+echo
+echo "medians (milliseconds except RSS):"
+printf '  %-6s %10s %10s %10s %14s\n' jobs total planning bodies peak_rss_bytes
+for jobs in 1 2 4 auto; do
+    awk -F'\t' -v wanted="$jobs" '$1 == wanted { print $3, $4, $5, $6 }' "$RESULTS" \
+        | awk -v label="$jobs" '{ total[NR]=$1; planning[NR]=$2; bodies[NR]=$3; rss[NR]=$4 }
+            END {
+                lo=int((NR + 1) / 2); hi=int((NR + 2) / 2);
+                for (i=1; i<=NR; i++)
+                    for (j=i+1; j<=NR; j++) {
+                        if (total[i] > total[j]) { t=total[i]; total[i]=total[j]; total[j]=t }
+                        if (planning[i] > planning[j]) { t=planning[i]; planning[i]=planning[j]; planning[j]=t }
+                        if (bodies[i] > bodies[j]) { t=bodies[i]; bodies[i]=bodies[j]; bodies[j]=t }
+                        if (rss[i] > rss[j]) { t=rss[i]; rss[i]=rss[j]; rss[j]=t }
+                    }
+                printf "  %-6s %10.0f %10.0f %10.0f %14.0f\n", label,
+                    (total[lo] + total[hi]) / 2,
+                    (planning[lo] + planning[hi]) / 2,
+                    (bodies[lo] + bodies[hi]) / 2,
+                    (rss[lo] + rss[hi]) / 2
+            }'
+done
+echo "per-run data: $RESULTS"

--- a/runtime/core/intrinsics/dn2cpp_system_threading.cpp
+++ b/runtime/core/intrinsics/dn2cpp_system_threading.cpp
@@ -281,25 +281,64 @@ int64_t dn2cpp_interlocked_and_i8(int64_t* loc, int64_t value)
 // bounded leak — acceptable, mirrors how a real CLR's sync-block table retains
 // inflated locks).
 //
-// The lock is a hand-rolled recursive mutex built on a plain std::mutex plus two
+// The lock is a hand-rolled recursive mutex built on a plain std::mutex and
 // condition variables, rather than std::recursive_mutex. We need this because
 // Monitor.Wait must atomically (a) fully release the lock — including the entire
 // recursion depth — (b) block on a condition signaled by Pulse/PulseAll, and
 // (c) re-acquire to the saved depth on wake; std::recursive_mutex exposes none of
 // that. Tracking the owner thread id and recursion count by hand gives us all
-// three. `lock_cv` wakes threads waiting to acquire the lock; `wait_cv` wakes
-// threads parked in Monitor.Wait.
+// three. `lock_cv` wakes threads waiting to acquire the lock. Each Wait has its
+// own condition variable so a thread that parks after Pulse/PulseAll cannot
+// consume a notification issued to the earlier wait set.
+struct Dn2CppMonitorWaiter
+{
+    std::condition_variable cv;
+    Dn2CppMonitorWaiter* prev = nullptr;
+    Dn2CppMonitorWaiter* next = nullptr;
+    bool released = false;
+};
+
 struct Dn2CppMonitor
 {
     std::mutex mtx;                   // guards the fields below + serializes enter/exit
     std::condition_variable lock_cv; // signaled when the lock becomes free (enter-waiters)
-    std::condition_variable wait_cv; // signaled by Pulse/PulseAll (Wait-waiters)
     std::thread::id owner;
     bool has_owner = false;
     uint32_t count = 0;              // recursion depth
-    int waiters = 0;                 // threads currently parked in Wait()
-    int to_release = 0;             // pending Pulse credits (waiters cleared to wake)
+    Dn2CppMonitorWaiter* wait_head = nullptr;
+    Dn2CppMonitorWaiter* wait_tail = nullptr;
 };
+
+static void dn2cpp_monitor_enqueue_waiter(Dn2CppMonitor* mon, Dn2CppMonitorWaiter* waiter)
+{
+    waiter->prev = mon->wait_tail;
+    if (mon->wait_tail != nullptr)
+        mon->wait_tail->next = waiter;
+    else
+        mon->wait_head = waiter;
+    mon->wait_tail = waiter;
+}
+
+static void dn2cpp_monitor_unlink_waiter(Dn2CppMonitor* mon, Dn2CppMonitorWaiter* waiter)
+{
+    if (waiter->prev != nullptr)
+        waiter->prev->next = waiter->next;
+    else
+        mon->wait_head = waiter->next;
+    if (waiter->next != nullptr)
+        waiter->next->prev = waiter->prev;
+    else
+        mon->wait_tail = waiter->prev;
+    waiter->prev = nullptr;
+    waiter->next = nullptr;
+}
+
+static void dn2cpp_monitor_release_waiter(Dn2CppMonitor* mon, Dn2CppMonitorWaiter* waiter)
+{
+    dn2cpp_monitor_unlink_waiter(mon, waiter);
+    waiter->released = true;
+    waiter->cv.notify_one();
+}
 
 // The object -> monitor table is STRIPED: one global mutex here used to be
 // taken twice per `lock` statement (enter + exit), serializing every monitor
@@ -424,25 +463,23 @@ int32_t dn2cpp_monitor_try_enter_timeout(Dn2CppObject* o, int32_t ms)
 }
 
 // Monitor.Wait: the caller owns the monitor. Fully release the lock (saving the
-// recursion depth), park on wait_cv until Pulse/PulseAll grants a credit, then
+// recursion depth), enqueue this waiter's identity for Pulse/PulseAll, then
 // re-acquire the lock to the saved depth. The no-timeout form always wakes on a
-// credit, so it reacquires and returns 1 (true).
+// notification, so it reacquires and returns 1 (true).
 int32_t dn2cpp_monitor_wait(Dn2CppObject* o)
 {
     Dn2CppMonitor* mon = dn2cpp_monitor_for(o);
     std::unique_lock<std::mutex> lk(mon->mtx);
     std::thread::id self = std::this_thread::get_id();
     uint32_t saved = mon->count;
+    Dn2CppMonitorWaiter waiter;
     // Fully release the lock — including the whole recursion depth — and let an
     // enter-waiter in.
     mon->count = 0;
     mon->has_owner = false;
-    mon->waiters++;
+    dn2cpp_monitor_enqueue_waiter(mon, &waiter);
     mon->lock_cv.notify_one();
-    // Park until a Pulse/PulseAll credit is available.
-    mon->wait_cv.wait(lk, [&] { return mon->to_release > 0; });
-    mon->to_release--;
-    mon->waiters--;
+    waiter.cv.wait(lk, [&] { return waiter.released; });
     // Re-acquire the lock (re-block if the pulser still holds it), restoring depth.
     mon->lock_cv.wait(lk, [&] { return !mon->has_owner; });
     mon->has_owner = true;
@@ -452,10 +489,10 @@ int32_t dn2cpp_monitor_wait(Dn2CppObject* o)
 }
 
 // Monitor.Wait(obj, int)/(obj, TimeSpan): as above, but park for at most ms. Returns 1 if
-// woken by a Pulse/PulseAll credit (consuming it), 0 on timeout. Either way the waiter
+// woken by Pulse/PulseAll, 0 on timeout. Either way the waiter
 // re-acquires the monitor to its saved recursion depth before returning (the .NET
 // contract — a timed-out waiter still owns the lock on return). A negative ms is an
-// infinite wait. CRITICAL: on timeout the pending-credit count is left untouched.
+// infinite wait.
 int32_t dn2cpp_monitor_wait_timeout(Dn2CppObject* o, int32_t ms)
 {
     if (ms < 0)
@@ -464,21 +501,15 @@ int32_t dn2cpp_monitor_wait_timeout(Dn2CppObject* o, int32_t ms)
     std::unique_lock<std::mutex> lk(mon->mtx);
     std::thread::id self = std::this_thread::get_id();
     uint32_t saved = mon->count;
+    Dn2CppMonitorWaiter waiter;
     mon->count = 0;
     mon->has_owner = false;
-    mon->waiters++;
+    dn2cpp_monitor_enqueue_waiter(mon, &waiter);
     mon->lock_cv.notify_one();
-    int32_t acquired;
-    if (mon->wait_cv.wait_for(lk, std::chrono::milliseconds(ms), [&] { return mon->to_release > 0; }))
-    {
-        mon->to_release--; // a credit was granted: consume it
-        acquired = 1;
-    }
-    else
-    {
-        acquired = 0; // timed out with no credit — leave to_release untouched
-    }
-    mon->waiters--;
+    int32_t acquired = waiter.cv.wait_for(
+        lk, std::chrono::milliseconds(ms), [&] { return waiter.released; }) ? 1 : 0;
+    if (acquired == 0)
+        dn2cpp_monitor_unlink_waiter(mon, &waiter);
     // A timed-out waiter must still re-acquire the monitor before returning.
     mon->lock_cv.wait(lk, [&] { return !mon->has_owner; });
     mon->has_owner = true;
@@ -487,26 +518,22 @@ int32_t dn2cpp_monitor_wait_timeout(Dn2CppObject* o, int32_t ms)
     return acquired;
 }
 
-// Monitor.Pulse: wake at most one parked waiter (grant one credit, but never more
-// credits than there are uncredited waiters).
+// Monitor.Pulse: wake at most one thread from the wait set that exists now.
 void dn2cpp_monitor_pulse(Dn2CppObject* o)
 {
     Dn2CppMonitor* mon = dn2cpp_monitor_for(o);
     std::unique_lock<std::mutex> lk(mon->mtx);
-    if (mon->waiters > mon->to_release)
-    {
-        mon->to_release++;
-        mon->wait_cv.notify_one();
-    }
+    if (mon->wait_head != nullptr)
+        dn2cpp_monitor_release_waiter(mon, mon->wait_head);
 }
 
-// Monitor.PulseAll: wake every parked waiter (grant a credit to each).
+// Monitor.PulseAll: detach and wake exactly the wait set that exists now.
 void dn2cpp_monitor_pulse_all(Dn2CppObject* o)
 {
     Dn2CppMonitor* mon = dn2cpp_monitor_for(o);
     std::unique_lock<std::mutex> lk(mon->mtx);
-    mon->to_release = mon->waiters;
-    mon->wait_cv.notify_all();
+    while (mon->wait_head != nullptr)
+        dn2cpp_monitor_release_waiter(mon, mon->wait_head);
 }
 
 // ---- Volatile.Read/Write (float/double) ----

--- a/samples/dotnet/PInvokeByValTStrBad/Program.cs
+++ b/samples/dotnet/PInvokeByValTStrBad/Program.cs
@@ -26,10 +26,22 @@ public static class Program
     [DllImport("libc")]
     private static extern void dn2cpp_never_linked_byvaltstr(FixedName s);
 
+    // These independent scalar bodies make the measure-mode refusal a real
+    // worker-scheduling subject before Main records the marshalling gap.
+    private static int Increment(int value)
+    {
+        // The loop forces primitive locals into IL without adding token-bearing operations.
+        int result = value;
+        for (int i = 0; i < 1; i++)
+            result++;
+        return result;
+    }
+
+    private static int Double(int value) => value * 2;
+
     public static void Main()
     {
-        var s = new FixedName { Id = 1, Name = "x" };
+        var s = new FixedName { Id = Double(Increment(0)), Name = "x" };
         dn2cpp_never_linked_byvaltstr(s);
-        Console.WriteLine(s.Id);
     }
 }

--- a/samples/dotnet/SyncPrimitives/Program.cs
+++ b/samples/dotnet/SyncPrimitives/Program.cs
@@ -28,6 +28,44 @@ static class Program
     static bool s_producerDone;
     static int s_consumedSum;
 
+    static int ProbeLateMonitorWait(bool broadcast)
+    {
+        const int waiterCount = 16;
+        var mon = new object();
+        var parked = new CountdownEvent(waiterCount);
+        var threads = new Thread[waiterCount];
+        for (int i = 0; i < threads.Length; i++)
+        {
+            threads[i] = new Thread(() =>
+            {
+                lock (mon)
+                {
+                    parked.Signal();
+                    Monitor.Wait(mon);
+                }
+            });
+            threads[i].Start();
+        }
+        parked.Wait();
+
+        int stolen = 0;
+        lock (mon)
+        {
+            if (broadcast)
+                Monitor.PulseAll(mon);
+            else
+                Monitor.Pulse(mon);
+            for (int i = 0; i < waiterCount; i++)
+                if (Monitor.Wait(mon, 0))
+                    stolen++;
+            // Release any original waiter that the first notification did not cover.
+            Monitor.PulseAll(mon);
+        }
+        for (int i = 0; i < threads.Length; i++)
+            threads[i].Join();
+        return stolen;
+    }
+
     static void Main()
     {
         // Pin both cultures first: gate output must not depend on the host locale (see AGENTS.md).
@@ -361,5 +399,22 @@ static class Program
 
         // ReaderWriterLockSlim per-thread ownership and the recursion matrix.
         RwLockRecursion.Program.__GateEntry();
+
+        // A notification belongs to the wait set present at the Pulse call. Later
+        // zero-timeout waits must not consume it, even while its original recipients
+        // are still reacquiring the monitor.
+        int pulseStolen = 0;
+        int pulseAllStolen = 0;
+        int waitSetProbes = 0;
+        for (int i = 0; i < 4; i++)
+        {
+            pulseStolen += ProbeLateMonitorWait(false);
+            waitSetProbes++;
+            pulseAllStolen += ProbeLateMonitorWait(true);
+            waitSetProbes++;
+        }
+        Console.WriteLine(waitSetProbes);          // 8 (every probe joined)
+        Console.WriteLine(pulseStolen);            // 0
+        Console.WriteLine(pulseAllStolen);         // 0
     }
 }

--- a/src/Dn2Cpp.Cli.Console/Program.cs
+++ b/src/Dn2Cpp.Cli.Console/Program.cs
@@ -20,6 +20,7 @@ bool verbose = false;
 bool autoRef = false;
 bool sharedGenerics = true;
 bool shadowStack = false;
+int maxDegreeOfParallelism = 0;
 var references = new List<string>();
 var noDefaultRefs = new List<string>();
 var projectRoots = new List<string>();
@@ -51,6 +52,21 @@ for (int i = 0; i < args.Length; i++)
         // reachable unsupported-IL / unmapped-intrinsic gap (instead of stopping at
         // the first), rather than emitting C++. See gates/selfhost-measure-console.sh.
         measure = true;
+    }
+    else if (args[i] == "--jobs")
+    {
+        if (i + 1 >= args.Length)
+        {
+            Console.Error.WriteLine("error: --jobs expects a positive integer");
+            return 1;
+        }
+        string value = args[++i];
+        if (!int.TryParse(value, out int jobs) || jobs <= 0)
+        {
+            Console.Error.WriteLine($"error: --jobs expects a positive integer, got '{value}'");
+            return 1;
+        }
+        maxDegreeOfParallelism = jobs;
     }
     else if (args[i] == "--verbose")
     {
@@ -111,7 +127,7 @@ for (int i = 0; i < args.Length; i++)
 
 if (string.IsNullOrEmpty(input))
 {
-    Console.Error.WriteLine("Usage: dn2cpp-console <assembly.dll> [-o <output-dir>] [-r <ref.dll>] [--no-default-ref <DnZlib|DnBrotli|DnHttp>] [--auto-ref] [--project-root <dir>] [--link-feature <com|sre|remoting>] [--no-shared-generics] [--shadow-stack] [--measure] [--verbose]");
+    Console.Error.WriteLine("Usage: dn2cpp-console <assembly.dll> [-o <output-dir>] [-r <ref.dll>] [--no-default-ref <DnZlib|DnBrotli|DnHttp>] [--auto-ref] [--project-root <dir>] [--link-feature <com|sre|remoting>] [--jobs <n>] [--no-shared-generics] [--shadow-stack] [--measure] [--verbose]");
     return 1;
 }
 
@@ -122,6 +138,7 @@ return TranspileDriver.RunConsole(new TranspileOptions
     NoDefaultRefs = noDefaultRefs,
     OutDir = outDir,
     Measure = measure,
+    MaxDegreeOfParallelism = maxDegreeOfParallelism,
     Verbose = verbose,
     AutoRef = autoRef,
     SharedGenerics = sharedGenerics,

--- a/src/Dn2Cpp.Cli/Program.cs
+++ b/src/Dn2Cpp.Cli/Program.cs
@@ -38,6 +38,7 @@ var linkFeatures = new List<string>();
 bool trimGodotClasses = false;
 var godotClassRoots = new List<string>();
 bool shadowStack = false;
+int maxDegreeOfParallelism = 0;
 string? isaSurfaceDump = null;
 string godotApiPath = "";
 
@@ -119,6 +120,21 @@ for (int i = 0; i < args.Length; i++)
         // reachable unsupported-IL / unmapped-intrinsic gap (instead of stopping at
         // the first), rather than emitting C++. See gates/selfhost-measure.sh.
         measure = true;
+    }
+    else if (args[i] == "--jobs")
+    {
+        if (i + 1 >= args.Length)
+        {
+            Console.Error.WriteLine("error: --jobs expects a positive integer");
+            return 1;
+        }
+        string value = args[++i];
+        if (!int.TryParse(value, out int jobs) || jobs <= 0)
+        {
+            Console.Error.WriteLine($"error: --jobs expects a positive integer, got '{value}'");
+            return 1;
+        }
+        maxDegreeOfParallelism = jobs;
     }
     else if (args[i] == "--verbose")
     {
@@ -476,7 +492,7 @@ if (generateBindings)
 
 if (string.IsNullOrEmpty(input))
 {
-    Console.Error.WriteLine("Usage: dn2cpp <assembly.dll> [-o <output-dir>] [-r <ref.dll>] [--no-default-ref <DnZlib|DnBrotli|DnHttp>] [--pinvoke-module <name>] [--auto-ref] [--project-root <dir>] [--link-feature <com|sre|remoting>] [--no-shared-generics] [--shadow-stack] [--trim-reflection] [--reflection-root <Type.Full.Name>] [--no-manifest-resources <Assembly>] [--manifest-resource-root <manifest.name>] [--trim-godot-classes] [--godot-class-root <Godot.Full.Name>] [--max-heap-mb <n>] [--verbose] [--dump-isa-surface <file>] [--gdextension [--godot-api <extension_api.json>]] [--dotnet-module] [--hotupdate-base] [--emit-patch <patch.dll> --base-abi <base-abi.json> [--patch-version <n>] [--patch-stackcode]] [--generate-bindings <extension_api.json>] [--check-wasm-imports <side.wasm> <main.wasm> [<main.js>] [--peer-module <peer.wasm>]...] [--print-runtime-dir]");
+    Console.Error.WriteLine("Usage: dn2cpp <assembly.dll> [-o <output-dir>] [-r <ref.dll>] [--no-default-ref <DnZlib|DnBrotli|DnHttp>] [--pinvoke-module <name>] [--auto-ref] [--project-root <dir>] [--link-feature <com|sre|remoting>] [--jobs <n>] [--no-shared-generics] [--shadow-stack] [--trim-reflection] [--reflection-root <Type.Full.Name>] [--no-manifest-resources <Assembly>] [--manifest-resource-root <manifest.name>] [--trim-godot-classes] [--godot-class-root <Godot.Full.Name>] [--max-heap-mb <n>] [--verbose] [--dump-isa-surface <file>] [--gdextension [--godot-api <extension_api.json>]] [--dotnet-module] [--hotupdate-base] [--emit-patch <patch.dll> --base-abi <base-abi.json> [--patch-version <n>] [--patch-stackcode]] [--generate-bindings <extension_api.json>] [--check-wasm-imports <side.wasm> <main.wasm> [<main.js>] [--peer-module <peer.wasm>]...] [--print-runtime-dir]");
     return 1;
 }
 
@@ -541,6 +557,7 @@ return TranspileDriver.Run(new TranspileOptions
     NoDefaultRefs = noDefaultRefs,
     OutDir = outDir,
     Measure = measure,
+    MaxDegreeOfParallelism = maxDegreeOfParallelism,
     Verbose = verbose,
     Backend = backend,
     SplitBytes = splitBytes,

--- a/src/Dn2Cpp.Transpiler/Compilation.cs
+++ b/src/Dn2Cpp.Transpiler/Compilation.cs
@@ -236,6 +236,12 @@ internal sealed partial class Compilation
     /// <see cref="ClassInfo.SharedUsers"/>) — emission is unchanged until shared
     /// body emission lands.</summary>
     public bool SharedGenericsEnabled { get; }
+    /// <summary>The CLI's requested body-compilation worker limit. Zero means the
+    /// host processor count; retained separately so timing diagnostics can say
+    /// whether the effective limit was automatic.</summary>
+    internal int BodyCompileJobsRequested { get; }
+    /// <summary>The resolved positive body-compilation worker limit.</summary>
+    internal int BodyCompileJobs { get; }
 
     /// <summary>Opt-in shadow stack (<c>--shadow-stack</c>): every body
     /// compiled through <c>MethodCompiler.Compile</c> opens with a
@@ -494,6 +500,11 @@ internal sealed partial class Compilation
             ? new() : new(options.Backend.AdditionalBoundedMethods);
         _genericRoots = options.HotupdateRefs;
         SharedGenericsEnabled = options.SharedGenerics;
+        BodyCompileJobsRequested = options.MaxDegreeOfParallelism;
+        int processorCount = System.Math.Max(1, Environment.ProcessorCount);
+        BodyCompileJobs = options.MaxDegreeOfParallelism == 0
+            ? processorCount
+            : System.Math.Min(options.MaxDegreeOfParallelism, processorCount);
         ShadowStackEnabled = options.ShadowStack;
         // Grouped specializations name their canonical owner's struct layout
         // (ClassInfo.CppStructName) only when sharing is on; a per-process

--- a/src/Dn2Cpp.Transpiler/CppEmitter.cs
+++ b/src/Dn2Cpp.Transpiler/CppEmitter.cs
@@ -15,6 +15,172 @@ internal sealed partial class CppEmitter
     private readonly Compilation _c;
     private readonly IEmitBackend _backend;
     private readonly LiteralPool _literals = new();
+    private int _parallelBodyPeak;
+    private int _parallelBodyEligible;
+    private int _parallelBodySerial;
+    private bool _parallelBodyStatsReported;
+    // Immutable body shape only. Dynamic exclusions (SharedImpl, ftn-target
+    // registries and replacement bodies) are checked again in every pass.
+    private Dictionary<MethodInfo, bool>? _parallelBodyPureShape;
+    // Tiny scalar bodies need several work items per worker to amortize the
+    // window's publish/join barrier and worker-pool bookkeeping.
+    private const int ParallelBodiesPerWorker = 8;
+
+    /// <summary>Automatic mode grows from two workers to the host processor
+    /// count only when this window has enough work to amortize them. Explicit
+    /// --jobs remains the exact operator-selected upper bound.</summary>
+    private int BodyCompileWorkerLimit(int workCount)
+    {
+        int limit = System.Math.Min(_c.BodyCompileJobs, workCount);
+        if (_c.BodyCompileJobsRequested != 0)
+            return limit;
+        int adaptive = (workCount - 1) / ParallelBodiesPerWorker + 1;
+        return System.Math.Min(limit, System.Math.Max(2, adaptive));
+    }
+
+    /// <summary>One worker result slot. Workers only write their own slot; the
+    /// coordinator reads and commits the slots in method order.</summary>
+    private sealed class ParallelBodyResult
+    {
+        internal string? Body;
+        internal Exception? Error;
+        internal List<(MethodInfo Callee, bool RgctxPassable)>? SharedDirectCallees;
+    }
+
+    /// <summary>A resident, bounded worker set used by one body-compilation round.
+    /// The coordinator publishes one fixed-size window at a time and waits for
+    /// every worker before touching shared compilation state again.</summary>
+    private sealed class BodyWorkerPool
+    {
+        private readonly object _gate = new();
+        private readonly Thread[] _threads;
+        private Action<int>? _work;
+        private int _workCount;
+        private int _nextWork;
+        private int _workersRemaining;
+        private int _generation;
+        private int _activeWorkers;
+        private int _peakActiveWorkers;
+        private Exception? _workerError;
+        private bool _stopping;
+
+        internal int WorkerCount => _threads.Length;
+
+        internal BodyWorkerPool(int workerCount)
+        {
+            _threads = new Thread[workerCount];
+            for (int i = 0; i < _threads.Length; i++)
+                _threads[i] = new Thread(WorkerLoop);
+            int started = 0;
+            try
+            {
+                for (; started < _threads.Length; started++)
+                    _threads[started].Start();
+            }
+            catch
+            {
+                lock (_gate)
+                {
+                    _stopping = true;
+                    Monitor.PulseAll(_gate);
+                }
+                for (int i = 0; i < started; i++)
+                    _threads[i].Join();
+                throw;
+            }
+        }
+
+        internal int Execute(int count, Action<int> work)
+        {
+            lock (_gate)
+            {
+                _work = work;
+                _workCount = count;
+                _nextWork = 0;
+                _workersRemaining = _threads.Length;
+                _activeWorkers = 0;
+                _peakActiveWorkers = 0;
+                _workerError = null;
+                _generation++;
+                Monitor.PulseAll(_gate);
+                while (_workersRemaining != 0)
+                    Monitor.Wait(_gate);
+                _work = null;
+                if (_workerError is { } error)
+                    throw error;
+                return _peakActiveWorkers;
+            }
+        }
+
+        private void WorkerLoop()
+        {
+            int observedGeneration = 0;
+            while (true)
+            {
+                lock (_gate)
+                {
+                    while (!_stopping && observedGeneration == _generation)
+                        Monitor.Wait(_gate);
+                    if (_stopping)
+                        return;
+                    observedGeneration = _generation;
+                }
+
+                try
+                {
+                    while (true)
+                    {
+                        Action<int> work;
+                        int index;
+                        lock (_gate)
+                        {
+                            if (_nextWork == _workCount)
+                                break;
+                            index = _nextWork++;
+                            work = _work!;
+                            _activeWorkers++;
+                            if (_activeWorkers > _peakActiveWorkers)
+                                _peakActiveWorkers = _activeWorkers;
+                        }
+                        try
+                        {
+                            work(index);
+                        }
+                        finally
+                        {
+                            lock (_gate)
+                                _activeWorkers--;
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    lock (_gate)
+                        _workerError ??= ex;
+                }
+                finally
+                {
+                    lock (_gate)
+                    {
+                        _workersRemaining--;
+                        if (_workersRemaining == 0)
+                            Monitor.PulseAll(_gate);
+                    }
+                }
+            }
+        }
+
+        internal void Stop()
+        {
+            lock (_gate)
+            {
+                _stopping = true;
+                Monitor.PulseAll(_gate);
+            }
+            foreach (var thread in _threads)
+                thread.Join();
+        }
+    }
     // Per-enum Object.ToString function bodies. Accumulated while emitting
     // the enum type-infos (which add their member-name string literals to the pool)
     // and flushed after the literal table, since the bodies reference those literals.
@@ -879,6 +1045,7 @@ internal sealed partial class CppEmitter
                 "// Auto-generated by Dn2Cpp.Transpiler — do not edit.\n"
                 + "#include \"intrinsics/dn2cpp_cpu_features.cpp\"\n");
         }
+        ReportParallelBodyStats();
         return new EmittedSources(o.Header, o.Data, o.BodyChunks, o.MetadataChunks, o.HotChunks,
             o.HotFastChunks, baseAbiJson);
     }
@@ -1610,6 +1777,255 @@ internal sealed partial class CppEmitter
         return depth;
     }
 
+    /// <summary>Whether a decoded IL instruction is translated without consulting
+    /// or mutating <see cref="Compilation"/>. This is deliberately a whitelist:
+    /// a new opcode stays on the established sequential path until it is proved
+    /// pure here.</summary>
+    private static bool IsParallelPureOpcode(ILOpCode op) => op switch
+    {
+        ILOpCode.Nop
+            or ILOpCode.Ldc_i4_m1 or ILOpCode.Ldc_i4_0 or ILOpCode.Ldc_i4_1
+            or ILOpCode.Ldc_i4_2 or ILOpCode.Ldc_i4_3 or ILOpCode.Ldc_i4_4
+            or ILOpCode.Ldc_i4_5 or ILOpCode.Ldc_i4_6 or ILOpCode.Ldc_i4_7
+            or ILOpCode.Ldc_i4_8 or ILOpCode.Ldc_i4_s or ILOpCode.Ldc_i4
+            or ILOpCode.Ldc_i8 or ILOpCode.Ldc_r4 or ILOpCode.Ldc_r8
+            or ILOpCode.Ldnull
+            or ILOpCode.Ldarg_0 or ILOpCode.Ldarg_1 or ILOpCode.Ldarg_2
+            or ILOpCode.Ldarg_3 or ILOpCode.Ldarg_s or ILOpCode.Ldarg
+            or ILOpCode.Starg_s or ILOpCode.Starg
+            or ILOpCode.Ldloc_0 or ILOpCode.Ldloc_1 or ILOpCode.Ldloc_2
+            or ILOpCode.Ldloc_3 or ILOpCode.Ldloc_s or ILOpCode.Ldloc
+            or ILOpCode.Stloc_0 or ILOpCode.Stloc_1 or ILOpCode.Stloc_2
+            or ILOpCode.Stloc_3 or ILOpCode.Stloc_s or ILOpCode.Stloc
+            or ILOpCode.Dup or ILOpCode.Pop
+            or ILOpCode.Add or ILOpCode.Sub or ILOpCode.Mul
+            or ILOpCode.Div or ILOpCode.Div_un or ILOpCode.Rem or ILOpCode.Rem_un
+            or ILOpCode.And or ILOpCode.Or or ILOpCode.Xor
+            or ILOpCode.Shl or ILOpCode.Shr or ILOpCode.Shr_un
+            or ILOpCode.Neg or ILOpCode.Not
+            or ILOpCode.Ceq or ILOpCode.Cgt or ILOpCode.Cgt_un
+            or ILOpCode.Clt or ILOpCode.Clt_un
+            or ILOpCode.Conv_i1 or ILOpCode.Conv_u1
+            or ILOpCode.Conv_i2 or ILOpCode.Conv_u2
+            or ILOpCode.Conv_i4 or ILOpCode.Conv_u4
+            or ILOpCode.Conv_i8 or ILOpCode.Conv_u8
+            or ILOpCode.Conv_r4 or ILOpCode.Conv_r8
+            or ILOpCode.Conv_i or ILOpCode.Conv_u or ILOpCode.Conv_r_un
+            or ILOpCode.Add_ovf or ILOpCode.Add_ovf_un
+            or ILOpCode.Sub_ovf or ILOpCode.Sub_ovf_un
+            or ILOpCode.Mul_ovf or ILOpCode.Mul_ovf_un
+            or ILOpCode.Conv_ovf_i1 or ILOpCode.Conv_ovf_i1_un
+            or ILOpCode.Conv_ovf_u1 or ILOpCode.Conv_ovf_u1_un
+            or ILOpCode.Conv_ovf_i2 or ILOpCode.Conv_ovf_i2_un
+            or ILOpCode.Conv_ovf_u2 or ILOpCode.Conv_ovf_u2_un
+            or ILOpCode.Conv_ovf_i4 or ILOpCode.Conv_ovf_i4_un
+            or ILOpCode.Conv_ovf_u4 or ILOpCode.Conv_ovf_u4_un
+            or ILOpCode.Conv_ovf_i8 or ILOpCode.Conv_ovf_i8_un
+            or ILOpCode.Conv_ovf_u8 or ILOpCode.Conv_ovf_u8_un
+            or ILOpCode.Conv_ovf_i or ILOpCode.Conv_ovf_i_un
+            or ILOpCode.Conv_ovf_u or ILOpCode.Conv_ovf_u_un
+            or ILOpCode.Ckfinite
+            or ILOpCode.Br or ILOpCode.Br_s
+            or ILOpCode.Brtrue or ILOpCode.Brtrue_s
+            or ILOpCode.Brfalse or ILOpCode.Brfalse_s
+            or ILOpCode.Beq or ILOpCode.Beq_s
+            or ILOpCode.Bne_un or ILOpCode.Bne_un_s
+            or ILOpCode.Bge or ILOpCode.Bge_s
+            or ILOpCode.Bgt or ILOpCode.Bgt_s
+            or ILOpCode.Ble or ILOpCode.Ble_s
+            or ILOpCode.Blt or ILOpCode.Blt_s
+            or ILOpCode.Bge_un or ILOpCode.Bge_un_s
+            or ILOpCode.Bgt_un or ILOpCode.Bgt_un_s
+            or ILOpCode.Ble_un or ILOpCode.Ble_un_s
+            or ILOpCode.Blt_un or ILOpCode.Blt_un_s
+            or ILOpCode.Switch or ILOpCode.Ret => true,
+        _ => false,
+    };
+
+    private static bool IsParallelScalarPrimitive(TypeDesc type) =>
+        type is
+        {
+            Kind: TypeKind.Primitive,
+            IsCanonPlaceholder: false,
+            Primitive: PrimitiveTypeCode.Boolean or PrimitiveTypeCode.Char
+                or PrimitiveTypeCode.SByte or PrimitiveTypeCode.Byte
+                or PrimitiveTypeCode.Int16 or PrimitiveTypeCode.UInt16
+                or PrimitiveTypeCode.Int32 or PrimitiveTypeCode.UInt32
+                or PrimitiveTypeCode.Int64 or PrimitiveTypeCode.UInt64
+                or PrimitiveTypeCode.IntPtr or PrimitiveTypeCode.UIntPtr
+                or PrimitiveTypeCode.Single or PrimitiveTypeCode.Double,
+        };
+
+    /// <summary>Reads a LOCAL_SIG without invoking the signature provider. A
+    /// worker may decode direct scalar primitives safely: BuildArgsAndLocals'
+    /// reference/layout notes and CanonAny taint are all no-ops for these kinds.
+    /// Every prefix, token and composite type code stays sequential.</summary>
+    private static bool HasOnlyParallelScalarPrimitiveLocals(
+        Module module, StandaloneSignatureHandle handle)
+    {
+        if (handle.IsNil)
+            return true;
+        var signature = module.Reader.GetStandaloneSignature(handle);
+        var blob = module.Reader.GetBlobReader(signature.Signature);
+        if (blob.RemainingBytes == 0 || blob.ReadByte() != 0x07) // LOCAL_SIG
+            return false;
+        int count = blob.ReadCompressedInteger();
+        if (count < 0)
+            return false;
+        for (int i = 0; i < count; i++)
+        {
+            if (blob.RemainingBytes == 0)
+                return false;
+            // ECMA-335 ELEMENT_TYPE_* direct primitive codes. Void and every
+            // prefix/composite/token-bearing code are intentionally absent.
+            if (blob.ReadByte() is not (0x02 or 0x03 or 0x04 or 0x05
+                    or 0x06 or 0x07 or 0x08 or 0x09 or 0x0a or 0x0b
+                    or 0x0c or 0x0d or 0x18 or 0x19))
+                return false;
+        }
+        return blob.RemainingBytes == 0;
+    }
+
+    private bool HasParallelPureShape(MethodInfo m)
+    {
+        _parallelBodyPureShape ??= new Dictionary<MethodInfo, bool>();
+        if (_parallelBodyPureShape.TryGetValue(m, out bool cached))
+            return cached;
+        bool pure = false;
+        try
+        {
+            var signature = m.Signature;
+            if (!signature.ReturnType.IsVoid
+                && !IsParallelScalarPrimitive(signature.ReturnType))
+                return _parallelBodyPureShape[m] = false;
+            foreach (var parameter in signature.ParameterTypes)
+                if (!IsParallelScalarPrimitive(parameter))
+                    return _parallelBodyPureShape[m] = false;
+            var body = m.Module.PE.GetMethodBody(m.Rva);
+            if (body.ExceptionRegions.Length != 0
+                || !HasOnlyParallelScalarPrimitiveLocals(m.Module, body.LocalSignature))
+                return _parallelBodyPureShape[m] = false;
+            var insns = ILDecoder.Decode(body.GetILBytes()!.ToImmutableArrayCompat());
+            foreach (var insn in insns)
+                if (!IsParallelPureOpcode(insn.OpCode))
+                    return _parallelBodyPureShape[m] = false;
+            // Materialize every lazy rendering the worker reads.
+            _ = MethodCompiler.Signature(m);
+            pure = true;
+        }
+        catch (Exception ex) when (!Compilation.IsMustEscape(ex))
+        {
+            // The ordinary compile reproduces the input failure at its established
+            // position; structural classification never owns a diagnostic.
+        }
+        _parallelBodyPureShape[m] = pure;
+        return pure;
+    }
+
+    /// <summary>Conservative proof that compiling one static scalar IL body is a
+    /// read-only operation on the completed model. Reference-bearing signatures,
+    /// non-scalar locals, token-bearing instructions, exception regions, special
+    /// replacement bodies and lazily unprepared caches stay sequential.</summary>
+    private bool CanCompileBodyInParallel(ClassInfo cls, MethodInfo m)
+    {
+        // MemoryGuard's sampled tick and first over-budget exception are ordered
+        // observables. Preserve its exact method boundary by staying sequential
+        // when the operator enables the heap ceiling.
+        if (_c.BodyCompileJobs <= 1 || MemoryGuard.LimitBytes > 0
+            || m.Rva == 0 || m.IsSynthetic || m.SharedImpl is not null
+            || !m.IsStatic || !m.SignatureReady
+            || m.IsSynchronized || m.IsUnmanagedCallersOnly || m.IsHotPath
+            || CoreIntrinsics.BrHttpShim.Matches(cls.FullName, m.Name)
+            || CoreIntrinsics.BrEnumInstanceFormat.Matches(cls.FullName, m.Name)
+            || _c.PInvokeFtnTargets.Contains(m) || _c.IntrinsicFtnTargets.Contains(m)
+            || _c.InterceptFtnTargets.Contains(m) || CoreIntrinsics.MdComparerCompare.Matches(m)
+            || _c.IsUnorderableComparerCompareBody(m)
+            || CoreIntrinsics.IsIntrinsicType(cls.FullName))
+            return false;
+        return HasParallelPureShape(m);
+    }
+
+    private ParallelBodyResult CompileParallelBody(
+        MethodInfo m, LiteralPool literals, bool planning)
+    {
+        var result = new ParallelBodyResult();
+        try
+        {
+            var mc = new MethodCompiler(_c, m, literals, _backend);
+            if (_c.SharedGenericsEnabled && Compilation.IsCanonicalMethod(m))
+            {
+                mc.SharedTrial = true;
+                if (planning)
+                    mc.SharedDirectCallees = new List<(MethodInfo, bool)>();
+            }
+            string body = mc.Compile();
+            if (!planning)
+                result.Body = body;
+            result.SharedDirectCallees = mc.SharedDirectCallees;
+        }
+        catch (Exception ex)
+        {
+            result.Error = ex;
+        }
+        return result;
+    }
+
+    private void CommitParallelBody(
+        MethodInfo m, ParallelBodyResult result, bool planning,
+        Action<MethodInfo, string>? emitBody, List<MethodInfo> compiledMethods,
+        List<MeasureGap>? diagnostics)
+    {
+        bool canonical = _c.SharedGenericsEnabled && Compilation.IsCanonicalMethod(m);
+        if (result.Error is { } error)
+        {
+            if (canonical && planning)
+            {
+                if (error is SharedBodyTaintException taint)
+                {
+                    _c.SharedTaint[m] = taint.Kind;
+                    return;
+                }
+                if (error is NotSupportedException unsupported
+                    && !Compilation.IsMustEscape(unsupported))
+                {
+                    _c.SharedTaint[m] = "unsupported";
+                    if (EnvKnobs.BoolIsOne(EnvKnobs.SharedDump))
+                        Console.WriteLine(
+                            $"dn2cpp: shared-generics unsupported {m.CppName}: {unsupported.Message}");
+                    return;
+                }
+                throw error;
+            }
+            if (diagnostics is not null && !Compilation.IsMustEscape(error))
+            {
+                diagnostics.Add(MeasureGap.From("compile", m, error));
+                return;
+            }
+            throw error;
+        }
+
+        if (canonical && planning)
+        {
+            _c.SharedTrialCompiled.Add(m);
+            _c.SharedCallEdges[m] = result.SharedDirectCallees!;
+            return;
+        }
+        if (planning && diagnostics is null)
+            return;
+        if (!planning)
+            emitBody?.Invoke(m, result.Body!);
+        compiledMethods.Add(m);
+    }
+
+    private void ReportParallelBodyStats()
+    {
+        if (_parallelBodyStatsReported)
+            return;
+        _parallelBodyStatsReported = true;
+        Timing.ParallelBodies(_c.BodyCompileJobsRequested, _c.BodyCompileJobs,
+            _parallelBodyPeak, 0, _parallelBodyEligible, _parallelBodySerial);
+    }
+
     /// <summary>Compiles every reachable, non-skipped method body to a fixpoint.
     /// Compiling a body can instantiate a generic the discovery scan never saw (a
     /// local/cast type), appending to <see cref="Compilation.Classes"/> and queuing it
@@ -1797,270 +2213,353 @@ internal sealed partial class CppEmitter
             // order-independent (both sets are least fixpoints of monotone operators), so
             // sorting inside the round makes the whole sequence a function of the input.
             batch.Sort(static (x, y) => MethodInfo.CompareByOrder(x.M, y.M));
-            foreach (var (cls, m) in batch)
+            BodyWorkerPool? workers = null;
+            try
             {
-                // Covers the planning pass, the emission pass and --measure alike.
-                MemoryGuard.Check("compile-bodies");
-                compiled.Add(m);
-                // A System.Net.Http method whose body dn2cpp replaces (the transport overrides,
-                // the ClientCertificateOptions accessors — the BodyReplace row CoreIntrinsics.
-                // BrHttpShim, whose other asker is Compilation.Reach): emit the synthesized body
-                // (CompileHttpShimBody) in place of the real IL that reachability cut. Like
-                // the minted value-body arm above, the planning pass leaves emitBody null,
-                // so the null-conditional skips the compile — the shim edge was already
-                // reached in Compilation.Reach, so no discovery is lost.
-                if (CoreIntrinsics.BrHttpShim.Matches(cls.FullName, m.Name))
+                // Amortize the publish/join barrier across several tiny scalar
+                // bodies per worker while keeping retained text O(jobs).
+                int windowSize = batch.Count;
+                if (_c.BodyCompileJobs > 1
+                    && _c.BodyCompileJobs <= int.MaxValue / ParallelBodiesPerWorker)
+                    windowSize = System.Math.Min(batch.Count,
+                        _c.BodyCompileJobs * ParallelBodiesPerWorker);
+                for (int windowStart = 0; windowStart < batch.Count;)
                 {
-                    emitBody?.Invoke(m, new MethodCompiler(_c, m, literals, _backend)
-                        .CompileHttpShimBody());
-                    compiledMethods.Add(m);
-                    continue;
-                }
-                // System.Enum's instance ToString/GetTypeCode/value-trio/GetValue — the
-                // BodyReplace row CoreIntrinsics.BrEnumInstanceFormat, whose other asker is Compilation.Reach:
-                // emit the synthesized enum-format body in place of the real IL that
-                // reachability cut. Like the HTTP shim above, the planning pass leaves emitBody
-                // null so the null-conditional skips the compile.
-                if (CoreIntrinsics.BrEnumInstanceFormat.Matches(cls.FullName, m.Name))
-                {
-                    emitBody?.Invoke(m, new MethodCompiler(_c, m, literals, _backend)
-                        .CompileEnumInstanceFormatBody());
-                    compiledMethods.Add(m);
-                    continue;
-                }
-                // An address-taken bodyless P/Invoke (ldftn / delegate method group
-                // over a [DllImport] that lowers to a direct native call): synthesize
-                // a forwarder from the same P/Invoke lowering a call site gets.
-                if (_c.PInvokeFtnTargets.Contains(m))
-                {
-                    var forwarder = new MethodCompiler(_c, m, literals, _backend)
-                            .CompilePInvokeWrapper()
-                        ?? throw new NotSupportedException(
-                            $"taking the address of {m.DeclaringClass.FullName}::{m.Name} " +
-                            "(delegate method group / function pointer over a [DllImport]): " +
-                            "the import's shape is not marshallable, so no forwarder body " +
-                            "can be synthesized");
-                    emitBody?.Invoke(m, forwarder);
-                    compiledMethods.Add(m);
-                    continue;
-                }
-                // An address-taken method of an intrinsic-mapped type (ldftn /
-                // delegate method group, e.g. Char.IsDigit): no real body is ever
-                // transpiled — synthesize one from the call intrinsic's lowering.
-                if (_c.IntrinsicFtnTargets.Contains(m))
-                {
-                    var wrapper = new MethodCompiler(_c, m, literals, _backend)
-                            .CompileCoreIntrinsicWrapper()
-                        ?? throw new NotSupportedException(
-                            $"taking the address of {m.DeclaringClass.FullName}::{m.Name} " +
-                            "(delegate method group / function pointer): the method has no " +
-                            "intrinsic lowering to synthesize a function body from");
-                    emitBody?.Invoke(m, wrapper);
-                    compiledMethods.Add(m);
-                    continue;
-                }
-                // System.Collections.Comparer.Compare is body-intercepted — the THIRD mouth
-                // of the row whose call-site mouths are CoreIntrinsics.MdComparerCompare /
-                // MrComparerCompare: synthesize from the intrinsic lowering
-                // (-> dn2cpp_object_compare) instead of transpiling the real IL, so the
-                // IComparer.Compare slot — how ArrayList.Sort()/SortedList and the
-                // non-generic boxed sort/search reach Comparer.Default — points at the
-                // boxed-object order, which handles a boxed primitive (the real body's
-                // `x as IComparable` cannot). The synthesized body carries Comparer.Compare's
-                // own symbol, so the slot, any ldftn and a direct call all resolve to it.
-                if (CoreIntrinsics.MdComparerCompare.Matches(m))
-                {
-                    var wrapper = new MethodCompiler(_c, m, literals, _backend)
-                            .CompileCoreIntrinsicWrapper()
-                        ?? throw new NotSupportedException(
-                            $"{m.DeclaringClass.FullName}::{m.Name}: non-generic boxed-ordering body intercept has no intrinsic lowering to synthesize from");
-                    emitBody?.Invoke(m, wrapper);
-                    compiledMethods.Add(m);
-                    continue;
-                }
-                // An address-taken member whose CALLS an intercept row cut (ldftn /
-                // delegate method group over e.g. ExecutionContext.Run): reachability
-                // deleted the edge to the real body, so replay that row's own emit arm
-                // at the body position — cut ⟹ route holds through the body too. Behind
-                // the Comparer.Compare arm above: that row already owns its own body, and
-                // an address taken of it must keep getting that one.
-                if (_c.InterceptFtnTargets.Contains(m))
-                {
-                    var wrapper = new MethodCompiler(_c, m, literals, _backend)
-                            .CompileInterceptWrapper()
-                        ?? throw new NotSupportedException(
-                            $"taking the address of {m.DeclaringClass.FullName}::{m.Name} " +
-                            "(delegate method group / function pointer): the intercept that " +
-                            "lowers its calls cannot be replayed as a function body");
-                    emitBody?.Invoke(m, wrapper);
-                    compiledMethods.Add(m);
-                    continue;
-                }
-                // A synthesized GenericComparer<T>.Compare over a VALUE TYPE real .NET's
-                // default comparer cannot order (see
-                // Compilation.IsUnorderableComparerCompareBody): its real IL boxes the value
-                // type for the null checks (an intrinsic value type has no ti_ to box
-                // through) and dispatches a CompareTo that does not exist. Real .NET throws
-                // ArgumentException here; body-replace with a catchable
-                // PlatformNotSupportedException so the comparer object stays real and only
-                // its Compare faults. The trailing `return 0;` is unreachable (the throw is
-                // [[noreturn]]) and only keeps the int32 return type-checking.
-                if (_c.IsUnorderableComparerCompareBody(m))
-                {
-                    string elem = _c.GenericDefFullName(m.DeclaringClass.Context.TypeArgs[0].Class!);
-                    string body = $"// {m.DeclaringClass.FullName}::{m.Name} (element not orderable — throws on call)\n"
-                        + $"{MethodCompiler.Signature(m)}\n{{\n"
-                        + $"    dn2cpp_throw_platform_not_supported(\"Comparer<{elem}>.Default.Compare: "
-                        + $"{elem} does not implement IComparable and is not orderable "
-                        + "(real .NET throws ArgumentException here)\");\n"
-                        + "    return 0;\n}\n";
-                    emitBody?.Invoke(m, body);
-                    compiledMethods.Add(m);
-                    continue;
-                }
-                // An intrinsic-mapped type's method whose body IS transpiled (String's
-                // interface impls): prefer synthesizing from the intrinsic lowering
-                // when one exists — String.Equals(String) becomes the same
-                // dn2cpp_string_equals its call sites use, instead of dragging the
-                // real body's private helpers (EqualsHelper's SIMD loops) into the
-                // tree. No lowering (GetEnumerator/Clone/the explicit interface
-                // impls) compiles the real IL; a real body that hits an unmapped
-                // intrinsic (an IConvertible impl over an unmodeled Convert form)
-                // degrades to a trap-on-call body instead of failing the build —
-                // the slot is only reached because SOME type dispatches the decl,
-                // and a string may never flow there.
-                if (CoreIntrinsics.IsIntrinsicType(m.DeclaringClass.FullName))
-                {
-                    string body;
-                    if (new MethodCompiler(_c, m, literals, _backend)
-                            .CompileCoreIntrinsicWrapper() is { } iw)
-                        body = iw;
-                    else
-                        try
-                        {
-                            body = new MethodCompiler(_c, m, literals, _backend).Compile();
-                        }
-                        // Must-escape (Compilation.IsMustEscape): a bound overrun is a
-                        // NotSupportedException, so the type alone does not filter it —
-                        // and baking it into a trap body would report the run as a
-                        // success while the model kept growing.
-                        catch (NotSupportedException ex) when (!Compilation.IsMustEscape(ex))
-                        {
-                            string msg = $"{m.DeclaringClass.FullName}.{m.Name} is not transpilable: {ex.Message}"
-                                .Replace("\\", "\\\\").Replace("\"", "\\\"");
-                            body = $"// {m.DeclaringClass.FullName}::{m.Name} (untranspilable — traps on call)\n"
-                                + $"{MethodCompiler.Signature(m)}\n{{\n    dn2cpp_fail(\"NotSupportedException ({msg})\");\n}}\n";
-                        }
-                    emitBody?.Invoke(m, body);
-                    compiledMethods.Add(m);
-                    continue;
-                }
-                // A grouped method bound to a hidden-parameter shared body keeps
-                // its own symbol as a one-line forwarder appending its class's
-                // rgctx table — the per-instantiation function identity every
-                // boundary (vtable, interface table, ldftn, reflection) uses.
-                if (m.SharedImpl is { } fwdImpl)
-                {
-                    string fwd = RgctxForwarderBody(m, fwdImpl);
-                    emitBody?.Invoke(m, fwd);
-                    compiledMethods.Add(m);
-                    _c.RgctxForwarderCount++;
-                    continue;
-                }
-                // A canonical-owner-world method is only ever a shared-body
-                // candidate: compile it with the taint checks armed. In the
-                // planning pass a taint (or an unsupported placeholder shape)
-                // just marks it unshareable — each grouped user then compiles
-                // its own body; in the final pass only shareable candidates
-                // survive in Reachable, so a throw here propagates as a real
-                // error.
-                if (_c.SharedGenericsEnabled && Compilation.IsCanonicalMethod(m))
-                {
-                    var mc = new MethodCompiler(_c, m, literals, _backend)
+                    int remaining = batch.Count - windowStart;
+                    int windowEnd = windowStart + System.Math.Min(windowSize, remaining);
+                    ParallelBodyResult?[]? parallel = null;
+                    List<int>? eligible = null;
+                    if (_c.BodyCompileJobs > 1)
                     {
-                        SharedTrial = true,
-                        SharedDirectCallees = planning ? new List<(MethodInfo, bool)>() : null,
-                    };
-                    if (planning)
-                    {
-                        try
+                        eligible = new List<int>();
+                        parallel = new ParallelBodyResult?[windowEnd - windowStart];
+                        for (int bi = windowStart; bi < windowEnd; bi++)
                         {
-                            mc.Compile();
-                            _c.SharedTrialCompiled.Add(m);
-                            _c.SharedCallEdges[m] = mc.SharedDirectCallees!;
+                            var candidate = batch[bi];
+                            if (CanCompileBodyInParallel(candidate.Cls, candidate.M))
+                                eligible.Add(bi);
                         }
-                        catch (SharedBodyTaintException ex)
+                        _parallelBodyEligible += eligible.Count;
+                        _parallelBodySerial += windowEnd - windowStart - eligible.Count;
+                        if (eligible.Count < 2)
                         {
-                            _c.SharedTaint[m] = ex.Kind;
+                            // One body cannot use more than one core; keep it on the
+                            // established path rather than paying a thread handoff.
+                            _parallelBodySerial += eligible.Count;
+                            _parallelBodyEligible -= eligible.Count;
+                            eligible.Clear();
                         }
-                        // Must-escape (Compilation.IsMustEscape): never a taint, never a
-                        // fallback — the same filter the measure-mode arm below carries.
-                        // A canonical trial DOES mint instantiations nothing else in the
-                        // run names (the emitter-invented SZArrayEnumerable<E> wrapper of
-                        // an array-to-collection boundary, a delegate ctor resolved under
-                        // the canonical context), so the bound can genuinely trip in here;
-                        // recorded as a taint it would silently change which bodies get
-                        // shared and keep feeding the overrun it bounds.
-                        catch (NotSupportedException ex) when (!Compilation.IsMustEscape(ex))
+                        else
                         {
-                            // A placeholder-only gap (e.g. an intrinsic keyed on
-                            // the concrete type): unshareable, users fall back.
-                            _c.SharedTaint[m] = "unsupported";
-                            if (EnvKnobs.BoolIsOne(EnvKnobs.SharedDump))
-                                Console.WriteLine(
-                                    $"dn2cpp: shared-generics unsupported {m.CppName}: {ex.Message}");
+                            // MethodCompiler's constructor reads this property. Some
+                            // backends initialize the intrinsics object lazily, so the
+                            // coordinator must publish it before constructors race.
+                            _ = _backend.CallIntrinsics;
+                            int usefulWorkers = BodyCompileWorkerLimit(eligible.Count);
+                            // Keep the largest pool this round has actually needed.
+                            // Execute publishes the smaller work count under the same lock,
+                            // so surplus workers claim no index and only join the barrier;
+                            // retaining them avoids stop/start churn across uneven windows.
+                            if (workers is null || workers.WorkerCount < usefulWorkers)
+                            {
+                                workers?.Stop();
+                                workers = new BodyWorkerPool(usefulWorkers);
+                            }
+                            var resultSlots = parallel;
+                            var workItems = eligible;
+                            int activePeak = workers.Execute(workItems.Count, wi =>
+                            {
+                                int bi = workItems[wi];
+                                resultSlots[bi - windowStart] = CompileParallelBody(
+                                    batch[bi].M, literals, planning);
+                            });
+                            _parallelBodyPeak = System.Math.Max(
+                                _parallelBodyPeak, activePeak);
                         }
-                    }
-                    else if (diagnostics is null)
-                    {
-                        string canon = mc.Compile();
-                        emitBody?.Invoke(m, canon);
-                        compiledMethods.Add(m);
                     }
                     else
                     {
-                        // Measure mode: a canonical survivor's throw becomes a gap
-                        // row instead of aborting the run (the normal-emit branch
-                        // above keeps the invariant that a throw is a real error).
+                        _parallelBodySerial += windowEnd - windowStart;
+                    }
+
+                    for (int bi = windowStart; bi < windowEnd; bi++)
+                    {
+                        var (cls, m) = batch[bi];
+                        // Covers the planning pass, the emission pass and --measure alike.
+                        MemoryGuard.Check("compile-bodies");
+                        compiled.Add(m);
+                        if (parallel is not null && parallel[bi - windowStart] is { } parallelResult)
+                        {
+                            CommitParallelBody(m, parallelResult, planning,
+                                emitBody, compiledMethods, diagnostics);
+                            continue;
+                        }
+                        // A System.Net.Http method whose body dn2cpp replaces (the transport overrides,
+                        // the ClientCertificateOptions accessors — the BodyReplace row CoreIntrinsics.
+                        // BrHttpShim, whose other asker is Compilation.Reach): emit the synthesized body
+                        // (CompileHttpShimBody) in place of the real IL that reachability cut. Like
+                        // the minted value-body arm above, the planning pass leaves emitBody null,
+                        // so the null-conditional skips the compile — the shim edge was already
+                        // reached in Compilation.Reach, so no discovery is lost.
+                        if (CoreIntrinsics.BrHttpShim.Matches(cls.FullName, m.Name))
+                        {
+                            emitBody?.Invoke(m, new MethodCompiler(_c, m, literals, _backend)
+                                .CompileHttpShimBody());
+                            compiledMethods.Add(m);
+                            continue;
+                        }
+                        // System.Enum's instance ToString/GetTypeCode/value-trio/GetValue — the
+                        // BodyReplace row CoreIntrinsics.BrEnumInstanceFormat, whose other asker is Compilation.Reach:
+                        // emit the synthesized enum-format body in place of the real IL that
+                        // reachability cut. Like the HTTP shim above, the planning pass leaves emitBody
+                        // null so the null-conditional skips the compile.
+                        if (CoreIntrinsics.BrEnumInstanceFormat.Matches(cls.FullName, m.Name))
+                        {
+                            emitBody?.Invoke(m, new MethodCompiler(_c, m, literals, _backend)
+                                .CompileEnumInstanceFormatBody());
+                            compiledMethods.Add(m);
+                            continue;
+                        }
+                        // An address-taken bodyless P/Invoke (ldftn / delegate method group
+                        // over a [DllImport] that lowers to a direct native call): synthesize
+                        // a forwarder from the same P/Invoke lowering a call site gets.
+                        if (_c.PInvokeFtnTargets.Contains(m))
+                        {
+                            var forwarder = new MethodCompiler(_c, m, literals, _backend)
+                                    .CompilePInvokeWrapper()
+                                ?? throw new NotSupportedException(
+                                    $"taking the address of {m.DeclaringClass.FullName}::{m.Name} " +
+                                    "(delegate method group / function pointer over a [DllImport]): " +
+                                    "the import's shape is not marshallable, so no forwarder body " +
+                                    "can be synthesized");
+                            emitBody?.Invoke(m, forwarder);
+                            compiledMethods.Add(m);
+                            continue;
+                        }
+                        // An address-taken method of an intrinsic-mapped type (ldftn /
+                        // delegate method group, e.g. Char.IsDigit): no real body is ever
+                        // transpiled — synthesize one from the call intrinsic's lowering.
+                        if (_c.IntrinsicFtnTargets.Contains(m))
+                        {
+                            var wrapper = new MethodCompiler(_c, m, literals, _backend)
+                                    .CompileCoreIntrinsicWrapper()
+                                ?? throw new NotSupportedException(
+                                    $"taking the address of {m.DeclaringClass.FullName}::{m.Name} " +
+                                    "(delegate method group / function pointer): the method has no " +
+                                    "intrinsic lowering to synthesize a function body from");
+                            emitBody?.Invoke(m, wrapper);
+                            compiledMethods.Add(m);
+                            continue;
+                        }
+                        // System.Collections.Comparer.Compare is body-intercepted — the THIRD mouth
+                        // of the row whose call-site mouths are CoreIntrinsics.MdComparerCompare /
+                        // MrComparerCompare: synthesize from the intrinsic lowering
+                        // (-> dn2cpp_object_compare) instead of transpiling the real IL, so the
+                        // IComparer.Compare slot — how ArrayList.Sort()/SortedList and the
+                        // non-generic boxed sort/search reach Comparer.Default — points at the
+                        // boxed-object order, which handles a boxed primitive (the real body's
+                        // `x as IComparable` cannot). The synthesized body carries Comparer.Compare's
+                        // own symbol, so the slot, any ldftn and a direct call all resolve to it.
+                        if (CoreIntrinsics.MdComparerCompare.Matches(m))
+                        {
+                            var wrapper = new MethodCompiler(_c, m, literals, _backend)
+                                    .CompileCoreIntrinsicWrapper()
+                                ?? throw new NotSupportedException(
+                                    $"{m.DeclaringClass.FullName}::{m.Name}: non-generic boxed-ordering body intercept has no intrinsic lowering to synthesize from");
+                            emitBody?.Invoke(m, wrapper);
+                            compiledMethods.Add(m);
+                            continue;
+                        }
+                        // An address-taken member whose CALLS an intercept row cut (ldftn /
+                        // delegate method group over e.g. ExecutionContext.Run): reachability
+                        // deleted the edge to the real body, so replay that row's own emit arm
+                        // at the body position — cut ⟹ route holds through the body too. Behind
+                        // the Comparer.Compare arm above: that row already owns its own body, and
+                        // an address taken of it must keep getting that one.
+                        if (_c.InterceptFtnTargets.Contains(m))
+                        {
+                            var wrapper = new MethodCompiler(_c, m, literals, _backend)
+                                    .CompileInterceptWrapper()
+                                ?? throw new NotSupportedException(
+                                    $"taking the address of {m.DeclaringClass.FullName}::{m.Name} " +
+                                    "(delegate method group / function pointer): the intercept that " +
+                                    "lowers its calls cannot be replayed as a function body");
+                            emitBody?.Invoke(m, wrapper);
+                            compiledMethods.Add(m);
+                            continue;
+                        }
+                        // A synthesized GenericComparer<T>.Compare over a VALUE TYPE real .NET's
+                        // default comparer cannot order (see
+                        // Compilation.IsUnorderableComparerCompareBody): its real IL boxes the value
+                        // type for the null checks (an intrinsic value type has no ti_ to box
+                        // through) and dispatches a CompareTo that does not exist. Real .NET throws
+                        // ArgumentException here; body-replace with a catchable
+                        // PlatformNotSupportedException so the comparer object stays real and only
+                        // its Compare faults. The trailing `return 0;` is unreachable (the throw is
+                        // [[noreturn]]) and only keeps the int32 return type-checking.
+                        if (_c.IsUnorderableComparerCompareBody(m))
+                        {
+                            string elem = _c.GenericDefFullName(m.DeclaringClass.Context.TypeArgs[0].Class!);
+                            string body = $"// {m.DeclaringClass.FullName}::{m.Name} (element not orderable — throws on call)\n"
+                                + $"{MethodCompiler.Signature(m)}\n{{\n"
+                                + $"    dn2cpp_throw_platform_not_supported(\"Comparer<{elem}>.Default.Compare: "
+                                + $"{elem} does not implement IComparable and is not orderable "
+                                + "(real .NET throws ArgumentException here)\");\n"
+                                + "    return 0;\n}\n";
+                            emitBody?.Invoke(m, body);
+                            compiledMethods.Add(m);
+                            continue;
+                        }
+                        // An intrinsic-mapped type's method whose body IS transpiled (String's
+                        // interface impls): prefer synthesizing from the intrinsic lowering
+                        // when one exists — String.Equals(String) becomes the same
+                        // dn2cpp_string_equals its call sites use, instead of dragging the
+                        // real body's private helpers (EqualsHelper's SIMD loops) into the
+                        // tree. No lowering (GetEnumerator/Clone/the explicit interface
+                        // impls) compiles the real IL; a real body that hits an unmapped
+                        // intrinsic (an IConvertible impl over an unmodeled Convert form)
+                        // degrades to a trap-on-call body instead of failing the build —
+                        // the slot is only reached because SOME type dispatches the decl,
+                        // and a string may never flow there.
+                        if (CoreIntrinsics.IsIntrinsicType(m.DeclaringClass.FullName))
+                        {
+                            string body;
+                            if (new MethodCompiler(_c, m, literals, _backend)
+                                    .CompileCoreIntrinsicWrapper() is { } iw)
+                                body = iw;
+                            else
+                                try
+                                {
+                                    body = new MethodCompiler(_c, m, literals, _backend).Compile();
+                                }
+                                // Must-escape (Compilation.IsMustEscape): a bound overrun is a
+                                // NotSupportedException, so the type alone does not filter it —
+                                // and baking it into a trap body would report the run as a
+                                // success while the model kept growing.
+                                catch (NotSupportedException ex) when (!Compilation.IsMustEscape(ex))
+                                {
+                                    string msg = $"{m.DeclaringClass.FullName}.{m.Name} is not transpilable: {ex.Message}"
+                                        .Replace("\\", "\\\\").Replace("\"", "\\\"");
+                                    body = $"// {m.DeclaringClass.FullName}::{m.Name} (untranspilable — traps on call)\n"
+                                        + $"{MethodCompiler.Signature(m)}\n{{\n    dn2cpp_fail(\"NotSupportedException ({msg})\");\n}}\n";
+                                }
+                            emitBody?.Invoke(m, body);
+                            compiledMethods.Add(m);
+                            continue;
+                        }
+                        // A grouped method bound to a hidden-parameter shared body keeps
+                        // its own symbol as a one-line forwarder appending its class's
+                        // rgctx table — the per-instantiation function identity every
+                        // boundary (vtable, interface table, ldftn, reflection) uses.
+                        if (m.SharedImpl is { } fwdImpl)
+                        {
+                            string fwd = RgctxForwarderBody(m, fwdImpl);
+                            emitBody?.Invoke(m, fwd);
+                            compiledMethods.Add(m);
+                            _c.RgctxForwarderCount++;
+                            continue;
+                        }
+                        // A canonical-owner-world method is only ever a shared-body
+                        // candidate: compile it with the taint checks armed. In the
+                        // planning pass a taint (or an unsupported placeholder shape)
+                        // just marks it unshareable — each grouped user then compiles
+                        // its own body; in the final pass only shareable candidates
+                        // survive in Reachable, so a throw here propagates as a real
+                        // error.
+                        if (_c.SharedGenericsEnabled && Compilation.IsCanonicalMethod(m))
+                        {
+                            var mc = new MethodCompiler(_c, m, literals, _backend)
+                            {
+                                SharedTrial = true,
+                                SharedDirectCallees = planning ? new List<(MethodInfo, bool)>() : null,
+                            };
+                            if (planning)
+                            {
+                                try
+                                {
+                                    mc.Compile();
+                                    _c.SharedTrialCompiled.Add(m);
+                                    _c.SharedCallEdges[m] = mc.SharedDirectCallees!;
+                                }
+                                catch (SharedBodyTaintException ex)
+                                {
+                                    _c.SharedTaint[m] = ex.Kind;
+                                }
+                                // Must-escape (Compilation.IsMustEscape): never a taint, never a
+                                // fallback — the same filter the measure-mode arm below carries.
+                                // A canonical trial DOES mint instantiations nothing else in the
+                                // run names (the emitter-invented SZArrayEnumerable<E> wrapper of
+                                // an array-to-collection boundary, a delegate ctor resolved under
+                                // the canonical context), so the bound can genuinely trip in here;
+                                // recorded as a taint it would silently change which bodies get
+                                // shared and keep feeding the overrun it bounds.
+                                catch (NotSupportedException ex) when (!Compilation.IsMustEscape(ex))
+                                {
+                                    // A placeholder-only gap (e.g. an intrinsic keyed on
+                                    // the concrete type): unshareable, users fall back.
+                                    _c.SharedTaint[m] = "unsupported";
+                                    if (EnvKnobs.BoolIsOne(EnvKnobs.SharedDump))
+                                        Console.WriteLine(
+                                            $"dn2cpp: shared-generics unsupported {m.CppName}: {ex.Message}");
+                                }
+                            }
+                            else if (diagnostics is null)
+                            {
+                                string canon = mc.Compile();
+                                emitBody?.Invoke(m, canon);
+                                compiledMethods.Add(m);
+                            }
+                            else
+                            {
+                                // Measure mode: a canonical survivor's throw becomes a gap
+                                // row instead of aborting the run (the normal-emit branch
+                                // above keeps the invariant that a throw is a real error).
+                                try
+                                {
+                                    string canon = mc.Compile();
+                                    emitBody?.Invoke(m, canon);
+                                    compiledMethods.Add(m);
+                                }
+                                // Must-escape (Compilation.IsMustEscape): never a gap row, never a fallback.
+                                catch (Exception ex) when (!Compilation.IsMustEscape(ex))
+                                {
+                                    diagnostics.Add(MeasureGap.From("compile", m, ex));
+                                }
+                            }
+                            continue;
+                        }
+                        if (diagnostics is null)
+                        {
+                            var body = new MethodCompiler(_c, m, literals, _backend).Compile();
+                            if (!planning)
+                            {
+                                emitBody?.Invoke(m, body);
+                                compiledMethods.Add(m);
+                            }
+                            continue;
+                        }
                         try
                         {
-                            string canon = mc.Compile();
-                            emitBody?.Invoke(m, canon);
+                            string body = new MethodCompiler(_c, m, literals, _backend).Compile();
+                            emitBody?.Invoke(m, body);
                             compiledMethods.Add(m);
                         }
-                        // Must-escape (Compilation.IsMustEscape): never a gap row, never a fallback.
+                        // Measure mode only (diagnostics != null): record any exception, by type,
+                        // and keep going — an unexpected throw must not truncate the gap inventory.
+                        // The must-escape pair (Compilation.IsMustEscape) is the exception: recording
+                        // the monomorphization bound and compiling on would feed the very growth it
+                        // exists to stop.
                         catch (Exception ex) when (!Compilation.IsMustEscape(ex))
                         {
                             diagnostics.Add(MeasureGap.From("compile", m, ex));
                         }
                     }
-                    continue;
+                    windowStart = windowEnd;
                 }
-                if (diagnostics is null)
-                {
-                    var body = new MethodCompiler(_c, m, literals, _backend).Compile();
-                    if (!planning)
-                    {
-                        emitBody?.Invoke(m, body);
-                        compiledMethods.Add(m);
-                    }
-                    continue;
-                }
-                try
-                {
-                    string body = new MethodCompiler(_c, m, literals, _backend).Compile();
-                    emitBody?.Invoke(m, body);
-                    compiledMethods.Add(m);
-                }
-                // Measure mode only (diagnostics != null): record any exception, by type,
-                // and keep going — an unexpected throw must not truncate the gap inventory.
-                // The must-escape pair (Compilation.IsMustEscape) is the exception: recording
-                // the monomorphization bound and compiling on would feed the very growth it
-                // exists to stop.
-                catch (Exception ex) when (!Compilation.IsMustEscape(ex))
-                {
-                    diagnostics.Add(MeasureGap.From("compile", m, ex));
-                }
+            }
+            finally
+            {
+                workers?.Stop();
             }
             // Complete any generics the just-compiled bodies instantiated, so their
             // layouts are ready for the struct/type-info emit below and the next
@@ -2178,6 +2677,7 @@ internal sealed partial class CppEmitter
                 diagnostics.Add(MeasureGap.Dangling(callee, caller));
             Timing.Mark("measure-dangling");
         }
+        ReportParallelBodyStats();
         return new MeasureResult(attempted, compiledMethods.Count, diagnostics, namedCount);
     }
 

--- a/src/Dn2Cpp.Transpiler/Timing.cs
+++ b/src/Dn2Cpp.Transpiler/Timing.cs
@@ -56,4 +56,17 @@ internal static class Timing
             $"dn2cpp-time: {phase} {now - _lastMs} ms total {now - _firstMs} ms heap {heapMb} MB{pop}");
         _lastMs = now;
     }
+
+    /// <summary>Reports the body scheduler's aggregate fan-out. Kept separate
+    /// from <see cref="Mark"/> because the counts describe all planning and
+    /// emission passes owned by one emitter rather than one timed phase.</summary>
+    internal static void ParallelBodies(
+        int requested, int effective, int peak, int retries, int eligible, int serial)
+    {
+        if (!Enabled)
+            return;
+        Console.Error.WriteLine(
+            $"dn2cpp-time: parallel-bodies requested {requested} effective {effective} "
+            + $"peak {peak} retries {retries} eligible {eligible} serial {serial}");
+    }
 }

--- a/src/Dn2Cpp.Transpiler/TranspileDriver.cs
+++ b/src/Dn2Cpp.Transpiler/TranspileDriver.cs
@@ -86,6 +86,11 @@ public static class TranspileDriver
         string input = options.Input;
         string outDir = options.OutDir;
         bool measure = options.Measure;
+        if (options.MaxDegreeOfParallelism < 0)
+        {
+            Console.Error.WriteLine("error: MaxDegreeOfParallelism must be zero or a positive integer");
+            return 1;
+        }
         if (!File.Exists(input))
         {
             Console.Error.WriteLine($"error: input assembly not found: {input}");

--- a/src/Dn2Cpp.Transpiler/TranspileOptions.cs
+++ b/src/Dn2Cpp.Transpiler/TranspileOptions.cs
@@ -22,6 +22,12 @@ public sealed record TranspileOptions
     /// report every reachable transpilation gap instead of emitting C++.</summary>
     public bool Measure { get; init; }
 
+    /// <summary>Maximum number of method bodies compiled concurrently
+    /// (<c>--jobs</c>). Zero selects <see cref="Environment.ProcessorCount"/>;
+    /// a positive value sets an explicit limit. Negative values are rejected by
+    /// <see cref="TranspileDriver"/>.</summary>
+    public int MaxDegreeOfParallelism { get; init; }
+
     /// <summary>Opt-in (<c>--verbose</c>): expand the driver's end-of-run reports that
     /// print a count by default into their per-item detail. A flag rather than an env
     /// knob — those reports answer "what did this build quietly decline to do", and an


### PR DESCRIPTION
## 概要

- 到達済みメソッド本体のうち、共有状態を変更しないことを証明できる static scalar body を bounded worker pool で並列コンパイルします。
- worker の結果・例外・measure 診断はメソッド順に commit し、出力の決定性を維持します。
- full/console 両 CLI に `--jobs <n>` を追加し、`--jobs 1` で逐次実行、未指定時は論理 CPU 数を上限とする適応 fan-out を使います。
- 通常 emit、shared-generics planning、`--measure` を同じスケジューラ経路で処理します。

## 安全性と回帰検証

- token-bearing IL、参照型、複合 local、例外領域などは従来の逐次経路へ fallback します。
- primitive LOCAL_SIG は raw metadata で判定し、prefix・token・composite type を並列対象から除外します。
- jobs=1/2、FIFO/LIFO、shared-generics on/off、strict completion、measure sidecar/diagnostic 順序の byte identity をゲートで確認します。
- 2 logical CPU を前提とする worker overlap は専用ゲートで `peak 2 / eligible 2 / serial 1` を固定します。1 CPU 環境では prerequisite skip になります。

## 検証

- `dotnet build src/Dn2Cpp.Cli -c Release`: warning/error 0
- `dotnet build src/Dn2Cpp.Cli -c Debug`: warning/error 0
- `gates/build-and-run-cli-args.sh`: PASS
- `gates/build-and-run-parallel-bodies.sh`: PASS
- `gates/build-and-run-emit-order-stability.sh`: Release/Debug PASS
- `gates/selfhost-emit-console.sh`: 102 translation units、clang syntax error 0
- self-host 3 回中央値: body compile 1061 ms -> 966 ms、end-to-end 7980 ms -> 7830 ms (`jobs=1` -> `jobs=2`)

`gates/pre-merge.sh` は人間専用のため実行していません。