### PR TITLE
Shard platform ISA native verification

### DIFF
--- a/.github/workflows/windows-smoke.yml
+++ b/.github/workflows/windows-smoke.yml
@@ -188,9 +188,6 @@ jobs:
 
       # Normal mode on purpose. DN2CPP_REQUIRE_ALL=1 would fail on the
       # cross-toolchain gates this runner cannot satisfy — see the header.
-      # Keep one gate worker on the hosted Windows image. The wide ISA build
-      # has a large temporary footprint, and memory pressure from even one
-      # concurrent MSVC gate can terminate its native probe mid-write.
       #
       # openssl: Git for Windows ships openssl.exe under usr/bin, which this
       # bash step's PATH should resolve — but that is unverified as of this
@@ -198,7 +195,7 @@ jobs:
       # openssl as a hard failure, not a gate_skip (see its command -v check),
       # so this is the first thing to look at if suite-smoke goes red here.
       - name: Run the non-Godot suite
-        run: JOBS=1 SKIP_GODOT=1 ./gates/run-all-gates.sh
+        run: SKIP_GODOT=1 ./gates/run-all-gates.sh
 
       # Before the log upload so a lingering build-server handle on a log file
       # cannot make the upload step see a partially-flushed file.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -302,10 +302,15 @@ capability contract, not a set of independent constants:
   re-derives both rules from the csv and the header.
 - **Every Lowered helper is exercised.** `Exercises.g.cs` in the probe, written
   by the same generator, calls each mapped method with fixed inputs and prints
-  the bytes; `gates/build-and-run-platform-isa-native.sh` transpiles and links
-  one probe, then diffs its X86 and Arm runs against real .NET, so a wrong
-  lowering fails on the machine that has the instruction rather than in a
-  user's program.
+  the bytes. The native gate compiles the probe in bounded reachability shards:
+  each managed variant omits the other families' table and exercise roots, so
+  their helper headers and immediate dispatches cannot enter that native image.
+  The gate proves the shards assign every row, top-level exercise and invalid
+  immediate witness exactly once, and that each generated image contains only
+  its assigned exercise bodies. It then concatenates their output and diffs it
+  against the identically sharded real-.NET runs. A wrong lowering therefore
+  fails on the machine that has the instruction rather than in a user's
+  program, without one compiler or process owning the full ISA surface.
   `Wasm.PackedSimd` has no such oracle (no host .NET answers true for it), so
   its run is frozen in `gates/expected/platform-isa-wasm-simd.txt` and every
   row with a portable equivalent carries a `@ref` cross-check against the

--- a/gates/_platform_isa.sh
+++ b/gates/_platform_isa.sh
@@ -86,36 +86,34 @@ platform_isa_join() {
     printf '%s\n' "$out"
 }
 
-PLATFORM_ISA_WINDOWS_SUPPORTED_CHUNK_ROWS=1
+PLATFORM_ISA_NATIVE_SHARDS="x86-base x86-avx x86-avx512 x86-avx10 arm"
 
-# A supported X86 probe touches a large fraction of the wide generated image.
-# Bound its Windows working-set high-water mark by giving each native process a
-# single registry row; row costs vary too much for a wider fixed-size slice to
-# be a memory bound. The oracle uses the identical slices.
-platform_isa_supported_chunks() {
-    local csv="$1" limit="$PLATFORM_ISA_WINDOWS_SUPPORTED_CHUNK_ROWS"
-    local rest="$csv" item chunk="" count=0
-    while [ -n "$rest" ]; do
-        case "$rest" in
-            *,*) item=${rest%%,*}; rest=${rest#*,} ;;
-            *)   item=$rest; rest="" ;;
-        esac
-        chunk="${chunk:+$chunk,}$item"
-        count=$((count + 1))
-        if [ "$count" -eq "$limit" ]; then
-            printf '%s\n' "$chunk"
-            chunk=""
-            count=0
-        fi
-    done
-    [ -z "$chunk" ] || printf '%s\n' "$chunk"
+platform_isa_shard_arch() {
+    case "$1" in
+        x86-*) printf 'x86\n' ;;
+        arm)   printf 'arm\n' ;;
+        *) echo "error: unknown native platform-ISA shard '$1'" >&2; return 1 ;;
+    esac
 }
 
-platform_isa_is_windows_shell() {
-    case "$(uname -s)" in
-        MINGW*|MSYS*|CYGWIN*) return 0 ;;
-        *)                    return 1 ;;
+platform_isa_exercise_body_markers() {
+    local name="$1" family
+    case "$name" in
+        X86.X86Base|X86.Lzcnt|X86.Popcnt|X86.Bmi1|X86.Bmi2|X86.X86Serialize)
+            family=${name#X86.}
+            printf 'PlatformIsaProbe.X86Sections::%sExercise\n' "$family"
+            ;;
+        Arm.ArmBase|Arm.Crc32)
+            family=${name#Arm.}
+            printf 'PlatformIsaProbe.ArmSections::%sExercise\n' "$family"
+            ;;
+        *)
+            printf 'PlatformIsaProbe.Exercises::%s\n' "${name//./}"
+            ;;
     esac
+    if [ "$name" = X86.Avx ]; then
+        printf 'PlatformIsaProbe.X86Sections::AvxCompareScalarTrueModesExercise\n'
+    fi
 }
 
 # platform_isa_contract_block TEXT — the `== contract ==` lines of a probe run.
@@ -131,7 +129,7 @@ platform_isa_invalid_immediate_rows() {
     [ -f "$PLATFORM_ISA_EXERCISES" ] \
         || { echo "error: $PLATFORM_ISA_EXERCISES not found" >&2; return 1; }
     tr -d '\r' < "$PLATFORM_ISA_EXERCISES" \
-        | sed -nE "s/^[[:space:]]*exercises\[\"($isa\.[^\"]+)\"\] = \(\) =>$/\1/p"
+        | sed -nE "s/^[[:space:]]*exercises\.Add\(\"($isa\.[^\"]+)\", \(\) =>$/\1/p"
 }
 
 # platform_isa_invalid_immediate_registry — every generated native-only
@@ -142,7 +140,7 @@ platform_isa_invalid_immediate_registry() {
     [ -f "$PLATFORM_ISA_EXERCISES" ] \
         || { echo "error: $PLATFORM_ISA_EXERCISES not found" >&2; return 1; }
     tr -d '\r' < "$PLATFORM_ISA_EXERCISES" \
-        | sed -nE 's/^[[:space:]]*exercises\["((X86|Arm|Wasm)\.[^"]+)"\] = \(\) =>$/\1/p'
+        | sed -nE 's/^[[:space:]]*exercises\.Add\("((X86|Arm|Wasm)\.[^"]+)", \(\) =>$/\1/p'
 }
 
 # platform_isa_invalid_immediate_violations TEXT — one diagnostic per boundary
@@ -326,13 +324,7 @@ _platform_isa_arch_context() {
 _platform_isa_native_plan_self_check() {
     local arch rows name lowered_flag combined_rows="" expected_rows
     local combined_invalid="" expected_invalid registry combined_registry=""
-    local lowered_names witness_count chunks flattened
-    chunks=$(platform_isa_supported_chunks 'a,b,c,d,e,f,g,h,i') || return 1
-    flattened=${chunks//$'\n'/,}
-    [ "$flattened" = 'a,b,c,d,e,f,g,h,i' ] \
-        || { echo "FAIL: platform-ISA supported-run chunks changed selection order" >&2; return 1; }
-    [ "$(grep -c . <<<"$chunks" || true)" -eq 9 ] \
-        || { echo "FAIL: platform-ISA supported-run chunk bound is not enforced" >&2; return 1; }
+    local lowered_names witness_count
     for arch in x86 arm; do
         rows=$(platform_isa_table_rows "$arch") || return 1
         lowered_names=""
@@ -372,25 +364,24 @@ _platform_isa_native_plan_self_check() {
 }
 
 # ── The native behaviour gate ────────────────────────────────────────────────
-# One shared host-native PlatformIsaProbe executes the X86 and Arm contracts,
-# diffed against real .NET. The family selection and every policy mask are
-# run-time inputs; neither changes the transpiled or compiled program.
+# Compile-time shards execute the X86 and Arm contracts diffed against real
+# .NET. A shard omits every other family's table and exercise registration, so
+# the transpiler cannot retain their helpers through a run-time selection arm.
 #
 # Runs, each ours-vs-oracle on stdout and exit code:
 #   F  foreign host only: every row of ARCH, no mask. Witness: no `=True`.
-#   S  native host, Lowered rows only, no mask on either side. Witness: the
+#   S  native host, every shard with exhaustive exercises enabled. Witness: the
 #      base family is true once it is Lowered.
 #   M  always: every row, DN2CPP_CPU_FEATURES=none vs DOTNET_EnableHWIntrinsic=0.
 #      Witnesses: no `=True`, and exactly one `effective=(none)` diag line.
-#   P  native host, Lowered rows only, the partial mask vs the oracle's knobs.
-#      Witnesses: PLATFORM_ISA_P_TRUE stays true, PLATFORM_ISA_P_FALSE goes false.
+#   P  native host, the two partial-mask witnesses in their one shard. The true
+#      witness executes its helper; the false witness executes its throwing probe.
 #   O  native x86 host, the AVX10.2 policy rows under the positive opt-in. The
 #      oracle opts in only when the configured compiler has the helper surface;
 #      otherwise both sides stay false and the nested throwing stubs are called.
-# Rows that are not Lowered fold to false on our side whatever the CPU, so S
-# and P select the Lowered set only; F and M expect false everywhere anyway.
+# Rows that are not Lowered fold to false on our side whatever the CPU.
 _platform_isa_run_arch() {
-    local arch="$1" out="$2" project="$3" host_arch="$4" avx10v2_compiler="$5"
+    local arch="$1" host_arch="$2" avx10v2_compiler="$3"
     local isa base
     isa=$(platform_isa_arch_name "$arch") || exit 1
     case "$arch" in
@@ -418,6 +409,33 @@ _platform_isa_run_arch() {
     invalid_count=$(grep -c . <<<"$invalid_rows" || true)
     [ "$invalid_count" -gt 0 ] \
         || { echo "error: generated exercises list no $isa invalid-immediate boundary" >&2; exit 1; }
+
+    local shard_names=() shard_outs=() shard_apps=() i
+    for ((i = 0; i < ${#PLATFORM_ISA_BUILT_SHARDS[@]}; i++)); do
+        if [ "${PLATFORM_ISA_BUILT_ARCHES[$i]}" = "$arch" ]; then
+            shard_names+=("${PLATFORM_ISA_BUILT_SHARDS[$i]}")
+            shard_outs+=("${PLATFORM_ISA_BUILT_OUTS[$i]}")
+            shard_apps+=("${PLATFORM_ISA_BUILT_APPS[$i]}")
+        fi
+    done
+    [ "${#shard_names[@]}" -gt 0 ] \
+        || { echo "error: no compiled platform-ISA shard for $arch" >&2; exit 1; }
+
+    local p_shard="" p_plan p_true_here p_false_here
+    for ((i = 0; i < ${#shard_names[@]}; i++)); do
+        p_plan=$(dotnet "${shard_apps[$i]}" --dump-plan) || exit 1
+        p_true_here=$(grep -Fxc "row=$PLATFORM_ISA_P_TRUE" <<<"$p_plan" || true)
+        p_false_here=$(grep -Fxc "row=$PLATFORM_ISA_P_FALSE" <<<"$p_plan" || true)
+        if [ "$p_true_here" -ne 0 ] || [ "$p_false_here" -ne 0 ]; then
+            [ "$p_true_here" -eq 1 ] && [ "$p_false_here" -eq 1 ] \
+                || { echo "error: partial-mask witnesses span native ISA shards" >&2; exit 1; }
+            [ -z "$p_shard" ] \
+                || { echo "error: partial-mask witnesses occur in multiple native ISA shards" >&2; exit 1; }
+            p_shard="${shard_names[$i]}"
+        fi
+    done
+    [ -n "$p_shard" ] \
+        || { echo "error: no native ISA shard contains the partial-mask witnesses" >&2; exit 1; }
 
     local native_host=0
     [ "$host_arch" = "$arch" ] && native_host=1
@@ -469,31 +487,45 @@ _platform_isa_run_arch() {
     _pi_run() {
         local label="$1" argv="$2" ours_env="$3" oracle_env="$4"
         local ours_code=0 expected_code=0 ours_out expected_out oracle_log
-        local chunk chunk_code expected_chunk_code chunks=("$argv")
+        local shard out app chunk_code expected_chunk_code executed_shards=0
+        local run_args=()
         _PI_LOG="$log_dir/$label.log"
         oracle_log="$log_dir/$label.oracle.log"
         ours_out="$log_dir/$label.out"
         expected_out="$log_dir/$label.oracle.out"
-        if { [ "$label" = S ] || [ "$label" = P ]; } && platform_isa_is_windows_shell; then
-            chunks=()
-            while IFS= read -r chunk; do chunks+=("$chunk"); done \
-                < <(platform_isa_supported_chunks "$argv")
-        fi
         : >"$ours_out"
         : >"$expected_out"
         : >"$_PI_LOG"
         : >"$oracle_log"
-        for chunk in "${chunks[@]}"; do
+        for ((i = 0; i < ${#shard_names[@]}; i++)); do
+            shard="${shard_names[$i]}"
+            out="${shard_outs[$i]}"
+            app="${shard_apps[$i]}"
+            if [ "$label" = O ] && [ "$shard" != x86-avx10 ]; then
+                continue
+            fi
+            if [ "$label" = P ] && [ "$shard" != "$p_shard" ]; then
+                continue
+            fi
+            if [ "$label" = O ] || [ "$label" = P ]; then
+                run_args=("$argv")
+            else
+                run_args=(all)
+            fi
+            case "$label" in
+                F|M) run_args+=(--contract-only) ;;
+            esac
+            executed_shards=$((executed_shards + 1))
             # Scope each ISA environment in a subshell: `env` cannot invoke the
             # run_bounded shell function. Direct files avoid MSYS native-pipe loss.
             set +e
             # shellcheck disable=SC2086
             (if [ -n "$ours_env" ]; then export $ours_env; fi
-             run_bounded "./$out/$project" "$chunk") \
+             run_bounded "./$out/$PLATFORM_ISA_PROJECT" "${run_args[@]}") \
                 >>"$ours_out" 2>>"$_PI_LOG"; chunk_code=$?
             # shellcheck disable=SC2086
             (if [ -n "$oracle_env" ]; then export $oracle_env; fi
-             run_bounded dotnet "$_CG_APP" "$chunk") \
+             run_bounded dotnet "$app" "${run_args[@]}") \
                 >>"$expected_out" 2>>"$oracle_log"; expected_chunk_code=$?
             set -e
             [ "$ours_code" -ne 0 ] || ours_code=$chunk_code
@@ -509,7 +541,7 @@ _platform_isa_run_arch() {
         _PI_RUN_ORACLE_OUTS+=("$expected_out")
         _PI_RUN_LOGS+=("$_PI_LOG")
         _PI_RUN_ORACLE_LOGS+=("$oracle_log")
-        echo "-- run $label: argv=$argv chunks=${#chunks[@]} ours=[${ours_env:-<no ISA env>}] oracle=[${oracle_env:-<no ISA env>}]"
+        echo "-- run $label: argv=$argv shards=$executed_shards ours=[${ours_env:-<no ISA env>}] oracle=[${oracle_env:-<no ISA env>}]"
         local failed=0
         if cmp -s "$ours_out" "$expected_out"; then
             cat "$ours_out"
@@ -534,14 +566,24 @@ _platform_isa_run_arch() {
     # are not an oracle for out-of-contract ConstantExpected values.
     _pi_run_native() {
         local label="$1" argv="$2" ours_env="$3" ours_code ours_out
+        local shard out shard_code=0
         _PI_LOG="$log_dir/$label.log"
         ours_out="$log_dir/$label.out"
-        set +e
-        # shellcheck disable=SC2086
-        (if [ -n "$ours_env" ]; then export $ours_env; fi
-         run_bounded "./$out/$project" "$argv" --invalid-immediates) \
-            >"$ours_out" 2>"$_PI_LOG"; ours_code=$?
-        set -e
+        : >"$ours_out"
+        : >"$_PI_LOG"
+        ours_code=0
+        for ((i = 0; i < ${#shard_names[@]}; i++)); do
+            shard="${shard_names[$i]}"
+            out="${shard_outs[$i]}"
+            set +e
+            # shellcheck disable=SC2086
+            (if [ -n "$ours_env" ]; then export $ours_env; fi
+             run_bounded "./$out/$PLATFORM_ISA_PROJECT" all --invalid-immediates) \
+                >>"$ours_out" 2>>"$_PI_LOG"; shard_code=$?
+            set -e
+            [ "$ours_code" -ne 0 ] || ours_code=$shard_code
+            [ "$shard_code" -eq 0 ] || break
+        done
         _PI_RUN_LABELS+=("$label")
         _PI_RUN_CODES+=("$ours_code")
         _PI_RUN_ORACLE_CODES+=("")
@@ -549,7 +591,7 @@ _platform_isa_run_arch() {
         _PI_RUN_ORACLE_OUTS+=("")
         _PI_RUN_LOGS+=("$_PI_LOG")
         _PI_RUN_ORACLE_LOGS+=("")
-        echo "-- run $label: argv=$argv --invalid-immediates ours=[${ours_env:-<no ISA env>}]"
+        echo "-- run $label: argv=$argv shards=${#shard_names[@]} --invalid-immediates ours=[${ours_env:-<no ISA env>}]"
         if [ "$ours_code" -ne 0 ]; then
             echo "FAIL: run $label of the $isa invalid-immediate contract exited $ours_code" >&2
             gate_run_diag_once
@@ -625,10 +667,11 @@ _platform_isa_run_arch() {
     n=$(grep -c '=True$' <<<"$block" || true)
     _pi_require_count M 0 "$n" "'=True' rows under DN2CPP_CPU_FEATURES=none"
     n=$(grep -c 'effective=(none)' "$_PI_LOG" || true)
-    _pi_require_count M 1 "$n" "'effective=(none)' diag line on stderr (DN2CPP_CPU_FEATURES_DIAG=1 prints exactly one)"
+    _pi_require_count M "${#shard_names[@]}" "$n" "'effective=(none)' diag lines on stderr (one per shard process)"
 
     if [ "$native_host" -eq 1 ] && [ -n "$lowered_csv" ]; then
-        _pi_run P "$lowered_csv" "DN2CPP_CPU_FEATURES=$PLATFORM_ISA_P_MASK" "$PLATFORM_ISA_P_KNOBS"
+        _pi_run P "$PLATFORM_ISA_P_TRUE,$PLATFORM_ISA_P_FALSE" \
+            "DN2CPP_CPU_FEATURES=$PLATFORM_ISA_P_MASK" "$PLATFORM_ISA_P_KNOBS"
         case ",$lowered_csv," in
             *",$PLATFORM_ISA_P_TRUE,"*)
                 n=$(grep -c "^$PLATFORM_ISA_P_TRUE=True\$" <<<"$_PI_OURS" || true)
@@ -682,13 +725,13 @@ _platform_isa_run_arch() {
             rosetta=" Rosetta is excluded on purpose: its CPUID exposes a feature set no shipping CPU has, and the oracle would be an emulated .NET rather than the host's."
         fi
         # One line: run-all-gates.sh's summary takes the FIRST line of the reason.
-        gate_expected_partial "runs $native_runs (the $isa families' supported, opt-in where applicable, and partially-masked paths) have no reachable state on this ${host_arch:-$(uname -m)} host: no software installable here creates an $isa CPU, so nothing this gate could do makes an $isa family's IsSupported true on either side.$rosetta Structural and permanent, not an absent prerequisite — which is why this is not a gate_skip/gate_partial. The uncovered surface IS asserted for real by this same gate, gates/build-and-run-platform-isa-native.sh, run on an $isa host (the linux-x64 and windows-x64 lanes for x86, macos-arm64 for arm), where $native_runs run end to end. Runs F (every $isa row false and every $isa family throwing PlatformNotSupportedException, exactly as real .NET does here) and M (DN2CPP_CPU_FEATURES=none vs DOTNET_EnableHWIntrinsic=0, with the one diag line) did run in this invocation and hold."
+        gate_expected_partial "runs $native_runs (the $isa families' supported, opt-in where applicable, and partially-masked paths) have no reachable state on this ${host_arch:-$(uname -m)} host: no software installable here creates an $isa CPU, so nothing this gate could do makes an $isa family's IsSupported true on either side.$rosetta Structural and permanent, not an absent prerequisite — which is why this is not a gate_skip/gate_partial. The uncovered surface IS asserted for real by this same gate, gates/build-and-run-platform-isa-native.sh, run on an $isa host (the linux-x64 and windows-x64 lanes for x86, macos-arm64 for arm), where $native_runs run end to end. Runs F (every $isa row false and every $isa family throwing PlatformNotSupportedException, exactly as real .NET does here) and M (DN2CPP_CPU_FEATURES=none vs DOTNET_EnableHWIntrinsic=0, with one diag line per shard process) did run in this invocation and hold."
     fi
 }
 
-# platform_isa_native_gate — transpile and compile PlatformIsaProbe once, then
-# execute both native architecture contracts. A cache entry is committed only
-# after the two plans and all their native/oracle runs have passed.
+# platform_isa_native_gate — compile each bounded reachability shard, then
+# execute the combined native architecture contracts. A cache entry is
+# committed only after every shard and native/oracle run has passed.
 platform_isa_native_gate() {
     [ "$#" -eq 0 ] \
         || { echo "error: platform_isa_native_gate takes no arguments" >&2; return 1; }
@@ -696,15 +739,114 @@ platform_isa_native_gate() {
     _platform_isa_native_plan_self_check || return 1
     _platform_isa_clear_runtime_env || return 1
 
-    local project="$PLATFORM_ISA_PROJECT" out host_arch avx10v2_compiler=0
+    local project="$PLATFORM_ISA_PROJECT" host_arch avx10v2_compiler=0
     local x86_ctx arm_ctx registry registry_csv registry_count ctx
-    out="$(_corelib_gate_out "$project")-isa-native"
+    local corelib project_file shard arch managed out app surface shard_surfaces=""
+    local expected_rows actual_rows expected_exercises actual_exercises
+    local expected_invalid actual_invalid first_out="" i
+    local plan plan_rows plan_exercises plan_invalid misplaced
+    local expected_body_markers actual_body_markers exercise marker
+    local key_inputs=()
     host_arch=$(platform_isa_host_arch)
     if [ "$host_arch" = x86 ] && platform_isa_avx10v2_compiler_capable; then
         avx10v2_compiler=1
     fi
 
-    _corelib_gate_core "$project" "$out"
+    echo "== 1/4 Locating the real CoreLib =="
+    corelib=$(locate_corelib)
+    _CG_CORELIB="$corelib"
+    echo "corlib: $corelib"
+
+    echo "== 2/4 Building compile-time reachability shards =="
+    project_file="samples/dotnet/$project/$project.csproj"
+    PLATFORM_ISA_BUILT_SHARDS=()
+    PLATFORM_ISA_BUILT_ARCHES=()
+    PLATFORM_ISA_BUILT_OUTS=()
+    PLATFORM_ISA_BUILT_APPS=()
+    for shard in $PLATFORM_ISA_NATIVE_SHARDS; do
+        arch=$(platform_isa_shard_arch "$shard") || return 1
+        managed="artifacts/platformisaprobe-managed-$shard"
+        out="artifacts/platformisaprobe-isa-native-$shard"
+        # The suite prebuild covers only the default all-family variant. These
+        # distinct IL reachability roots are part of this gate's subject.
+        dotnet build "$project_file" -c "$CONFIG" --nologo -v q \
+            -p:PlatformIsaShard="$shard" \
+            -p:OutputPath="../../../$managed/" \
+            -p:IntermediateOutputPath="../../../$managed/obj/" || return 1
+        app="$managed/$project.dll"
+        [ -f "$app" ] \
+            || { echo "error: $shard build produced no $app" >&2; return 1; }
+        PLATFORM_ISA_BUILT_SHARDS+=("$shard")
+        PLATFORM_ISA_BUILT_ARCHES+=("$arch")
+        PLATFORM_ISA_BUILT_OUTS+=("$out")
+        PLATFORM_ISA_BUILT_APPS+=("$app")
+        key_inputs+=("$app" "${app%.dll}.runtimeconfig.json" "${app%.dll}.deps.json")
+    done
+
+    echo "== 3/4 Transpiling shards and checking their exact coverage =="
+    expected_exercises=$(_platform_isa_table_fields \
+        | awk -F'\t' '$1 != "Wasm" && $4 == "true" && $2 !~ /\.[^.]+\.[^.]+$/ { print $2 }' \
+        | LC_ALL=C sort)
+    actual_rows=""
+    actual_exercises=""
+    actual_invalid=""
+    for ((i = 0; i < ${#PLATFORM_ISA_BUILT_SHARDS[@]}; i++)); do
+        shard="${PLATFORM_ISA_BUILT_SHARDS[$i]}"
+        out="${PLATFORM_ISA_BUILT_OUTS[$i]}"
+        app="${PLATFORM_ISA_BUILT_APPS[$i]}"
+        invoke_cli "$app" -r "$corelib" -o "$out" || return 1
+        surface=$(_gate_surface_lines "$out") || return 1
+        shard_surfaces="$shard_surfaces$shard:$(printf '%s\n' "$surface" | shasum -a 256 | awk '{print $1}')|"
+        [ -n "$first_out" ] || first_out="$out"
+        plan=$(dotnet "$app" --dump-plan) || return 1
+        plan_rows=$(sed -n 's/^row=//p' <<<"$plan" | LC_ALL=C sort)
+        plan_exercises=$(sed -n 's/^exercise=//p' <<<"$plan" | LC_ALL=C sort)
+        plan_invalid=$(sed -n 's/^invalid=//p' <<<"$plan" | LC_ALL=C sort)
+        misplaced=$(comm -23 <(printf '%s\n' "$plan_exercises") <(printf '%s\n' "$plan_rows"))
+        [ -z "$misplaced" ] \
+            || { echo "FAIL: $shard registers exercises outside its table: $misplaced" >&2; return 1; }
+        misplaced=$(comm -23 <(printf '%s\n' "$plan_invalid") <(printf '%s\n' "$plan_rows"))
+        [ -z "$misplaced" ] \
+            || { echo "FAIL: $shard registers invalid-immediate witnesses outside its table: $misplaced" >&2; return 1; }
+        expected_body_markers=""
+        while IFS= read -r exercise; do
+            [ -n "$exercise" ] || continue
+            while IFS= read -r marker; do
+                expected_body_markers="$expected_body_markers$marker"$'\n'
+            done < <(platform_isa_exercise_body_markers "$exercise")
+        done <<<"$plan_exercises"
+        expected_body_markers=$(printf '%s' "$expected_body_markers" | sed '/^$/d' | LC_ALL=C sort)
+        actual_body_markers=""
+        while IFS= read -r exercise; do
+            [ -n "$exercise" ] || continue
+            while IFS= read -r marker; do
+                if grep -Fqx -- "// $marker" "$out/generated.h" "$out"/generated*.cpp; then
+                    actual_body_markers="$actual_body_markers$marker"$'\n'
+                fi
+            done < <(platform_isa_exercise_body_markers "$exercise")
+        done <<<"$expected_exercises"
+        actual_body_markers=$(printf '%s' "$actual_body_markers" | sed '/^$/d' | LC_ALL=C sort)
+        [ "$actual_body_markers" = "$expected_body_markers" ] \
+            || { echo "FAIL: $shard generated exercise bodies escape their reachability shard" >&2; return 1; }
+        actual_rows="$actual_rows$plan_rows"$'\n'
+        actual_exercises="$actual_exercises$plan_exercises"$'\n'
+        actual_invalid="$actual_invalid$plan_invalid"$'\n'
+    done
+    actual_rows=$(printf '%s' "$actual_rows" | sed '/^$/d' | LC_ALL=C sort)
+    expected_rows=$(_platform_isa_table_fields \
+        | awk -F'\t' '$1 == "X86" || $1 == "Arm" { print $2 }' \
+        | LC_ALL=C sort)
+    [ "$actual_rows" = "$expected_rows" ] \
+        || { echo "FAIL: native shards do not assign every X86+Arm row exactly once" >&2; return 1; }
+    actual_exercises=$(printf '%s' "$actual_exercises" | sed '/^$/d' | LC_ALL=C sort)
+    [ "$actual_exercises" = "$expected_exercises" ] \
+        || { echo "FAIL: native shards do not assign every Lowered X86+Arm top-level exercise exactly once" >&2; return 1; }
+    actual_invalid=$(printf '%s' "$actual_invalid" | sed '/^$/d' | LC_ALL=C sort)
+    expected_invalid=$(platform_isa_invalid_immediate_registry \
+        | awk '/^(X86|Arm)\./' | LC_ALL=C sort)
+    [ "$actual_invalid" = "$expected_invalid" ] \
+        || { echo "FAIL: native shards do not assign every X86+Arm invalid-immediate witness exactly once" >&2; return 1; }
+
     x86_ctx=$(_platform_isa_arch_context x86 "$avx10v2_compiler") || return 1
     arm_ctx=$(_platform_isa_arch_context arm "$avx10v2_compiler") || return 1
     registry=$(platform_isa_invalid_immediate_registry) || return 1
@@ -714,18 +856,22 @@ platform_isa_native_gate() {
     [ "$registry_count" -gt 0 ] \
         || { echo "error: generated exercises list no invalid-immediate boundaries" >&2; return 1; }
     ctx="platform_isa_native|host:${host_arch:-other}|$_CG_CORELIB"
-    ctx="$ctx|windows-supported-chunk-rows:$PLATFORM_ISA_WINDOWS_SUPPORTED_CHUNK_ROWS"
+    ctx="$ctx|shards:$PLATFORM_ISA_NATIVE_SHARDS|surfaces:$shard_surfaces"
     ctx="$ctx|invalid-registry-count:$registry_count|invalid-registry:$registry_csv"
     ctx="$ctx|$x86_ctx|$arm_ctx$(_gate_ctx_extras)"
-    if _corelib_gate_check "$out" "$ctx"; then
+    while IFS= read -r app; do key_inputs+=("$app"); done < <(_gate_extra_inputs)
+    if gate_cache_check "$first_out" "$ctx" "${key_inputs[@]}"; then
         gate_cache_hit_msg
         return 0
     fi
 
-    echo "== 4/4 Compiling C++ once and running the X86 + Arm contracts (exact diff vs real .NET) =="
-    compile_console "$out" "$project"
+    echo "== 4/4 Compiling bounded shards and running the X86 + Arm contracts (exact diff vs real .NET) =="
+    for ((i = 0; i < ${#PLATFORM_ISA_BUILT_SHARDS[@]}; i++)); do
+        echo "-- compile ${PLATFORM_ISA_BUILT_SHARDS[$i]}"
+        compile_console "${PLATFORM_ISA_BUILT_OUTS[$i]}" "$project"
+    done
     gate_run_logs_init "platform_isa_native" "platform-isa-native"
-    _platform_isa_run_arch x86 "$out" "$project" "$host_arch" "$avx10v2_compiler"
-    _platform_isa_run_arch arm "$out" "$project" "$host_arch" "$avx10v2_compiler"
+    _platform_isa_run_arch x86 "$host_arch" "$avx10v2_compiler"
+    _platform_isa_run_arch arm "$host_arch" "$avx10v2_compiler"
     gate_cache_commit
 }

--- a/gates/build-and-run-platform-isa-native.sh
+++ b/gates/build-and-run-platform-isa-native.sh
@@ -1,14 +1,16 @@
 #!/usr/bin/env bash
 # The X86 and Arm platform-ISA capability contracts, diffed against real .NET
-# from one shared host-native PlatformIsaProbe. On the matching host every
-# Lowered family answers from run-time CPU detection and executes the instruction
-# results real .NET prints; on the foreign host every row is false and every
-# representative call throws PlatformNotSupportedException. Both families run
-# with all hardware intrinsics disabled, with their architecture-specific
-# partial masks, and through native-only invalid-immediate boundaries. X86 also
+# from compile-time reachability shards of PlatformIsaProbe. On the matching
+# host every Lowered family answers from run-time CPU detection and executes
+# the instruction results real .NET prints; on the foreign host every row is
+# false and every representative call throws PlatformNotSupportedException.
+# Both families run with all hardware intrinsics disabled, with their
+# architecture-specific partial masks, and through native-only invalid-immediate
+# boundaries. X86 also
 # runs the AVX10.2 opt-in when the compiler can build those helpers. Rows,
 # Lowered flags and boundary cases come from the generated tables, so the shared
-# plan changes without a hand-maintained family list here.
+# plan changes without a hand-maintained family list here. False-only runs skip
+# exhaustive exercises; supported and partial-mask runs execute their helpers.
 source "$(dirname "$0")/_common.sh"
 source "$(dirname "$0")/_platform_isa.sh"
 

--- a/samples/dotnet/PlatformIsaProbe/ArmSections.cs
+++ b/samples/dotnet/PlatformIsaProbe/ArmSections.cs
@@ -12,9 +12,11 @@ internal static class ArmSections
 {
     internal static void RegisterExercises(Dictionary<string, Action> exercises)
     {
-        exercises["Arm.ArmBase"] = ArmBaseExercise;
-        exercises["Arm.Crc32"] = Crc32Exercise;
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_ARM
+        exercises.Add("Arm.ArmBase", ArmBaseExercise);
+        exercises.Add("Arm.Crc32", Crc32Exercise);
         Exercises.RegisterArm(exercises);
+#endif
     }
 
     internal static void ProbeArmBase() { _ = ArmBase.LeadingZeroCount(1); }

--- a/samples/dotnet/PlatformIsaProbe/Exercises.g.cs
+++ b/samples/dotnet/PlatformIsaProbe/Exercises.g.cs
@@ -15,44 +15,104 @@ internal static class Exercises
 {
     internal static void RegisterX86(Dictionary<string, Action> exercises)
     {
-        exercises["X86.Sse"] = X86Sse;
-        exercises["X86.Sse2"] = X86Sse2;
-        exercises["X86.Sse3"] = X86Sse3;
-        exercises["X86.Ssse3"] = X86Ssse3;
-        exercises["X86.Sse41"] = X86Sse41;
-        exercises["X86.Sse42"] = X86Sse42;
-        exercises["X86.Pclmulqdq"] = X86Pclmulqdq;
-        exercises["X86.Aes"] = X86Aes;
-        exercises["X86.Avx"] = X86Avx;
-        exercises["X86.Avx2"] = X86Avx2;
-        exercises["X86.Fma"] = X86Fma;
-        exercises["X86.AvxVnni"] = X86AvxVnni;
-        exercises["X86.Avx512F"] = X86Avx512F;
-        exercises["X86.Avx512BW"] = X86Avx512BW;
-        exercises["X86.Avx512CD"] = X86Avx512CD;
-        exercises["X86.Avx512DQ"] = X86Avx512DQ;
-        exercises["X86.Avx512Vbmi"] = X86Avx512Vbmi;
-        exercises["X86.Avx512Vbmi2"] = X86Avx512Vbmi2;
-        exercises["X86.Avx10v1"] = X86Avx10v1;
-        exercises["X86.Avx10v2"] = X86Avx10v2;
-        exercises["X86.AvxVnniInt8"] = X86AvxVnniInt8;
-        exercises["X86.AvxVnniInt16"] = X86AvxVnniInt16;
-        exercises["X86.Gfni"] = X86Gfni;
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_BASE
+        exercises.Add("X86.Sse", X86Sse);
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_BASE
+        exercises.Add("X86.Sse2", X86Sse2);
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_BASE
+        exercises.Add("X86.Sse3", X86Sse3);
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_BASE
+        exercises.Add("X86.Ssse3", X86Ssse3);
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_BASE
+        exercises.Add("X86.Sse41", X86Sse41);
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_BASE
+        exercises.Add("X86.Sse42", X86Sse42);
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_BASE
+        exercises.Add("X86.Pclmulqdq", X86Pclmulqdq);
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_BASE
+        exercises.Add("X86.Aes", X86Aes);
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_AVX
+        exercises.Add("X86.Avx", X86Avx);
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_AVX
+        exercises.Add("X86.Avx2", X86Avx2);
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_AVX
+        exercises.Add("X86.Fma", X86Fma);
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_AVX
+        exercises.Add("X86.AvxVnni", X86AvxVnni);
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_AVX512
+        exercises.Add("X86.Avx512F", X86Avx512F);
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_AVX512
+        exercises.Add("X86.Avx512BW", X86Avx512BW);
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_AVX512
+        exercises.Add("X86.Avx512CD", X86Avx512CD);
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_AVX512
+        exercises.Add("X86.Avx512DQ", X86Avx512DQ);
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_AVX10
+        exercises.Add("X86.Avx512Vbmi", X86Avx512Vbmi);
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_AVX10
+        exercises.Add("X86.Avx512Vbmi2", X86Avx512Vbmi2);
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_AVX10
+        exercises.Add("X86.Avx10v1", X86Avx10v1);
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_AVX10
+        exercises.Add("X86.Avx10v2", X86Avx10v2);
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_AVX10
+        exercises.Add("X86.AvxVnniInt8", X86AvxVnniInt8);
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_AVX10
+        exercises.Add("X86.AvxVnniInt16", X86AvxVnniInt16);
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_AVX10
+        exercises.Add("X86.Gfni", X86Gfni);
+#endif
     }
 
     internal static void RegisterArm(Dictionary<string, Action> exercises)
     {
-        exercises["Arm.AdvSimd"] = ArmAdvSimd;
-        exercises["Arm.Aes"] = ArmAes;
-        exercises["Arm.Sha1"] = ArmSha1;
-        exercises["Arm.Sha256"] = ArmSha256;
-        exercises["Arm.Dp"] = ArmDp;
-        exercises["Arm.Rdm"] = ArmRdm;
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_ARM
+        exercises.Add("Arm.AdvSimd", ArmAdvSimd);
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_ARM
+        exercises.Add("Arm.Aes", ArmAes);
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_ARM
+        exercises.Add("Arm.Sha1", ArmSha1);
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_ARM
+        exercises.Add("Arm.Sha256", ArmSha256);
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_ARM
+        exercises.Add("Arm.Dp", ArmDp);
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_ARM
+        exercises.Add("Arm.Rdm", ArmRdm);
+#endif
     }
 
     internal static void RegisterWasm(Dictionary<string, Action> exercises)
     {
-        exercises["Wasm.PackedSimd"] = WasmPackedSimd;
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_WASM
+        exercises.Add("Wasm.PackedSimd", WasmPackedSimd);
+#endif
     }
 
     private static unsafe void ArmAdvSimd()
@@ -31217,82 +31277,118 @@ internal static class Exercises
 
     internal static unsafe void RegisterInvalidImmediates(Dictionary<string, Action> exercises)
     {
-        exercises["Arm.AdvSimd"] = () =>
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_ARM
+        exercises.Add("Arm.AdvSimd", () =>
         {
             Console.WriteLine("DuplicateSelectedScalarToVector128(v128f32,u8) imm=4=" + Fmt.Thrown(() => { _ = Arm.AdvSimd.DuplicateSelectedScalarToVector128(Vector128.Create(4.0f, 3.0f, 2.0f, 1.0f), Fmt.NonConstant((byte)4)); }));
-        };
-        exercises["Arm.AdvSimd.Arm64"] = () =>
+        });
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_ARM
+        exercises.Add("Arm.AdvSimd.Arm64", () =>
         {
             Console.WriteLine("Arm64.DuplicateSelectedScalarToVector128(v128f64,u8) imm=2=" + Fmt.Thrown(() => { _ = Arm.AdvSimd.Arm64.DuplicateSelectedScalarToVector128(Vector128.Create(2.0, 1.5), Fmt.NonConstant((byte)2)); }));
-        };
-        exercises["Arm.Dp"] = () =>
+        });
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_ARM
+        exercises.Add("Arm.Dp", () =>
         {
             Console.WriteLine("DotProductBySelectedQuadruplet(v128i32,v128i8,v128i8,u8) imm=4=" + Fmt.Thrown(() => { _ = Arm.Dp.DotProductBySelectedQuadruplet(Vector128.Create(4604796, 9337503, 14070210, 18802917), Vector128.Create((sbyte)65, (sbyte)102, (sbyte)-117, (sbyte)-80, (sbyte)-43, (sbyte)-6, (sbyte)31, (sbyte)68, (sbyte)105, (sbyte)-114, (sbyte)-77, (sbyte)-40, (sbyte)-3, (sbyte)34, (sbyte)71, (sbyte)108), Vector128.Create((sbyte)94, (sbyte)-125, (sbyte)-88, (sbyte)-51, (sbyte)-14, (sbyte)23, (sbyte)60, (sbyte)97, (sbyte)-122, (sbyte)-85, (sbyte)-48, (sbyte)-11, (sbyte)26, (sbyte)63, (sbyte)100, (sbyte)-119), Fmt.NonConstant((byte)4)); }));
-        };
-        exercises["Arm.Rdm"] = () =>
+        });
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_ARM
+        exercises.Add("Arm.Rdm", () =>
         {
             Console.WriteLine("MultiplyRoundedDoublingBySelectedScalarAndAddSaturateHigh(v128i16,v128i16,v128i16,u8) imm=8=" + Fmt.Thrown(() => { _ = Arm.Rdm.MultiplyRoundedDoublingBySelectedScalarAndAddSaturateHigh(Vector128.Create((short)17964, (short)-29109, (short)-10646, (short)7817, (short)26280, (short)-20793, (short)-2330, (short)16133), Vector128.Create((short)32435, (short)-14638, (short)3825, (short)22288, (short)-24785, (short)-6322, (short)12141, (short)30604), Vector128.Create((short)-18630, (short)-167, (short)18296, (short)-28777, (short)-10314, (short)8149, (short)26612, (short)-20461), Fmt.NonConstant((byte)8)); }));
-        };
-        exercises["Arm.Rdm.Arm64"] = () =>
+        });
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_ARM
+        exercises.Add("Arm.Rdm.Arm64", () =>
         {
             Console.WriteLine("Arm64.MultiplyRoundedDoublingScalarBySelectedScalarAndAddSaturateHigh(v64i16,v64i16,v128i16,u8) imm=8=" + Fmt.Thrown(() => { _ = Arm.Rdm.Arm64.MultiplyRoundedDoublingScalarBySelectedScalarAndAddSaturateHigh(Vector64.Create((short)17964, (short)-29109, (short)-10646, (short)7817), Vector64.Create((short)32435, (short)-14638, (short)3825, (short)22288), Vector128.Create((short)-18630, (short)-167, (short)18296, (short)-28777, (short)-10314, (short)8149, (short)26612, (short)-20461), Fmt.NonConstant((byte)8)); }));
-        };
-        exercises["Wasm.PackedSimd"] = () =>
+        });
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_WASM
+        exercises.Add("Wasm.PackedSimd", () =>
         {
             var a0 = Vector128.Create(4.0f, 3.0f, 2.0f, 1.0f);
             Console.WriteLine("ExtractScalar(v128f32,u8) imm=4=" + Fmt.Thrown(() => { _ = Wasm.PackedSimd.ExtractScalar(a0, Fmt.NonConstant((byte)4)); }));
-        };
-        exercises["X86.Avx"] = () =>
+        });
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_AVX
+        exercises.Add("X86.Avx", () =>
         {
             Console.WriteLine("Compare(v128f32,v128f32,u8) imm=32=" + Fmt.Thrown(() => { _ = X86.Avx.Compare(Vector128.Create(4.0f, 3.0f, 2.0f, 1.0f), Vector128.Create(1.0f, 0.0f, -1.0f, -2.0f), Fmt.NonConstant((System.Runtime.Intrinsics.X86.FloatComparisonMode)(byte)32)); }));
-        };
-        exercises["X86.Avx2"] = () =>
+        });
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_AVX
+        exercises.Add("X86.Avx2", () =>
         {
             byte* raw1 = stackalloc byte[128];
             byte* p1 = Fmt.Align(raw1, 64);
             Fmt.Fill(p1, 64, 2);
             Console.WriteLine("GatherMaskVector128(v128f32,pf32,v128i32,v128f32,u8) imm=9=" + Fmt.Thrown(() => { _ = X86.Avx2.GatherMaskVector128(Vector128.Create(4.0f, 3.0f, 2.0f, 1.0f), (float*)p1, Vector128.Create(4, 1, 3, 0), Vector128.Create(-5.0f, 4.25f, 3.25f, 2.25f), Fmt.NonConstant((byte)9)); }));
-        };
-        exercises["X86.Avx512F"] = () =>
+        });
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_AVX512
+        exercises.Add("X86.Avx512F", () =>
         {
             Console.WriteLine("Add(v512f32,v512f32,u8) imm=12=" + Fmt.Thrown(() => { _ = X86.Avx512F.Add(Vector512.Create(4.0f, 3.0f, 2.0f, 1.0f, 0.0f, -1.0f, -2.0f, -3.0f, -4.0f, -5.0f, 4.25f, 3.25f, 2.25f, 1.25f, 0.25f, -0.75f), Vector512.Create(1.0f, 0.0f, -1.0f, -2.0f, -3.0f, -4.0f, -5.0f, 4.25f, 3.25f, 2.25f, 1.25f, 0.25f, -0.75f, -1.75f, -2.75f, -3.75f), Fmt.NonConstant((System.Runtime.Intrinsics.X86.FloatRoundingMode)(byte)12)); }));
-        };
-        exercises["X86.Avx512F.VL"] = () =>
+        });
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_AVX512
+        exercises.Add("X86.Avx512F.VL", () =>
         {
             Console.WriteLine("VL.Compare(v128f32,v128f32,u8) imm=32=" + Fmt.Thrown(() => { _ = X86.Avx512F.VL.Compare(Vector128.Create(4.0f, 3.0f, 2.0f, 1.0f), Vector128.Create(1.0f, 0.0f, -1.0f, -2.0f), Fmt.NonConstant((System.Runtime.Intrinsics.X86.FloatComparisonMode)(byte)32)); }));
-        };
-        exercises["X86.Avx512F.X64"] = () =>
+        });
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_AVX512
+        exercises.Add("X86.Avx512F.X64", () =>
         {
             Console.WriteLine("X64.ConvertScalarToVector128Double(v128f64,i64,u8) imm=12=" + Fmt.Thrown(() => { _ = X86.Avx512F.X64.ConvertScalarToVector128Double(Vector128.Create(2.0, 1.5), 8718138975195L, Fmt.NonConstant((System.Runtime.Intrinsics.X86.FloatRoundingMode)(byte)12)); }));
-        };
-        exercises["X86.Avx512DQ"] = () =>
+        });
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_AVX512
+        exercises.Add("X86.Avx512DQ", () =>
         {
             Console.WriteLine("ConvertToVector256Single(v512i64,u8) imm=12=" + Fmt.Thrown(() => { _ = X86.Avx512DQ.ConvertToVector256Single(Vector512.Create(4828507740108L, 9791140695219L, 14753773650330L, 19716406605441L, 24679039560552L, 29641672515663L, 34604305470774L, 39566938425885L), Fmt.NonConstant((System.Runtime.Intrinsics.X86.FloatRoundingMode)(byte)12)); }));
-        };
-        exercises["X86.Avx512DQ.VL"] = () =>
+        });
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_AVX512
+        exercises.Add("X86.Avx512DQ.VL", () =>
         {
             Console.WriteLine("VL.Range(v128f32,v128f32,u8) imm=16=" + Fmt.Thrown(() => { _ = X86.Avx512DQ.VL.Range(Vector128.Create(4.0f, 3.0f, 2.0f, 1.0f), Vector128.Create(1.0f, 0.0f, -1.0f, -2.0f), Fmt.NonConstant((byte)16)); }));
-        };
-        exercises["X86.Avx10v1"] = () =>
+        });
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_AVX10
+        exercises.Add("X86.Avx10v1", () =>
         {
             Console.WriteLine("AddScalar(v128f32,v128f32,u8) imm=12=" + Fmt.Thrown(() => { _ = X86.Avx10v1.AddScalar(Vector128.Create(4.0f, 3.0f, 2.0f, 1.0f), Vector128.Create(1.0f, 0.0f, -1.0f, -2.0f), Fmt.NonConstant((System.Runtime.Intrinsics.X86.FloatRoundingMode)(byte)12)); }));
-        };
-        exercises["X86.Avx10v1.V512"] = () =>
+        });
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_AVX10
+        exercises.Add("X86.Avx10v1.V512", () =>
         {
             Console.WriteLine("V512.ConvertToVector256Single(v512i64,u8) imm=12=" + Fmt.Thrown(() => { _ = X86.Avx10v1.V512.ConvertToVector256Single(Vector512.Create(4828507740108L, 9791140695219L, 14753773650330L, 19716406605441L, 24679039560552L, 29641672515663L, 34604305470774L, 39566938425885L), Fmt.NonConstant((System.Runtime.Intrinsics.X86.FloatRoundingMode)(byte)12)); }));
-        };
-        exercises["X86.Avx10v1.X64"] = () =>
+        });
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_AVX10
+        exercises.Add("X86.Avx10v1.X64", () =>
         {
             Console.WriteLine("X64.ConvertScalarToVector128Double(v128f64,i64,u8) imm=12=" + Fmt.Thrown(() => { _ = X86.Avx10v1.X64.ConvertScalarToVector128Double(Vector128.Create(2.0, 1.5), 8718138975195L, Fmt.NonConstant((System.Runtime.Intrinsics.X86.FloatRoundingMode)(byte)12)); }));
-        };
-        exercises["X86.Avx10v2"] = () =>
+        });
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_AVX10
+        exercises.Add("X86.Avx10v2", () =>
         {
             Console.WriteLine("MinMax(v128f32,v128f32,u8) imm=32=" + Fmt.Thrown(() => { _ = X86.Avx10v2.MinMax(Vector128.Create(4.0f, 3.0f, 2.0f, 1.0f), Vector128.Create(1.0f, 0.0f, -1.0f, -2.0f), Fmt.NonConstant((byte)32)); }));
-        };
-        exercises["X86.Avx10v2.V512"] = () =>
+        });
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_AVX10
+        exercises.Add("X86.Avx10v2.V512", () =>
         {
             Console.WriteLine("V512.ConvertToByteWithSaturationAndZeroExtendToInt32(v512f32,u8) imm=12=" + Fmt.Thrown(() => { _ = X86.Avx10v2.V512.ConvertToByteWithSaturationAndZeroExtendToInt32(Vector512.Create(4.0f, 3.0f, 2.0f, 1.0f, 0.0f, -1.0f, -2.0f, -3.0f, -4.0f, -5.0f, 4.25f, 3.25f, 2.25f, 1.25f, 0.25f, -0.75f), Fmt.NonConstant((System.Runtime.Intrinsics.X86.FloatRoundingMode)(byte)12)); }));
-        };
+        });
+#endif
     }
 
 }

--- a/samples/dotnet/PlatformIsaProbe/PlatformIsaProbe.csproj
+++ b/samples/dotnet/PlatformIsaProbe/PlatformIsaProbe.csproj
@@ -12,6 +12,40 @@
          signed ShiftRightLogicalRoundedNarrowingSaturateLower overloads [Obsolete]
          (SYSLIB0055) in this CoreLib; the contract covers them anyway. -->
     <NoWarn>SYSLIB5003;SYSLIB5004;SYSLIB0055</NoWarn>
+    <PlatformIsaShard Condition="'$(PlatformIsaShard)' == ''">all</PlatformIsaShard>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(PlatformIsaShard)' == 'all'">
+    <DefineConstants>$(DefineConstants);PLATFORM_ISA_SHARD_ALL</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(PlatformIsaShard)' == 'x86-base'">
+    <DefineConstants>$(DefineConstants);PLATFORM_ISA_SHARD_X86_BASE</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(PlatformIsaShard)' == 'x86-avx'">
+    <DefineConstants>$(DefineConstants);PLATFORM_ISA_SHARD_X86_AVX</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(PlatformIsaShard)' == 'x86-avx512'">
+    <DefineConstants>$(DefineConstants);PLATFORM_ISA_SHARD_X86_AVX512</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(PlatformIsaShard)' == 'x86-avx10'">
+    <DefineConstants>$(DefineConstants);PLATFORM_ISA_SHARD_X86_AVX10</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(PlatformIsaShard)' == 'arm'">
+    <DefineConstants>$(DefineConstants);PLATFORM_ISA_SHARD_ARM</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(PlatformIsaShard)' == 'wasm'">
+    <DefineConstants>$(DefineConstants);PLATFORM_ISA_SHARD_WASM</DefineConstants>
+  </PropertyGroup>
+
+  <Target Name="ValidatePlatformIsaShard" BeforeTargets="CoreCompile">
+    <Error Condition="'$(PlatformIsaShard)' != 'all' and
+                      '$(PlatformIsaShard)' != 'x86-base' and
+                      '$(PlatformIsaShard)' != 'x86-avx' and
+                      '$(PlatformIsaShard)' != 'x86-avx512' and
+                      '$(PlatformIsaShard)' != 'x86-avx10' and
+                      '$(PlatformIsaShard)' != 'arm' and
+                      '$(PlatformIsaShard)' != 'wasm'"
+           Text="Unknown PlatformIsaShard '$(PlatformIsaShard)'." />
+  </Target>
 
 </Project>

--- a/samples/dotnet/PlatformIsaProbe/Program.cs
+++ b/samples/dotnet/PlatformIsaProbe/Program.cs
@@ -9,7 +9,8 @@ namespace PlatformIsaProbe;
 
 // The platform-ISA capability contract, diffed against real .NET.
 //
-//   PlatformIsaProbe [selection] [--invalid-immediates]
+//   PlatformIsaProbe [selection] [--contract-only|--invalid-immediates]
+//   PlatformIsaProbe --dump-plan
 //
 // selection: comma-separated contract row names (X86.Lzcnt.X64), an arch name
 // (X86 / Arm / Wasm) for every row of that arch, `all`, or absent (= all).
@@ -71,6 +72,7 @@ internal static class Program
     // types in ordinal order. This order IS the contract table's order.
     private static readonly Family[] Table =
     {
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_BASE
         new("X86", "X86Base", () => X86.X86Base.IsSupported, X86Sections.ProbeX86Base,
             ("X64", () => X86.X86Base.X64.IsSupported)),
         new("X86", "Lzcnt", () => X86.Lzcnt.IsSupported, X86Sections.ProbeLzcnt,
@@ -83,6 +85,8 @@ internal static class Program
             ("X64", () => X86.Bmi2.X64.IsSupported)),
         new("X86", "X86Serialize", () => X86.X86Serialize.IsSupported, X86Sections.ProbeX86Serialize,
             ("X64", () => X86.X86Serialize.X64.IsSupported)),
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_ARM
         new("Arm", "ArmBase", () => Arm.ArmBase.IsSupported, ArmSections.ProbeArmBase,
             ("Arm64", () => Arm.ArmBase.Arm64.IsSupported)),
         new("Arm", "Crc32", () => Arm.Crc32.IsSupported, ArmSections.ProbeCrc32,
@@ -99,7 +103,11 @@ internal static class Program
             ("Arm64", () => Arm.Dp.Arm64.IsSupported)),
         new("Arm", "Rdm", () => Arm.Rdm.IsSupported, ArmSections.ProbeRdm,
             ("Arm64", () => Arm.Rdm.Arm64.IsSupported)),
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_WASM
         new("Wasm", "PackedSimd", () => Wasm.PackedSimd.IsSupported, WasmSections.ProbePackedSimd),
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_BASE
         new("X86", "Sse", () => X86.Sse.IsSupported, X86Sections.ProbeSse,
             ("X64", () => X86.Sse.X64.IsSupported)),
         new("X86", "Sse2", () => X86.Sse2.IsSupported, X86Sections.ProbeSse2,
@@ -118,6 +126,8 @@ internal static class Program
             ("X64", () => X86.Pclmulqdq.X64.IsSupported)),
         new("X86", "Aes", () => X86.Aes.IsSupported, X86Sections.ProbeAes,
             ("X64", () => X86.Aes.X64.IsSupported)),
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_AVX
         new("X86", "Avx", () => X86.Avx.IsSupported, X86Sections.ProbeAvx,
             ("X64", () => X86.Avx.X64.IsSupported)),
         new("X86", "Avx2", () => X86.Avx2.IsSupported, X86Sections.ProbeAvx2,
@@ -126,6 +136,8 @@ internal static class Program
             ("X64", () => X86.Fma.X64.IsSupported)),
         new("X86", "AvxVnni", () => X86.AvxVnni.IsSupported, X86Sections.ProbeAvxVnni,
             ("X64", () => X86.AvxVnni.X64.IsSupported)),
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_AVX512
         new("X86", "Avx512F", () => X86.Avx512F.IsSupported, X86Sections.ProbeAvx512F,
             ("VL", () => X86.Avx512F.VL.IsSupported),
             ("X64", () => X86.Avx512F.X64.IsSupported)),
@@ -138,6 +150,8 @@ internal static class Program
         new("X86", "Avx512DQ", () => X86.Avx512DQ.IsSupported, X86Sections.ProbeAvx512DQ,
             ("VL", () => X86.Avx512DQ.VL.IsSupported),
             ("X64", () => X86.Avx512DQ.X64.IsSupported)),
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_AVX10
         new("X86", "Avx512Vbmi", () => X86.Avx512Vbmi.IsSupported, X86Sections.ProbeAvx512Vbmi,
             ("VL", () => X86.Avx512Vbmi.VL.IsSupported),
             ("X64", () => X86.Avx512Vbmi.X64.IsSupported)),
@@ -162,10 +176,13 @@ internal static class Program
             ("V256", () => X86.Gfni.V256.IsSupported),
             ("V512", () => X86.Gfni.V512.IsSupported),
             ("X64", () => X86.Gfni.X64.IsSupported)),
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_ARM
         new("Arm", "Sve", () => Arm.Sve.IsSupported, ArmSections.ProbeSve,
             ("Arm64", () => Arm.Sve.Arm64.IsSupported)),
         new("Arm", "Sve2", () => Arm.Sve2.IsSupported, ArmSections.ProbeSve2,
             ("Arm64", () => Arm.Sve2.Arm64.IsSupported)),
+#endif
     };
 
     // Exercise hook, keyed by top-level row name (X86.Lzcnt). A supported family
@@ -188,7 +205,8 @@ internal static class Program
         CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
 
         bool invalidImmediates = args.Length == 2 && args[1] == "--invalid-immediates";
-        if (args.Length > 1 && !invalidImmediates)
+        bool contractOnly = args.Length == 2 && args[1] == "--contract-only";
+        if (args.Length > 1 && !invalidImmediates && !contractOnly)
         {
             Console.Error.WriteLine("PlatformIsaProbe: unknown option");
             return 2;
@@ -198,6 +216,27 @@ internal static class Program
         ArmSections.RegisterExercises(Exercises);
         WasmSections.RegisterExercises(Exercises);
         global::PlatformIsaProbe.Exercises.RegisterInvalidImmediates(InvalidImmediates);
+
+        if (args.Length == 1 && args[0] == "--dump-plan")
+        {
+            foreach (Family family in Table)
+            {
+                Console.WriteLine("row=" + family.RowName);
+                foreach ((string name, Func<bool> _) in family.Nested)
+                {
+                    Console.WriteLine("row=" + family.RowName + "." + name);
+                }
+            }
+            foreach (string name in Exercises.Keys)
+            {
+                Console.WriteLine("exercise=" + name);
+            }
+            foreach (string name in InvalidImmediates.Keys)
+            {
+                Console.WriteLine("invalid=" + name);
+            }
+            return 0;
+        }
 
         string selection = args.Length > 0 ? args[0] : "all";
         List<Row> rows = Select(selection);
@@ -241,7 +280,7 @@ internal static class Program
             Console.WriteLine("== " + family.RowName + " ==");
             if (family.IsSupported())
             {
-                if (Exercises.TryGetValue(family.RowName, out Action exercise))
+                if (!contractOnly && Exercises.TryGetValue(family.RowName, out Action exercise))
                 {
                     exercise();
                 }

--- a/samples/dotnet/PlatformIsaProbe/WasmSections.cs
+++ b/samples/dotnet/PlatformIsaProbe/WasmSections.cs
@@ -11,7 +11,9 @@ internal static class WasmSections
     // The PackedSimd exercise is generated (Exercises.g.cs) once the family is Lowered.
     internal static void RegisterExercises(Dictionary<string, Action> exercises)
     {
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_WASM
         Exercises.RegisterWasm(exercises);
+#endif
     }
 
     internal static void ProbePackedSimd() { _ = PackedSimd.Add(Vector128<int>.Zero, Vector128<int>.Zero); }

--- a/samples/dotnet/PlatformIsaProbe/X86Sections.cs
+++ b/samples/dotnet/PlatformIsaProbe/X86Sections.cs
@@ -18,22 +18,28 @@ internal static class X86Sections
         Dictionary<string, Action> exercises,
         Dictionary<string, Action> nestedProbes)
     {
-        exercises["X86.X86Base"] = X86BaseExercise;
-        exercises["X86.Lzcnt"] = LzcntExercise;
-        exercises["X86.Popcnt"] = PopcntExercise;
-        exercises["X86.Bmi1"] = Bmi1Exercise;
-        exercises["X86.Bmi2"] = Bmi2Exercise;
-        exercises["X86.X86Serialize"] = X86SerializeExercise;
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_BASE
+        exercises.Add("X86.X86Base", X86BaseExercise);
+        exercises.Add("X86.Lzcnt", LzcntExercise);
+        exercises.Add("X86.Popcnt", PopcntExercise);
+        exercises.Add("X86.Bmi1", Bmi1Exercise);
+        exercises.Add("X86.Bmi2", Bmi2Exercise);
+        exercises.Add("X86.X86Serialize", X86SerializeExercise);
+#endif
         Exercises.RegisterX86(exercises);
-        nestedProbes["X86.Avx10v2.V512"] = ProbeAvx10v2V512;
-        nestedProbes["X86.AvxVnniInt8.V512"] = ProbeAvxVnniInt8V512;
-        nestedProbes["X86.AvxVnniInt16.V512"] = ProbeAvxVnniInt16V512;
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_AVX10
+        nestedProbes.Add("X86.Avx10v2.V512", ProbeAvx10v2V512);
+        nestedProbes.Add("X86.AvxVnniInt8.V512", ProbeAvxVnniInt8V512);
+        nestedProbes.Add("X86.AvxVnniInt16.V512", ProbeAvxVnniInt16V512);
+#endif
+#if PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_AVX
         Action avxExercise = exercises["X86.Avx"];
         exercises["X86.Avx"] = () =>
         {
             avxExercise();
             AvxCompareScalarTrueModesExercise();
         };
+#endif
     }
 
     internal static void ProbeX86Base()

--- a/tools/gen-isa-map/gen-isa-map.cs
+++ b/tools/gen-isa-map/gen-isa-map.cs
@@ -1922,7 +1922,11 @@ static class Exercises
         {
             sb.Append($"    internal static void Register{Contract.IsaArch(arch)}(Dictionary<string, Action> exercises)\n    {{\n");
             foreach (var f in tops.Where(f => f.Arch == arch))
-                sb.Append($"        exercises[\"{Contract.Display(f.QualifiedName)}\"] = {MethodName(f)};\n");
+            {
+                sb.Append("#if ").Append(ShardCondition(f.QualifiedName)).Append('\n');
+                sb.Append($"        exercises.Add(\"{Contract.Display(f.QualifiedName)}\", {MethodName(f)});\n");
+                sb.Append("#endif\n");
+            }
             sb.Append("    }\n\n");
         }
         foreach (var f in tops)
@@ -1935,11 +1939,13 @@ static class Exercises
         sb.Append("    internal static unsafe void RegisterInvalidImmediates(Dictionary<string, Action> exercises)\n    {\n");
         foreach (var witness in invalidImmediateWitnesses)
         {
-            sb.Append($"        exercises[\"{witness.Row}\"] = () =>\n        {{\n");
+            sb.Append("#if ").Append(ShardCondition(witness.Row)).Append('\n');
+            sb.Append($"        exercises.Add(\"{witness.Row}\", () =>\n        {{\n");
             foreach (string line in witness.Setup.Split('\n', StringSplitOptions.RemoveEmptyEntries))
                 sb.Append("            ").Append(line.TrimStart()).Append('\n');
             sb.Append($"            Console.WriteLine(\"{witness.Label} imm={witness.Past}=\" + Fmt.Thrown(() => {{ {witness.Statement} }}));\n");
-            sb.Append("        };\n");
+            sb.Append("        });\n");
+            sb.Append("#endif\n");
         }
         sb.Append("    }\n\n");
         sb.Append("}\n");
@@ -1947,6 +1953,36 @@ static class Exercises
     }
 
     static string MethodName(Family f) => Contract.IsaArch(f.Arch) + f.TypePath.Replace("+", "");
+
+    static string ShardCondition(string qualifiedName)
+    {
+        string display = qualifiedName.StartsWith(Contract.IntrinsicsPrefix, StringComparison.Ordinal)
+            ? Contract.Display(qualifiedName)
+            : qualifiedName;
+        display = display.Replace('+', '.');
+        if (display.StartsWith("Arm.", StringComparison.Ordinal))
+            return "PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_ARM";
+        if (display.StartsWith("Wasm.", StringComparison.Ordinal))
+            return "PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_WASM";
+
+        string family = display.Split('.')[1];
+        return family switch
+        {
+            "X86Base" or "Lzcnt" or "Popcnt" or "Bmi1" or "Bmi2" or
+            "X86Serialize" or "Sse" or "Sse2" or "Sse3" or "Ssse3" or
+            "Sse41" or "Sse42" or "Pclmulqdq" or "Aes" =>
+                "PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_BASE",
+            "Avx" or "Avx2" or "Fma" or "AvxVnni" =>
+                "PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_AVX",
+            "Avx512F" or "Avx512BW" or "Avx512CD" or "Avx512DQ" =>
+                "PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_AVX512",
+            "Avx512Vbmi" or "Avx512Vbmi2" or "Avx10v1" or "Avx10v2" or
+            "AvxVnniInt8" or "AvxVnniInt16" or "Gfni" =>
+                "PLATFORM_ISA_SHARD_ALL || PLATFORM_ISA_SHARD_X86_AVX10",
+            _ => throw new InvalidOperationException(
+                $"X86 family '{family}' has no platform-ISA reachability shard"),
+        };
+    }
 
     static string CsFamily(Family f) => Contract.IsaArch(f.Arch) + "." + f.TypePath.Replace('+', '.');
 


### PR DESCRIPTION
## Summary

- split the native platform-ISA probe into five compile-time reachability shards
- prove every table row, exhaustive exercise, and invalid-immediate witness is assigned exactly once
- compare each native shard with the identically built .NET oracle and keep capability-only runs lightweight
- remove the Windows-only single-row execution and JOBS=1 workarounds

The previous mitigation only reduced the number of rows handled by each process. Every process still loaded the same wide generated image, while that image retained all ISA helpers and hundreds of immediate-dispatch switches. This change bounds the compiler input and native image themselves, independently of the host OS.

## Verification

- dotnet build src/Dn2Cpp.Cli -c Release
- gates/build-and-run-platform-isa-native.sh (Release)
- CONFIG=Debug gates/build-and-run-platform-isa-native.sh
- gates/build-and-run-platform-isa-surface.sh
- gates/build-and-run-platform-isa-includes.sh
- gates/build-and-run-doc-claims.sh
- generated ISA map check