### PR TITLE
Barrier Array.Resize ref write-backs

### DIFF
--- a/gates/build-and-run-weak-references.sh
+++ b/gates/build-and-run-weak-references.sh
@@ -12,8 +12,9 @@
 # collector, and real .NET's JIT-driven liveness, can both retain any one
 # specific referent indefinitely via incidental register/stack copies).
 # IncrementalWriteBarrier mutates old holders through field, array, byref,
-# reference-containing struct, bulk-copy, Interlocked and Volatile stores while
-# allocation advances collection cycles; both GC modes run from one native image.
+# reference-containing struct, bulk-copy, Interlocked, Volatile and Array.Resize
+# stores while allocation advances collection cycles; both GC modes run from one
+# native image.
 # It also drives Array.Fill of a reference element and the only proven-same-element
 # Array.Copy of a reference-bearing struct array in the corpus — the two inline
 # fast paths that bypass the barriered runtime helpers. InternBarrier covers
@@ -41,6 +42,17 @@ do
     fi
 done
 
+resize_barriers=$(awk '
+    /\/\/ IncrementalWriteBarrierSubset\.Program::Resize/ { in_method = 1; next }
+    in_method && /^\/\/ / { in_method = 0 }
+    in_method && /dn2cpp_gc_write_barrier_if_heap/ { count++ }
+    END { print count + 0 }
+' "$out/generated.h" "$out"/generated*.cpp)
+if [ "$resize_barriers" -ne 1 ]; then
+    echo "FAIL: Array.Resize ref write-back emitted $resize_barriers heap barriers, expected 1" >&2
+    exit 1
+fi
+
 pending_barriers=$(awk '
     /\/\/ PendingCallArgumentSubset\.Program::__GateEntry/ { in_method = 1; next }
     in_method && /^\/\/ / { in_method = 0 }
@@ -52,7 +64,7 @@ if [ "$pending_barriers" -ne 1 ]; then
     exit 1
 fi
 
-ctx="weak_references|$_CG_CORELIB|runs:DN2CPP_GC_INCREMENTAL=0+1|DN2CPP_GC_STATS=1|assert:mode+diff+exit+generated-barriers+memmove-refs+pending-web-liveness"
+ctx="weak_references|$_CG_CORELIB|runs:DN2CPP_GC_INCREMENTAL=0+1|DN2CPP_GC_STATS=1|assert:mode+diff+exit+generated-barriers+resize-ref+memmove-refs+pending-web-liveness"
 ctx="$ctx$(_gate_ctx_extras)"
 if _corelib_gate_check "$out" "$ctx"; then
     gate_cache_hit_msg
@@ -112,6 +124,10 @@ if ! grep -qF '[dn2cpp] GC mode: incremental' "$log_dir/incremental.log"; then
 fi
 if [ "$(grep -cF 'incremental write barriers:' <<<"$incremental")" -ne 1 ]; then
     echo "FAIL: incremental write-barrier section did not run exactly once" >&2
+    exit 1
+fi
+if [ "$(grep -cF 'Array.Resize field barrier:' <<<"$incremental")" -ne 1 ]; then
+    echo "FAIL: Array.Resize field-barrier section did not run exactly once" >&2
     exit 1
 fi
 

--- a/gates/build-and-run-weak-references.sh
+++ b/gates/build-and-run-weak-references.sh
@@ -21,6 +21,10 @@
 # string.Intern / IsInterned over a run-time-built string, whose only root is the
 # intern cell. PendingCallArgument keeps a Dictionary/string graph on the IL
 # evaluation stack while the next nested-call argument forces collection.
+# The Array.Resize run is a stress signal, not a deterministic proof of the GC's
+# held window. The exact generated store-before-barrier check below and the
+# deterministic runtime helper probe in build-and-run-gc-write-barrier.sh provide
+# the two deterministic layers.
 # Former gates: none (new area).
 source "$(dirname "$0")/_common.sh"
 
@@ -42,19 +46,35 @@ do
     fi
 done
 
-resize_barriers=$(awk '
-    /\/\/ IncrementalWriteBarrierSubset\.Program::Resize/ { in_method = 1; next }
+resize_shape=$(awk '
+    FNR == 1 { in_method = 0 }
+    $0 == "// IncrementalWriteBarrierSubset.Program::Resize" {
+        in_method = 1
+        methods++
+        saw_store = 0
+        next
+    }
     in_method && /^\/\/ / { in_method = 0 }
-    in_method && /dn2cpp_gc_write_barrier_if_heap/ { count++ }
-    END { print count + 0 }
+    in_method && /^[[:space:]]*\(\*\(Dn2CppArrayRef\*\*\)\([^)]*\)\) =/ {
+        stores++
+        saw_store = 1
+        next
+    }
+    in_method && /dn2cpp_gc_write_barrier_if_heap/ {
+        barriers++
+        if (saw_store)
+            ordered++
+    }
+    END { print methods + 0 ":" stores + 0 ":" barriers + 0 ":" ordered + 0 }
 ' "$out/generated.h" "$out"/generated*.cpp)
-if [ "$resize_barriers" -ne 1 ]; then
-    echo "FAIL: Array.Resize ref write-back emitted $resize_barriers heap barriers, expected 1" >&2
+if [ "$resize_shape" != "1:1:1:1" ]; then
+    echo "FAIL: Array.Resize method/store/barrier/ordered counts were $resize_shape, expected 1:1:1:1" >&2
     exit 1
 fi
 
 pending_barriers=$(awk '
-    /\/\/ PendingCallArgumentSubset\.Program::__GateEntry/ { in_method = 1; next }
+    FNR == 1 { in_method = 0 }
+    $0 == "// PendingCallArgumentSubset.Program::__GateEntry" { in_method = 1; next }
     in_method && /^\/\/ / { in_method = 0 }
     in_method && /DN2CPP_WEB_GC_LIVENESS\(/ { count++ }
     END { print count + 0 }
@@ -126,8 +146,8 @@ if [ "$(grep -cF 'incremental write barriers:' <<<"$incremental")" -ne 1 ]; then
     echo "FAIL: incremental write-barrier section did not run exactly once" >&2
     exit 1
 fi
-if [ "$(grep -cF 'Array.Resize field barrier:' <<<"$incremental")" -ne 1 ]; then
-    echo "FAIL: Array.Resize field-barrier section did not run exactly once" >&2
+if [ "$(grep -cF 'Array.Resize field stress:' <<<"$incremental")" -ne 1 ]; then
+    echo "FAIL: Array.Resize field-stress section did not run exactly once" >&2
     exit 1
 fi
 

--- a/runtime/core/dn2cpp_casts.cpp
+++ b/runtime/core/dn2cpp_casts.cpp
@@ -1417,9 +1417,9 @@ Dn2CppObject* dn2cpp_delegate_remove(Dn2CppObject* source, Dn2CppObject* value)
         return source; // no match further down
     auto* copy = static_cast<Dn2CppDelegate*>(dn2cpp_alloc(sizeof(Dn2CppDelegate)));
     copy->type = s->type;
-    copy->target = s->target;
+    dn2cpp_gc_store_ref(&copy->target, s->target);
     copy->method = s->method;
-    copy->prev = rest;
+    dn2cpp_gc_store_ref(&copy->prev, rest);
     return copy;
 }
 

--- a/runtime/core/dn2cpp_core.h
+++ b/runtime/core/dn2cpp_core.h
@@ -4684,11 +4684,14 @@ inline int32_t dn2cpp_threadpool_queue_value(Dn2CppObject* callback, T state)
     item->type = &dn2cpp_object_type;
     item->callback = callback;
     item->state = state;
+    // T may itself be a managed reference or contain managed references.
+    dn2cpp_gc_write_barrier(item);
     auto* del = static_cast<Dn2CppDelegate*>(dn2cpp_alloc(sizeof(Dn2CppDelegate)));
     del->type = &dn2cpp_object_type;
     del->target = item;
     del->method = reinterpret_cast<void*>(&dn2cpp_threadpool_value_thunk<T>);
     del->prev = nullptr;
+    dn2cpp_gc_write_barrier(del);
     return dn2cpp_threadpool_queue(del, nullptr);
 }
 // ThreadPool.UnsafeQueueUserWorkItem(IThreadPoolWorkItem, bool) — fire-and-forget

--- a/runtime/core/dn2cpp_exceptions.cpp
+++ b/runtime/core/dn2cpp_exceptions.cpp
@@ -634,8 +634,8 @@ Dn2CppObject* dn2cpp_exception_new(const Dn2CppTypeInfo* ti, Dn2CppString* messa
     // ctor body; the finalize registration below still fires for those that reach here.
     if (ti->finalize != nullptr)
         dn2cpp_register_finalizer(e);
-    e->message = message;
-    e->inner = inner;
+    dn2cpp_gc_store_ref(&e->message, message);
+    dn2cpp_gc_store_ref(&e->inner, inner);
     // System.Exception's base ctor default (COR_E_EXCEPTION). A derived ctor that
     // runs (the AOT/interp newobj paths) overwrites this with its per-type value via
     // set_HResult; a runtime-RAISED exception (no ctor body) keeps the base default
@@ -1210,7 +1210,7 @@ Dn2CppStackFrame* dn2cpp_stackframe_new(Dn2CppString* fileName, int32_t line, in
 {
     auto* f = static_cast<Dn2CppStackFrame*>(dn2cpp_alloc(sizeof(Dn2CppStackFrame)));
     f->type = &dn2cpp_stackframe_type;
-    f->fileName = fileName;
+    dn2cpp_gc_store_ref(&f->fileName, fileName);
     f->lineNumber = line;
     f->columnNumber = column;
     f->methodDesc = nullptr; // only a materialized capture (below) fills it
@@ -1286,7 +1286,7 @@ static Dn2CppStackTrace* dn2cpp_stacktrace_wrap(Dn2CppArrayRef* frames, int32_t 
 {
     auto* st = static_cast<Dn2CppStackTrace*>(dn2cpp_alloc(sizeof(Dn2CppStackTrace)));
     st->type = &dn2cpp_stacktrace_type;
-    st->frames = frames;
+    dn2cpp_gc_store_ref(&st->frames, frames);
     st->dropped = dropped;
     return st;
 }
@@ -1401,7 +1401,7 @@ Dn2CppStackTrace* dn2cpp_stacktrace_of_exception(const Dn2CppTypeInfo* frameArrT
 Dn2CppStackTrace* dn2cpp_stacktrace_of_frame(const Dn2CppTypeInfo* frameArrTi, Dn2CppObject* frame)
 {
     Dn2CppArrayRef* frames = dn2cpp_newarr_ref_t(1, frameArrTi);
-    frames->data[0] = frame;
+    dn2cpp_gc_store_ref(&frames->data[0], frame);
     return dn2cpp_stacktrace_wrap(frames, 0);
 }
 
@@ -1506,8 +1506,9 @@ Dn2CppObject* dn2cpp_aggregate_exception_new(Dn2CppArrayRef* inner)
     Dn2CppString* msgStr = dn2cpp_string_from_utf8(msg.c_str(), static_cast<int32_t>(msg.size()));
     auto* e = static_cast<Dn2CppAggregateExceptionObject*>(dn2cpp_alloc(sizeof(Dn2CppAggregateExceptionObject)));
     e->type = &dn2cpp_aggregate_exception_type;
-    e->message = msgStr;
-    e->inner = (inner != nullptr && inner->length > 0) ? inner->data[0] : nullptr;
+    dn2cpp_gc_store_ref(&e->message, msgStr);
+    dn2cpp_gc_store_ref(&e->inner,
+                        (inner != nullptr && inner->length > 0) ? inner->data[0] : nullptr);
     e->hresult = static_cast<int32_t>(0x80131500); // base default; get_HResult reads the shared prefix slot
     // `inner` is whatever its caller allocated, and the four runtime callers
     // (dn2cpp_task_block_wait, Task.WaitAll, dn2cpp_task_exception, the Parallel fault
@@ -1517,7 +1518,7 @@ Dn2CppObject* dn2cpp_aggregate_exception_new(Dn2CppArrayRef* inner)
     // back. Re-tagging at allocation would need a handle the runtime cannot name —
     // dn2cpp_exception_type is the RUNTIME's Exception, not the transpiled CoreLib's.
     // A reader that bypasses the getter is what would make this a defect.
-    e->innerExceptions = inner; // trace stays null (GC alloc zero-fills) until the throw stamps it
+    dn2cpp_gc_store_ref(&e->innerExceptions, inner); // trace stays null (GC alloc zero-fills) until the throw stamps it
     return e;
 }
 

--- a/runtime/core/dn2cpp_gc.cpp
+++ b/runtime/core/dn2cpp_gc.cpp
@@ -2495,8 +2495,7 @@ Dn2CppDependentHandle dn2cpp_dependenthandle_alloc(Dn2CppObject* target, Dn2CppO
 {
     auto* cell = static_cast<Dn2CppDependentCell*>(dn2cpp_alloc(sizeof(Dn2CppDependentCell)));
     cell->targetWeak = dn2cpp_gchandle_internal_alloc(target, 0); // 0 = Weak (short link)
-    cell->dependent = dependent;
-    dn2cpp_gc_write_barrier(cell); // one barrier covers both plain stores above
+    dn2cpp_gc_store_ref(&cell->dependent, dependent);
     return Dn2CppDependentHandle{cell};
 }
 
@@ -2516,6 +2515,7 @@ Dn2CppObject* dn2cpp_dependenthandle_target_and_dependent(Dn2CppDependentHandle 
     // target is still alive (a collected/nulled target yields (null, null)).
     Dn2CppObject* target = dn2cpp_dependenthandle_target(h);
     *dependent = target != nullptr ? h.cell->dependent : nullptr;
+    dn2cpp_gc_write_barrier_if_heap(dependent);
     return target;
 }
 

--- a/runtime/core/dn2cpp_interp.cpp
+++ b/runtime/core/dn2cpp_interp.cpp
@@ -3577,7 +3577,8 @@ ExecResult interp_run(InterpFrame& f, uint32_t pc)
                                     const void* thunk = find_dg_thunk(dti);
                                     if (thunk == nullptr)
                                         interp_fail("BPI bind: no delegate thunk (Invoke signature outside the bridged surface)");
-                                    dg->target = reinterpret_cast<Dn2CppObject*>(c);
+                                    dn2cpp_gc_store_ref(
+                                        &dg->target, reinterpret_cast<Dn2CppObject*>(c));
                                     dg->method = const_cast<void*>(thunk);
                                 }
                                 else
@@ -3609,7 +3610,8 @@ ExecResult interp_run(InterpFrame& f, uint32_t pc)
                                     // caller never set.
                                     if (!dg_aot_signature_ok(c, dti))
                                         interp_fail(kDgSigFail);
-                                    dg->target = static_cast<Dn2CppObject*>(targetSlot.ref);
+                                    dn2cpp_gc_store_ref(
+                                        &dg->target, static_cast<Dn2CppObject*>(targetSlot.ref));
                                     dg->method = c->aotFn;
                                 }
                                 Slot v{};
@@ -4794,7 +4796,8 @@ ExecResult interp_run_reg(InterpFrame& f, uint32_t pc)
                                     const void* thunk = find_dg_thunk(dti);
                                     if (thunk == nullptr)
                                         interp_fail("BPI bind: no delegate thunk (Invoke signature outside the bridged surface)");
-                                    dg->target = reinterpret_cast<Dn2CppObject*>(c);
+                                    dn2cpp_gc_store_ref(
+                                        &dg->target, reinterpret_cast<Dn2CppObject*>(c));
                                     dg->method = const_cast<void*>(thunk);
                                 }
                                 else
@@ -4821,7 +4824,8 @@ ExecResult interp_run_reg(InterpFrame& f, uint32_t pc)
                                     // caller never set.
                                     if (!dg_aot_signature_ok(c, dti))
                                         interp_fail(kDgSigFail);
-                                    dg->target = static_cast<Dn2CppObject*>(targetSlot.ref);
+                                    dn2cpp_gc_store_ref(
+                                        &dg->target, static_cast<Dn2CppObject*>(targetSlot.ref));
                                     dg->method = c->aotFn;
                                 }
                                 regs[r0].ref = dg;

--- a/runtime/core/dn2cpp_marshal.cpp
+++ b/runtime/core/dn2cpp_marshal.cpp
@@ -975,8 +975,8 @@ void** dn2cpp_pinvoke_ptrarr_dup(void** buf, int32_t n)
         return nullptr;
     void** copy = static_cast<void**>(
         dn2cpp_alloc(static_cast<size_t>(n > 0 ? n : 1) * sizeof(void*)));
-    for (int32_t i = 0; i < n; i++)
-        copy[i] = buf[i];
+    if (n > 0)
+        dn2cpp_gc_memmove_refs(copy, buf, static_cast<size_t>(n) * sizeof(void*));
     return copy;
 }
 
@@ -1151,4 +1151,3 @@ void* dn2cpp_native_library_get_symbol(void* handle, Dn2CppString* symbolName)
     return ::dlsym(handle, narrow.c_str());
 #endif
 }
-

--- a/runtime/core/dn2cpp_runtime.cpp
+++ b/runtime/core/dn2cpp_runtime.cpp
@@ -347,7 +347,7 @@ Dn2CppObject* dn2cpp_object_memberwise_clone(Dn2CppObject* obj)
             bytes = floor;
     }
     auto* clone = static_cast<Dn2CppObject*>(dn2cpp_alloc(bytes));
-    std::memcpy(clone, obj, bytes);
+    dn2cpp_gc_memmove_refs(clone, obj, bytes);
     // .NET finalizes the CLONE as well as the original — measured on CoreCLR 10.0.9, a
     // clone of a finalizable class runs its finalizer, so a program that clones N
     // objects sees N+1 finalizations. dn2cpp registers at newobj and at the reflective

--- a/runtime/core/dn2cpp_tasks.cpp
+++ b/runtime/core/dn2cpp_tasks.cpp
@@ -103,6 +103,7 @@ Dn2CppTask* dn2cpp_task_from_result(uint64_t result)
     auto* t = dn2cpp_task_alloc();
     t->status.store(DN2CPP_TASK_SUCCEEDED, std::memory_order_relaxed);
     t->result = result;
+    dn2cpp_gc_write_barrier(&t->result);
     return t;
 }
 
@@ -512,6 +513,7 @@ static void dn2cpp_sched_post_to(Dn2CppScheduler* s, void (*fn)(void*), void* st
     auto* c = static_cast<Dn2CppCont*>(dn2cpp_alloc(sizeof(Dn2CppCont)));
     c->fn = fn;
     c->state = state;
+    dn2cpp_gc_write_barrier(&c->state);
     c->owner = s;
     dn2cpp_sched_enqueue(s, c);
 }
@@ -604,6 +606,7 @@ static bool dn2cpp_task_try_queue_cont(Dn2CppTask* t, void (*fn)(void*), void* s
     auto* c = static_cast<Dn2CppCont*>(dn2cpp_alloc(sizeof(Dn2CppCont)));
     c->fn = fn;
     c->state = state;
+    dn2cpp_gc_write_barrier(&c->state);
     c->owner = dn2cpp_sched_self();
     std::lock_guard<std::mutex> lk(g_task_mtx);
     if (t->status != DN2CPP_TASK_PENDING)
@@ -781,7 +784,7 @@ Dn2CppTask* dn2cpp_task_delay(int64_t ms)
     }
     Dn2CppScheduler* s = dn2cpp_sched_self();
     auto* e = static_cast<Dn2CppTimer*>(dn2cpp_alloc(sizeof(Dn2CppTimer)));
-    e->task = t;
+    dn2cpp_gc_store_ref(&e->task, t);
     e->due = s->virtual_now + ms;
     e->seq = s->timer_seq++;
     e->next = nullptr;
@@ -1051,8 +1054,8 @@ Dn2CppTask* dn2cpp_task_when_any(Dn2CppArrayRef* tasks)
     for (int32_t i = 0; i < tasks->length; i++)
     {
         auto* e = static_cast<Dn2CppWhenAnyEntry*>(dn2cpp_alloc(sizeof(Dn2CppWhenAnyEntry)));
-        e->shared = s;
-        e->task = reinterpret_cast<Dn2CppTask*>(tasks->data[i]);
+        dn2cpp_gc_store_ref(&e->shared, s);
+        dn2cpp_gc_store_ref(&e->task, reinterpret_cast<Dn2CppTask*>(tasks->data[i]));
         // Synchronous registration, so a settled input wins the join before this
         // returns; the winner is then the FIRST settled input in array order, as on
         // real .NET. Stop once one has won: a continuation on a still-pending input
@@ -1131,7 +1134,7 @@ Dn2CppArrayRef* dn2cpp_refspan_to_array(Dn2CppObject** data, int32_t len)
 Dn2CppTask* dn2cpp_task_from_exception(Dn2CppObject* exception)
 {
     auto* t = dn2cpp_task_alloc();
-    t->exception = exception;
+    dn2cpp_gc_store_ref(&t->exception, exception);
     t->status.store(DN2CPP_TASK_FAULTED, std::memory_order_relaxed);
     return t;
 }
@@ -2327,7 +2330,7 @@ Dn2CppThread* dn2cpp_thread_new(Dn2CppObject* start)
 {
     auto* t = static_cast<Dn2CppThread*>(dn2cpp_alloc(sizeof(Dn2CppThread)));
     t->type = &dn2cpp_thread_type;
-    t->start = start;
+    dn2cpp_gc_store_ref(&t->start, start);
     t->arg = nullptr;
     t->handle = nullptr;
     t->sync = nullptr;
@@ -2582,9 +2585,9 @@ static void dn2cpp_pool_unlink(Dn2CppPoolNode* node)
 static Dn2CppPoolNode* dn2cpp_pool_node_new(Dn2CppTask* task, Dn2CppObject* del, Dn2CppObject* state)
 {
     auto* node = static_cast<Dn2CppPoolNode*>(dn2cpp_alloc(sizeof(Dn2CppPoolNode)));
-    node->task = task;
-    node->del = del;
-    node->state = state;
+    dn2cpp_gc_store_ref(&node->task, task);
+    dn2cpp_gc_store_ref(&node->del, del);
+    dn2cpp_gc_store_ref(&node->state, state);
     node->next = nullptr;
     return node;
 }
@@ -3208,8 +3211,8 @@ static Dn2CppTask* dn2cpp_task_cold(Dn2CppObject* del, Dn2CppObject* state,
     dn2cpp_task_require_delegate(del, "action");
     Dn2CppTask* t = dn2cpp_task_alloc();
     auto* c = static_cast<Dn2CppTaskCold*>(dn2cpp_alloc(sizeof(Dn2CppTaskCold)));
-    c->del = del;
-    c->state = state;
+    dn2cpp_gc_store_ref(&c->del, del);
+    dn2cpp_gc_store_ref(&c->state, state);
     c->invoke = invoke;
     c->invoke2 = invoke2;
     dn2cpp_gc_store_ref(&t->cold, c);
@@ -3435,10 +3438,10 @@ Dn2CppTask* dn2cpp_task_continue_with(Dn2CppTask* t, Dn2CppObject* del, Dn2CppOb
     // A caller holding the continuation task also keeps its delegate reachable.
     dn2cpp_gc_store_ref(&ct->workerKeepAlive, del);
     auto* c = static_cast<Dn2CppContWith*>(dn2cpp_alloc(sizeof(Dn2CppContWith)));
-    c->antecedent = t;
-    c->task = ct;
-    c->del = del;
-    c->state = state;
+    dn2cpp_gc_store_ref(&c->antecedent, t);
+    dn2cpp_gc_store_ref(&c->task, ct);
+    dn2cpp_gc_store_ref(&c->del, del);
+    dn2cpp_gc_store_ref(&c->state, state);
     c->kind = kind;
     c->options = options;
     c->invokeStruct = nullptr;
@@ -3482,8 +3485,8 @@ Dn2CppTask* dn2cpp_task_wait_async(Dn2CppTask* t, Dn2CppCancelSource* src)
 {
     Dn2CppTask* wt = dn2cpp_task_alloc();
     auto* w = static_cast<Dn2CppWaitAsync*>(dn2cpp_alloc(sizeof(Dn2CppWaitAsync)));
-    w->antecedent = t;
-    w->task = wt;
+    dn2cpp_gc_store_ref(&w->antecedent, t);
+    dn2cpp_gc_store_ref(&w->task, wt);
     // THE ANTECEDENT'S COMPLETION WINS OVER AN ALREADY-REQUESTED TOKEN, and the order of
     // these two blocks is that rule. .NET's WaitAsyncCore tests `IsCompleted` and returns
     // `this` BEFORE it ever looks at the token, so `Task.FromResult(5).WaitAsync(ct)` on an
@@ -3547,9 +3550,9 @@ Dn2CppTask* dn2cpp_task_continue_with_struct(Dn2CppTask* t, Dn2CppObject* del,
     // A caller holding the continuation task also keeps its delegate reachable.
     dn2cpp_gc_store_ref(&ct->workerKeepAlive, del);
     auto* c = static_cast<Dn2CppContWith*>(dn2cpp_alloc(sizeof(Dn2CppContWith)));
-    c->antecedent = t;
-    c->task = ct;
-    c->del = del;
+    dn2cpp_gc_store_ref(&c->antecedent, t);
+    dn2cpp_gc_store_ref(&c->task, ct);
+    dn2cpp_gc_store_ref(&c->del, del);
     c->state = nullptr;
     c->kind = DN2CPP_CONTWITH_STRUCT;
     c->options = options;
@@ -3628,11 +3631,11 @@ int32_t dn2cpp_threadpool_queue_workitem(Dn2CppObject* wi, const void* executeFn
 {
     auto* inv = static_cast<Dn2CppWorkItemInvoker*>(dn2cpp_alloc(sizeof(Dn2CppWorkItemInvoker)));
     inv->header.type = &dn2cpp_workitem_invoker_type;
-    inv->wi = wi;
+    dn2cpp_gc_store_ref(&inv->wi, wi);
     inv->fn = executeFn;
     auto* del = static_cast<Dn2CppDelegate*>(dn2cpp_alloc(sizeof(Dn2CppDelegate)));
     del->type = &dn2cpp_workitem_invoker_type; // opaque header; only {target, method} are read
-    del->target = &inv->header;
+    dn2cpp_gc_store_ref(&del->target, &inv->header);
     del->method = reinterpret_cast<void*>(&dn2cpp_workitem_execute_thunk);
     del->prev = nullptr;
     return dn2cpp_threadpool_queue(del, nullptr);
@@ -3658,7 +3661,7 @@ void dn2cpp_task_throw_async(Dn2CppObject* exc, Dn2CppObject* /*syncCtx*/)
         return;
     auto* del = static_cast<Dn2CppDelegate*>(dn2cpp_alloc(sizeof(Dn2CppDelegate)));
     del->type = &dn2cpp_workitem_invoker_type; // opaque header; only {target, method, prev} read
-    del->target = exc;
+    dn2cpp_gc_store_ref(&del->target, exc);
     del->method = reinterpret_cast<void*>(&dn2cpp_rethrow_thunk);
     del->prev = nullptr;
     dn2cpp_threadpool_queue(del, nullptr);
@@ -3906,7 +3909,7 @@ Dn2CppTask* dn2cpp_vts_task(Dn2CppObject* vts, int16_t version,
     dn2cpp_gc_store_ref(&t->vtsBridge, &b->header);
     auto* del = static_cast<Dn2CppDelegate*>(dn2cpp_alloc(sizeof(Dn2CppDelegate)));
     del->type = actionTi;
-    del->target = &b->header;
+    dn2cpp_gc_store_ref(&del->target, &b->header);
     del->method = reinterpret_cast<void*>(&dn2cpp_vts_continuation);
     del->prev = nullptr;
     // Count the bridge in flight BEFORE registering: OnCompleted may invoke the

--- a/runtime/core/dn2cpp_threading.cpp
+++ b/runtime/core/dn2cpp_threading.cpp
@@ -368,7 +368,7 @@ static void dn2cpp_parallel_run(int64_t count, void* ctx, void (*fn)(void*, int6
         Dn2CppArrayRef* inner = dn2cpp_newarr_ref(excCount);
         int32_t k = 0;
         for (ExcNode* n = excHead; n != nullptr; n = n->next)
-            inner->data[k++] = n->exc;
+            dn2cpp_gc_store_ref(&inner->data[k++], n->exc);
         // Real .NET Parallel.* always wraps in an AggregateException — even a single
         // iteration's exception.
         dn2cpp_throw(dn2cpp_aggregate_exception_new(inner));
@@ -2080,8 +2080,8 @@ static Dn2CppObject* dn2cpp_timer_new_with_type(Dn2CppTypeInfo* type,
     auto* t = static_cast<Dn2CppManagedTimer*>(dn2cpp_alloc(sizeof(Dn2CppManagedTimer)));
     new (t) Dn2CppManagedTimer();
     t->type = type;
-    t->callback = callback;
-    t->state = state;
+    dn2cpp_gc_store_ref(&t->callback, callback);
+    dn2cpp_gc_store_ref(&t->state, state);
     t->dueMs = dueMs;
     t->periodMs = periodMs;
     t->disposed = false;

--- a/runtime/core/intrinsics/dn2cpp_search_values.cpp
+++ b/runtime/core/intrinsics/dn2cpp_search_values.cpp
@@ -23,7 +23,9 @@ static Dn2CppSearchValues* sv_create(const T* vals, int32_t n)
         if (static_cast<uint32_t>(vals[i]) > 255u) hiN++;
     if (hiN > 0)
     {
-        sv->hi = static_cast<int32_t*>(dn2cpp_alloc_atomic(static_cast<size_t>(hiN) * sizeof(int32_t)));
+        dn2cpp_gc_store_ref(
+            &sv->hi,
+            static_cast<int32_t*>(dn2cpp_alloc_atomic(static_cast<size_t>(hiN) * sizeof(int32_t))));
         int32_t k = 0;
         for (int32_t i = 0; i < n; i++)
         {
@@ -99,12 +101,14 @@ int32_t dn2cpp_search_values_contains_u16(uint16_t value, const Dn2CppSearchValu
 Dn2CppSearchValues* dn2cpp_search_values_create_str(Dn2CppString** vals, int32_t n, int32_t ignoreCase)
 {
     Dn2CppSearchValues* sv = static_cast<Dn2CppSearchValues*>(dn2cpp_alloc(sizeof(Dn2CppSearchValues)));
-    sv->strs = static_cast<Dn2CppString**>(dn2cpp_alloc(static_cast<size_t>(n) * sizeof(Dn2CppString*)));
+    dn2cpp_gc_store_ref(
+        &sv->strs,
+        static_cast<Dn2CppString**>(dn2cpp_alloc(static_cast<size_t>(n) * sizeof(Dn2CppString*))));
     for (int32_t i = 0; i < n; i++)
     {
         if (vals[i] == nullptr)
             dn2cpp_throw_argument_null();
-        sv->strs[i] = vals[i];
+        dn2cpp_gc_store_ref(&sv->strs[i], vals[i]);
     }
     sv->strCount = n;
     sv->strIgnoreCase = ignoreCase;

--- a/runtime/core/intrinsics/dn2cpp_string_core.cpp
+++ b/runtime/core/intrinsics/dn2cpp_string_core.cpp
@@ -74,7 +74,7 @@ Dn2CppString* dn2cpp_string_alloc(char16_t** outBuf, int32_t length)
     auto* s = static_cast<Dn2CppString*>(dn2cpp_alloc(sizeof(Dn2CppString)));
     s->type = &dn2cpp_string_type;
     s->length = length;
-    s->chars = buf;
+    dn2cpp_gc_store_ref(&s->chars, static_cast<const char16_t*>(buf));
     *outBuf = buf;
     return s;
 }
@@ -285,7 +285,7 @@ Dn2CppString* dn2cpp_string_from_utf8(const char* utf8, int32_t byteLength)
     auto* s = static_cast<Dn2CppString*>(dn2cpp_alloc(sizeof(Dn2CppString)));
     s->type = &dn2cpp_string_type;
     s->length = out;
-    s->chars = buf;
+    dn2cpp_gc_store_ref(&s->chars, static_cast<const char16_t*>(buf));
     return s;
 }
 
@@ -386,7 +386,7 @@ Dn2CppString* dn2cpp_string_from_ansi(const char* bytes, int32_t byteLength)
     auto* s = static_cast<Dn2CppString*>(dn2cpp_alloc(sizeof(Dn2CppString)));
     s->type = &dn2cpp_string_type;
     s->length = n;
-    s->chars = buf;
+    dn2cpp_gc_store_ref(&s->chars, static_cast<const char16_t*>(buf));
     return s;
 }
 

--- a/runtime/core/intrinsics/dn2cpp_system_reflection.cpp
+++ b/runtime/core/intrinsics/dn2cpp_system_reflection.cpp
@@ -64,7 +64,8 @@ Dn2CppArrayRef* dn2cpp_type_get_generic_arguments(Dn2CppType* t)
     int32_t n = ti->genericArgCount;
     Dn2CppArrayRef* arr = dn2cpp_newarr_ref(n);
     for (int32_t i = 0; i < n; i++)
-        arr->data[i] = reinterpret_cast<Dn2CppObject*>(dn2cpp_get_type_from_handle(ti->genericArgs[i]));
+        dn2cpp_gc_store_ref(&arr->data[i],
+            reinterpret_cast<Dn2CppObject*>(dn2cpp_get_type_from_handle(ti->genericArgs[i])));
     return arr;
 }
 
@@ -394,7 +395,8 @@ Dn2CppArrayRef* dn2cpp_type_get_interfaces(Dn2CppType* t)
     Dn2CppArrayRef* arr = dn2cpp_newarr_ref(eff.Count());
     int32_t k = 0;
     eff.ForEach([&](const Dn2CppTypeInfo* itf) {
-        arr->data[k++] = reinterpret_cast<Dn2CppObject*>(dn2cpp_get_type_from_handle(itf));
+        dn2cpp_gc_store_ref(&arr->data[k++],
+            reinterpret_cast<Dn2CppObject*>(dn2cpp_get_type_from_handle(itf)));
     });
     return arr;
 }
@@ -499,8 +501,8 @@ Dn2CppArrayRef* dn2cpp_assembly_get_types(const char* asmName)
     int32_t i = 0;
     for (int32_t k = 0; k < dn2cpp_type_registry_count; k++)
         if (owned(k))
-            arr->data[i++] = reinterpret_cast<Dn2CppObject*>(
-                dn2cpp_get_type_from_handle(dn2cpp_type_registry[k].type));
+            dn2cpp_gc_store_ref(&arr->data[i++], reinterpret_cast<Dn2CppObject*>(
+                dn2cpp_get_type_from_handle(dn2cpp_type_registry[k].type)));
     return arr;
 }
 
@@ -736,8 +738,8 @@ static int32_t dn2cpp_enum_parse_type_core(Dn2CppType* t, Dn2CppString* s, int32
     for (int32_t i = 0; i < n; i++)
     {
         values[i] = ti->enumMembers[i].value;
-        names[i] = dn2cpp_string_from_utf8(ti->enumMembers[i].name,
-            static_cast<int32_t>(std::strlen(ti->enumMembers[i].name)));
+        dn2cpp_gc_store_ref(&names[i], dn2cpp_string_from_utf8(ti->enumMembers[i].name,
+            static_cast<int32_t>(std::strlen(ti->enumMembers[i].name))));
     }
     int32_t uWidth = 4;
     bool uUnsigned = false;
@@ -951,7 +953,8 @@ Dn2CppArrayRef* dn2cpp_type_get_nested_types(Dn2CppType* t)
     int32_t n = ti->nestedCount;
     Dn2CppArrayRef* arr = dn2cpp_newarr_ref(n);
     for (int32_t i = 0; i < n; i++)
-        arr->data[i] = reinterpret_cast<Dn2CppObject*>(dn2cpp_get_type_from_handle(ti->nestedTypes[i]));
+        dn2cpp_gc_store_ref(&arr->data[i],
+            reinterpret_cast<Dn2CppObject*>(dn2cpp_get_type_from_handle(ti->nestedTypes[i])));
     return arr;
 }
 
@@ -1327,8 +1330,8 @@ static int32_t dn2cpp_collect_fields(const Dn2CppTypeInfo* type, int32_t flags, 
             if (dn2cpp_field_matches(&ti->fields[i], flags, inherited))
             {
                 if (out != nullptr)
-                    out[n] = reinterpret_cast<Dn2CppObject*>(
-                        dn2cpp_make_fieldref(&ti->fields[i], type));
+                    dn2cpp_gc_store_ref(&out[n], reinterpret_cast<Dn2CppObject*>(
+                        dn2cpp_make_fieldref(&ti->fields[i], type)));
                 n++;
             }
         if (flags & DN2CPP_BF_DECLAREDONLY)
@@ -1664,7 +1667,8 @@ static int32_t dn2cpp_collect_methods(const Dn2CppTypeInfo* type, int32_t flags,
                     seen[seenCount++] = mi->vtableSlot;
             }
             if (out != nullptr)
-                out[n] = reinterpret_cast<Dn2CppObject*>(dn2cpp_make_methodref(mi, type));
+                dn2cpp_gc_store_ref(&out[n],
+                    reinterpret_cast<Dn2CppObject*>(dn2cpp_make_methodref(mi, type)));
             n++;
         }
         if (flags & DN2CPP_BF_DECLAREDONLY)
@@ -2333,14 +2337,14 @@ Dn2CppObject* dn2cpp_delegate_create(Dn2CppType* dt, Dn2CppObject* target,
     auto* node = static_cast<Dn2CppReflBind*>(dn2cpp_alloc(sizeof(Dn2CppReflBind)));
     node->type = &dn2cpp_reflbind_type;
     node->method = mi;
-    node->target = target;
+    dn2cpp_gc_store_ref(&node->target, target);
     node->mode = mode;
     size_t sz = sizeof(Dn2CppDelegate);
     if (dti->instanceSize > 0 && static_cast<size_t>(dti->instanceSize) > sz)
         sz = static_cast<size_t>(dti->instanceSize);
     auto* dg = static_cast<Dn2CppDelegate*>(dn2cpp_alloc(sz));
     dg->type = dti;
-    dg->target = reinterpret_cast<Dn2CppObject*>(node);
+    dn2cpp_gc_store_ref(&dg->target, reinterpret_cast<Dn2CppObject*>(node));
     dg->method = tramp;
     dg->prev = nullptr;
     return reinterpret_cast<Dn2CppObject*>(dg);
@@ -2419,7 +2423,8 @@ static int32_t dn2cpp_collect_ctors(const Dn2CppTypeInfo* ti, int32_t flags, Dn2
         if (dn2cpp_member_matches(ti->ctors[i].attrs, flags, false))
         {
             if (out != nullptr)
-                out[n] = reinterpret_cast<Dn2CppObject*>(dn2cpp_make_methodref(&ti->ctors[i], ti));
+                dn2cpp_gc_store_ref(&out[n],
+                    reinterpret_cast<Dn2CppObject*>(dn2cpp_make_methodref(&ti->ctors[i], ti)));
             n++;
         }
     return n;
@@ -2559,7 +2564,8 @@ static int32_t dn2cpp_collect_props(const Dn2CppTypeInfo* type, int32_t flags, D
             if (seenCount < 256)
                 seen[seenCount++] = p->name;
             if (out != nullptr)
-                out[n] = reinterpret_cast<Dn2CppObject*>(dn2cpp_make_propref(p, type));
+                dn2cpp_gc_store_ref(&out[n],
+                    reinterpret_cast<Dn2CppObject*>(dn2cpp_make_propref(p, type)));
             n++;
         }
         if (flags & DN2CPP_BF_DECLAREDONLY)
@@ -2813,7 +2819,8 @@ static int32_t dn2cpp_collect_member_matches(const Dn2CppTypeInfo* type, Dn2CppS
                 if (hidden || !dn2cpp_name_pattern_matches(mi->name, name))
                     continue;
                 if (out != nullptr)
-                    out[n] = reinterpret_cast<Dn2CppObject*>(dn2cpp_make_methodref(mi, type));
+                    dn2cpp_gc_store_ref(&out[n],
+                        reinterpret_cast<Dn2CppObject*>(dn2cpp_make_methodref(mi, type)));
                 n++;
             }
             if (flags & DN2CPP_BF_DECLAREDONLY)
@@ -2828,7 +2835,8 @@ static int32_t dn2cpp_collect_member_matches(const Dn2CppTypeInfo* type, Dn2CppS
                 || !dn2cpp_name_pattern_matches(ci->name, name))
                 continue;
             if (out != nullptr)
-                out[n] = reinterpret_cast<Dn2CppObject*>(dn2cpp_make_methodref(ci, type));
+                dn2cpp_gc_store_ref(&out[n],
+                    reinterpret_cast<Dn2CppObject*>(dn2cpp_make_methodref(ci, type)));
             n++;
         }
     if (memberTypes & DN2CPP_MT_PROPERTY)
@@ -2859,7 +2867,8 @@ static int32_t dn2cpp_collect_member_matches(const Dn2CppTypeInfo* type, Dn2CppS
                 if (!dn2cpp_name_pattern_matches(p->name, name))
                     continue;
                 if (out != nullptr)
-                    out[n] = reinterpret_cast<Dn2CppObject*>(dn2cpp_make_propref(p, type));
+                    dn2cpp_gc_store_ref(&out[n],
+                        reinterpret_cast<Dn2CppObject*>(dn2cpp_make_propref(p, type)));
                 n++;
             }
             if (flags & DN2CPP_BF_DECLAREDONLY)
@@ -2877,8 +2886,8 @@ static int32_t dn2cpp_collect_member_matches(const Dn2CppTypeInfo* type, Dn2CppS
                     || !dn2cpp_name_pattern_matches(ti->fields[i].name, name))
                     continue;
                 if (out != nullptr)
-                    out[n] = reinterpret_cast<Dn2CppObject*>(
-                        dn2cpp_make_fieldref(&ti->fields[i], type));
+                    dn2cpp_gc_store_ref(&out[n], reinterpret_cast<Dn2CppObject*>(
+                        dn2cpp_make_fieldref(&ti->fields[i], type)));
                 n++;
             }
             if (flags & DN2CPP_BF_DECLAREDONLY)
@@ -2895,8 +2904,8 @@ static int32_t dn2cpp_collect_member_matches(const Dn2CppTypeInfo* type, Dn2CppS
                     dn2cpp_simple_type_name(type->nestedTypes[i]->name), name))
                 continue;
             if (out != nullptr)
-                out[n] = reinterpret_cast<Dn2CppObject*>(
-                    dn2cpp_get_type_from_handle(type->nestedTypes[i]));
+                dn2cpp_gc_store_ref(&out[n], reinterpret_cast<Dn2CppObject*>(
+                    dn2cpp_get_type_from_handle(type->nestedTypes[i])));
             n++;
         }
     return n;
@@ -3966,11 +3975,11 @@ Dn2CppArrayRef* dn2cpp_type_find_interfaces(Dn2CppType* t, Dn2CppObject* filter,
     eff.ForEach([&](const Dn2CppTypeInfo* row) {
         auto* itf = reinterpret_cast<Dn2CppObject*>(dn2cpp_get_type_from_handle(row));
         if (fn(d->target, itf, criteria) != 0)
-            keep[n++] = itf;
+            dn2cpp_gc_store_ref(&keep[n++], itf);
     });
     Dn2CppArrayRef* arr = dn2cpp_newarr_ref(n);
     for (int32_t i = 0; i < n; i++)
-        arr->data[i] = keep[i];
+        dn2cpp_gc_store_ref(&arr->data[i], keep[i]);
     return arr;
 }
 
@@ -4103,7 +4112,8 @@ Dn2CppArrayRef* dn2cpp_methodref_get_generic_arguments(Dn2CppMethodRef* m)
     int32_t n = (mi->genericArgs != nullptr) ? mi->genericParamCount : 0;
     Dn2CppArrayRef* arr = dn2cpp_newarr_ref(n);
     for (int32_t i = 0; i < n; i++)
-        arr->data[i] = reinterpret_cast<Dn2CppObject*>(dn2cpp_get_type_from_handle(mi->genericArgs[i]));
+        dn2cpp_gc_store_ref(&arr->data[i],
+            reinterpret_cast<Dn2CppObject*>(dn2cpp_get_type_from_handle(mi->genericArgs[i])));
     return arr;
 }
 

--- a/runtime/core/intrinsics/dn2cpp_system_resources.cpp
+++ b/runtime/core/intrinsics/dn2cpp_system_resources.cpp
@@ -444,7 +444,7 @@ Dn2CppResourceManager* dn2cpp_resourcemanager_new(Dn2CppString* baseName, const 
         dn2cpp_throw_argument_null();
     auto* rm = static_cast<Dn2CppResourceManager*>(dn2cpp_alloc(sizeof(Dn2CppResourceManager)));
     rm->type = &dn2cpp_resourcemanager_type;
-    rm->baseName = baseName;
+    dn2cpp_gc_store_ref(&rm->baseName, baseName);
     // A null assembly handle would mean "no registry row", which every lookup below
     // would then report as a missing SET — true, but naming no assembly. The empty
     // name is what dn2cpp_assembly_reg_find already treats as unknown, and it prints.

--- a/runtime/core/intrinsics/dn2cpp_system_string.cpp
+++ b/runtime/core/intrinsics/dn2cpp_system_string.cpp
@@ -935,7 +935,7 @@ static Dn2CppArrayRef* dn2cpp_split_sole_value(Dn2CppString* s, bool removeEmpty
         return dn2cpp_newarr_ref(0);
     Dn2CppArrayRef* arr = dn2cpp_newarr_ref(1);
     Dn2CppString* v = (a == 0 && b == s->length) ? s : dn2cpp_str_substring(s, a, b - a);
-    arr->data[0] = reinterpret_cast<Dn2CppObject*>(v);
+    dn2cpp_gc_store_ref(&arr->data[0], reinterpret_cast<Dn2CppObject*>(v));
     return arr;
 }
 
@@ -1110,7 +1110,7 @@ Dn2CppArrayRef* dn2cpp_str_split_str(Dn2CppString* s, Dn2CppString* sep, int32_t
     if (sep == nullptr || sep->length == 0)
         return dn2cpp_split_sole_value(s, (opts & 1) != 0, (opts & 2) != 0);
     Dn2CppArrayRef* one = dn2cpp_newarr_ref(1);
-    one->data[0] = reinterpret_cast<Dn2CppObject*>(sep);
+    dn2cpp_gc_store_ref(&one->data[0], reinterpret_cast<Dn2CppObject*>(sep));
     return dn2cpp_str_split(s, nullptr, 0, one, count, opts);
 }
 
@@ -1610,7 +1610,7 @@ Dn2CppString* dn2cpp_string_concat_objects_n(Dn2CppArrayRef* objs, int32_t n)
         n = 0;
     auto** parts = static_cast<Dn2CppString**>(dn2cpp_alloc(sizeof(Dn2CppString*) * (n > 0 ? n : 1)));
     for (int32_t i = 0; i < n; i++)
-        parts[i] = dn2cpp_object_tostring(objs->data[i]);
+        dn2cpp_gc_store_ref(&parts[i], dn2cpp_object_tostring(objs->data[i]));
     return dn2cpp_string_concat_n(parts, n);
 }
 
@@ -1629,9 +1629,9 @@ static Dn2CppString* dn2cpp_join_strings(Dn2CppString* sep, Dn2CppString** elems
     auto** parts = static_cast<Dn2CppString**>(dn2cpp_alloc(sizeof(Dn2CppString*) * pc));
     for (int32_t i = 0; i < n; i++)
     {
-        parts[2 * i] = elems[i];
+        dn2cpp_gc_store_ref(&parts[2 * i], elems[i]);
         if (i < n - 1)
-            parts[2 * i + 1] = sep;
+            dn2cpp_gc_store_ref(&parts[2 * i + 1], sep);
     }
     return dn2cpp_string_concat_n(parts, pc);
 }
@@ -1644,7 +1644,7 @@ Dn2CppString* dn2cpp_string_join_i4_n(Dn2CppString* sep, Dn2CppArrayI4* a, int32
     if (a == nullptr || n < 0) n = 0;
     auto** e = static_cast<Dn2CppString**>(dn2cpp_alloc(sizeof(Dn2CppString*) * (n > 0 ? n : 1)));
     for (int32_t i = 0; i < n; i++)
-        e[i] = dn2cpp_int_to_string(a->data[i]);
+        dn2cpp_gc_store_ref(&e[i], dn2cpp_int_to_string(a->data[i]));
     return dn2cpp_join_strings(sep, e, n);
 }
 
@@ -1659,7 +1659,7 @@ Dn2CppString* dn2cpp_string_join_i8_n(Dn2CppString* sep, Dn2CppArrayN* a, int32_
     auto* d = reinterpret_cast<int64_t*>(a->data);
     auto** e = static_cast<Dn2CppString**>(dn2cpp_alloc(sizeof(Dn2CppString*) * (n > 0 ? n : 1)));
     for (int32_t i = 0; i < n; i++)
-        e[i] = dn2cpp_long_to_string(d[i]);
+        dn2cpp_gc_store_ref(&e[i], dn2cpp_long_to_string(d[i]));
     return dn2cpp_join_strings(sep, e, n);
 }
 
@@ -1675,7 +1675,7 @@ Dn2CppString* dn2cpp_string_join_u4_n(Dn2CppString* sep, Dn2CppArrayI4* a, int32
     if (a == nullptr || n < 0) n = 0;
     auto** e = static_cast<Dn2CppString**>(dn2cpp_alloc(sizeof(Dn2CppString*) * (n > 0 ? n : 1)));
     for (int32_t i = 0; i < n; i++)
-        e[i] = dn2cpp_format_uint(static_cast<uint32_t>(a->data[i]), 4, nullptr);
+        dn2cpp_gc_store_ref(&e[i], dn2cpp_format_uint(static_cast<uint32_t>(a->data[i]), 4, nullptr));
     return dn2cpp_join_strings(sep, e, n);
 }
 
@@ -1690,7 +1690,7 @@ Dn2CppString* dn2cpp_string_join_u8_n(Dn2CppString* sep, Dn2CppArrayN* a, int32_
     auto* d = reinterpret_cast<uint64_t*>(a->data);
     auto** e = static_cast<Dn2CppString**>(dn2cpp_alloc(sizeof(Dn2CppString*) * (n > 0 ? n : 1)));
     for (int32_t i = 0; i < n; i++)
-        e[i] = dn2cpp_format_uint(d[i], 8, nullptr);
+        dn2cpp_gc_store_ref(&e[i], dn2cpp_format_uint(d[i], 8, nullptr));
     return dn2cpp_join_strings(sep, e, n);
 }
 
@@ -1705,7 +1705,7 @@ Dn2CppString* dn2cpp_string_join_r8_n(Dn2CppString* sep, Dn2CppArrayN* a, int32_
     auto* d = reinterpret_cast<double*>(a->data);
     auto** e = static_cast<Dn2CppString**>(dn2cpp_alloc(sizeof(Dn2CppString*) * (n > 0 ? n : 1)));
     for (int32_t i = 0; i < n; i++)
-        e[i] = dn2cpp_double_to_string(d[i]);
+        dn2cpp_gc_store_ref(&e[i], dn2cpp_double_to_string(d[i]));
     return dn2cpp_join_strings(sep, e, n);
 }
 
@@ -1723,7 +1723,7 @@ Dn2CppString* dn2cpp_string_join_ch_n(Dn2CppString* sep, Dn2CppArrayN* a, int32_
         return dn2cpp_string_from_chars(d, n);
     auto** e = static_cast<Dn2CppString**>(dn2cpp_alloc(sizeof(Dn2CppString*) * (n > 0 ? n : 1)));
     for (int32_t i = 0; i < n; i++)
-        e[i] = dn2cpp_char_to_string(d[i]);
+        dn2cpp_gc_store_ref(&e[i], dn2cpp_char_to_string(d[i]));
     return dn2cpp_join_strings(sep, e, n);
 }
 
@@ -1737,7 +1737,7 @@ Dn2CppString* dn2cpp_string_join_ref_n(Dn2CppString* sep, Dn2CppArrayRef* a, int
     if (a == nullptr || n < 0) n = 0;
     auto** e = static_cast<Dn2CppString**>(dn2cpp_alloc(sizeof(Dn2CppString*) * (n > 0 ? n : 1)));
     for (int32_t i = 0; i < n; i++)
-        e[i] = dn2cpp_object_tostring(a->data[i]);
+        dn2cpp_gc_store_ref(&e[i], dn2cpp_object_tostring(a->data[i]));
     return dn2cpp_join_strings(sep, e, n);
 }
 
@@ -1755,7 +1755,7 @@ Dn2CppString* dn2cpp_string_join_objs(Dn2CppString* sep, Dn2CppObject* const* d,
     if (d == nullptr || n < 0) n = 0;
     auto** e = static_cast<Dn2CppString**>(dn2cpp_alloc(sizeof(Dn2CppString*) * (n > 0 ? n : 1)));
     for (int32_t i = 0; i < n; i++)
-        e[i] = dn2cpp_object_tostring(d[i]);
+        dn2cpp_gc_store_ref(&e[i], dn2cpp_object_tostring(d[i]));
     return dn2cpp_join_strings(sep, e, n);
 }
 
@@ -1764,7 +1764,7 @@ Dn2CppString* dn2cpp_string_concat_objs(Dn2CppObject* const* d, int32_t n)
     if (d == nullptr || n < 0) n = 0;
     auto** e = static_cast<Dn2CppString**>(dn2cpp_alloc(sizeof(Dn2CppString*) * (n > 0 ? n : 1)));
     for (int32_t i = 0; i < n; i++)
-        e[i] = dn2cpp_object_tostring(d[i]);
+        dn2cpp_gc_store_ref(&e[i], dn2cpp_object_tostring(d[i]));
     return dn2cpp_string_concat_n(e, n);
 }
 
@@ -1781,7 +1781,7 @@ Dn2CppString* dn2cpp_string_join_ref_range(Dn2CppString* sep, Dn2CppArrayRef* a,
         dn2cpp_throw_argument_out_of_range();
     auto** e = static_cast<Dn2CppString**>(dn2cpp_alloc(sizeof(Dn2CppString*) * (count > 0 ? count : 1)));
     for (int32_t i = 0; i < count; i++)
-        e[i] = dn2cpp_object_tostring(a->data[startIndex + i]);
+        dn2cpp_gc_store_ref(&e[i], dn2cpp_object_tostring(a->data[startIndex + i]));
     return dn2cpp_join_strings(sep, e, count);
 }
 

--- a/runtime/core/intrinsics/dn2cpp_system_text.cpp
+++ b/runtime/core/intrinsics/dn2cpp_system_text.cpp
@@ -44,7 +44,9 @@ Dn2CppStringBuilder* dn2cpp_sb_new_cap(int32_t capacity)
     auto* sb = static_cast<Dn2CppStringBuilder*>(dn2cpp_alloc(sizeof(Dn2CppStringBuilder)));
     sb->type = &dn2cpp_stringbuilder_type;
     int32_t cap = capacity > 0 ? capacity : 16;
-    sb->buf = static_cast<char16_t*>(dn2cpp_alloc_atomic(static_cast<size_t>(cap) * sizeof(char16_t)));
+    dn2cpp_gc_store_ref(
+        &sb->buf,
+        static_cast<char16_t*>(dn2cpp_alloc_atomic(static_cast<size_t>(cap) * sizeof(char16_t))));
     sb->length = 0;
     sb->capacity = cap;
     return sb;

--- a/runtime/core/intrinsics/dn2cpp_system_threading.cpp
+++ b/runtime/core/intrinsics/dn2cpp_system_threading.cpp
@@ -668,7 +668,7 @@ Dn2CppObject* dn2cpp_threadlocal_new(Dn2CppObject* factory, const Dn2CppTypeInfo
 {
     auto* h = static_cast<Dn2CppThreadLocal*>(dn2cpp_alloc(sizeof(Dn2CppThreadLocal)));
     h->type = &dn2cpp_threadlocal_type;
-    h->factory = factory;
+    dn2cpp_gc_store_ref(&h->factory, factory);
     h->ti = ti;
     h->size = size;
     h->kind = kind;

--- a/samples/dotnet/BlockingCollectionSubset/Program.cs
+++ b/samples/dotnet/BlockingCollectionSubset/Program.cs
@@ -8,6 +8,8 @@ using System.Threading;
 // or leaked element — or a missed CompleteAdding wake — would not reproduce these totals.
 static class Program
 {
+    sealed class StringOutHolder { internal string? Value; }
+
     static int s_consumedCount;
     static int s_consumedSum;
 
@@ -167,7 +169,10 @@ static class Program
         strings.Add("alpha");
         strings.Add("beta");
         strings.Add("gamma");
-        Console.WriteLine(strings.Take() + "|" + strings.Take() + "|" + strings.Take());
+        var stringOut = new StringOutHolder();
+        if (!strings.TryTake(out stringOut.Value))
+            throw new InvalidOperationException("reference TryTake unexpectedly failed");
+        Console.WriteLine(stringOut.Value + "|" + strings.Take() + "|" + strings.Take());
 
         // 64-bit value T (long): exercises the i8 box/unbox kind.
         var longs = new BlockingCollection<long>();

--- a/samples/dotnet/EnumOps/EnumTryParseTypeSubset.cs
+++ b/samples/dotnet/EnumOps/EnumTryParseTypeSubset.cs
@@ -34,26 +34,31 @@ namespace EnumTryParseTypeSubset
     // string forms.
     internal static class Program
     {
+        private sealed class OutHolder { internal object Value; }
+
         private static void TryColor(string label, string s)
         {
-            object v;
-            bool ok = Enum.TryParse(typeof(Color), s, out v);
+            var holder = new OutHolder();
+            bool ok = Enum.TryParse(typeof(Color), s, out holder.Value);
+            object v = holder.Value;
             Console.WriteLine(label + ": " + ok + " " + (ok ? (int)(Color)v : -1)
                 + " null=" + (v == null));
         }
 
         private static void TryColorIc(string label, string s)
         {
-            object v;
-            bool ok = Enum.TryParse(typeof(Color), s, true, out v);
+            var holder = new OutHolder();
+            bool ok = Enum.TryParse(typeof(Color), s, true, out holder.Value);
+            object v = holder.Value;
             Console.WriteLine(label + ": " + ok + " " + (ok ? (int)(Color)v : -1)
                 + " null=" + (v == null));
         }
 
         private static void TryPerm(string label, string s)
         {
-            object v;
-            bool ok = Enum.TryParse(typeof(Perm), s, out v);
+            var holder = new OutHolder();
+            bool ok = Enum.TryParse(typeof(Perm), s, out holder.Value);
+            object v = holder.Value;
             Console.WriteLine(label + ": " + ok + " " + (ok ? (int)(Perm)v : -1));
         }
 

--- a/samples/dotnet/PInvokeNative/PInvokeByRefStringSubset.cs
+++ b/samples/dotnet/PInvokeNative/PInvokeByRefStringSubset.cs
@@ -10,6 +10,8 @@ namespace PInvokeByRefStringSubset;
 
 internal static class Program
 {
+    private sealed class StringHolder { internal string Value; }
+
     [DllImport("dn2cpptest", CharSet = CharSet.Ansi)]
     private static extern void dn2cpptest_out_str(out string s);
     [DllImport("dn2cpptest", CharSet = CharSet.Unicode)]
@@ -23,8 +25,9 @@ internal static class Program
 
     internal static void __GateEntry()
     {
-        dn2cpptest_out_str(out string a);
-        Console.WriteLine(a);                  // native-made
+        var holder = new StringHolder();
+        dn2cpptest_out_str(out holder.Value);
+        Console.WriteLine(holder.Value);         // native-made
 
         dn2cpptest_out_wstr(out string w);
         Console.WriteLine(w);                  // Ok☺

--- a/samples/dotnet/PInvokeNative/PInvokeMarshalStructSubset.cs
+++ b/samples/dotnet/PInvokeNative/PInvokeMarshalStructSubset.cs
@@ -15,6 +15,8 @@ internal static class Program
     [StructLayout(LayoutKind.Sequential)]
     private struct Person { public int Id; public string Name; }
 
+    private sealed class PersonHolder { internal Person Value; }
+
     // The same under CharSet.Unicode, so the string field is UTF-16.
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
     private struct WidePerson { public int Id; public string Name; }
@@ -46,9 +48,9 @@ internal static class Program
         Console.WriteLine(dn2cpptest_person_score(p));          // 15
 
         // by-ref [In,Out]: the native replaces the name slot, leaving our GC buffer alone.
-        var b = new Person { Id = 3, Name = "abc" };
-        dn2cpptest_person_bump(ref b);
-        Console.WriteLine($"{b.Id} {b.Name}");                  // 4 ABC
+        var b = new PersonHolder { Value = new Person { Id = 3, Name = "abc" } };
+        dn2cpptest_person_bump(ref b.Value);
+        Console.WriteLine($"{b.Value.Id} {b.Value.Name}");      // 4 ABC
 
         // [In] ref: the native still mutates its copy, but nothing writes back.
         var q = new Person { Id = 3, Name = "abc" };

--- a/samples/dotnet/SpanOps/SpanInstanceSubset.cs
+++ b/samples/dotnet/SpanOps/SpanInstanceSubset.cs
@@ -45,6 +45,10 @@ class Program
         string[] sdst = new string[2];
         ((Span<string>)ssrc).CopyTo(sdst);
         Console.WriteLine($"{sdst[0]},{sdst[1]}");              // p,q
+        string[] sdstTry = new string[2];
+        if (!((Span<string>)ssrc).TryCopyTo(sdstTry)
+            || sdstTry[0] != "p" || sdstTry[1] != "q")
+            throw new InvalidOperationException("Span<string>.TryCopyTo failed");
 
         // --- Span.ToArray (a fresh copy, independent of the source) ---
         int[] orig = { 1, 2, 3 };

--- a/samples/dotnet/WeakReferences/IncrementalWriteBarrierSubset.cs
+++ b/samples/dotnet/WeakReferences/IncrementalWriteBarrierSubset.cs
@@ -6,7 +6,7 @@ namespace IncrementalWriteBarrierSubset
     internal static class Program
     {
         private const int HolderCount = 384;
-        private const int PathCount = 10;
+        private const int PathCount = 11;
         private const int CollectionCount = 4;
         private const int AllocationLimit = 100_000;
 
@@ -41,11 +41,17 @@ namespace IncrementalWriteBarrierSubset
             internal Payload Volatile;
             internal readonly Payload[] Fill = new Payload[1];
             internal readonly RefPair[] PairBulk = new RefPair[1];
+            internal Payload[] Resize = new Payload[1];
         }
 
         private static void StoreByRef(ref Payload slot, Payload value)
         {
             slot = value;
+        }
+
+        private static void Resize(ref Payload[] array, int length)
+        {
+            Array.Resize(ref array, length);
         }
 
         private static void Store(Holder holder, int path, Payload value)
@@ -79,11 +85,15 @@ namespace IncrementalWriteBarrierSubset
                 case 8:
                     Array.Fill(holder.Fill, value);
                     break;
-                default:
+                case 9:
                     // The source must be statically RefPair[]: an Array-typed one
                     // fails the same-element proof and takes the dynamic helper.
                     var pairs = new RefPair[] { new RefPair { Value = value } };
                     Array.Copy(pairs, holder.PairBulk, 1);
+                    break;
+                default:
+                    Resize(ref holder.Resize, holder.Resize.Length + 1);
+                    holder.Resize[holder.Resize.Length - 1] = value;
                     break;
             }
         }
@@ -101,7 +111,8 @@ namespace IncrementalWriteBarrierSubset
                 6 => holder.Atomic,
                 7 => holder.Volatile,
                 8 => holder.Fill[0],
-                _ => holder.PairBulk[0].Value,
+                9 => holder.PairBulk[0].Value,
+                _ => holder.Resize[holder.Resize.Length - 1],
             };
         }
 
@@ -183,6 +194,7 @@ namespace IncrementalWriteBarrierSubset
             GC.KeepAlive(holders);
             GC.KeepAlive(pressure);
             Console.WriteLine("incremental write barriers: True");
+            Console.WriteLine("Array.Resize field barrier: True");
         }
     }
 }

--- a/samples/dotnet/WeakReferences/IncrementalWriteBarrierSubset.cs
+++ b/samples/dotnet/WeakReferences/IncrementalWriteBarrierSubset.cs
@@ -6,7 +6,7 @@ namespace IncrementalWriteBarrierSubset
     internal static class Program
     {
         private const int HolderCount = 384;
-        private const int PathCount = 11;
+        private const int PathCount = 10;
         private const int CollectionCount = 4;
         private const int AllocationLimit = 100_000;
 
@@ -41,7 +41,11 @@ namespace IncrementalWriteBarrierSubset
             internal Payload Volatile;
             internal readonly Payload[] Fill = new Payload[1];
             internal readonly RefPair[] PairBulk = new RefPair[1];
-            internal Payload[] Resize = new Payload[1];
+        }
+
+        private sealed class ResizeHolder
+        {
+            internal Payload[] Values = new Payload[1];
         }
 
         private static void StoreByRef(ref Payload slot, Payload value)
@@ -85,15 +89,11 @@ namespace IncrementalWriteBarrierSubset
                 case 8:
                     Array.Fill(holder.Fill, value);
                     break;
-                case 9:
+                default:
                     // The source must be statically RefPair[]: an Array-typed one
                     // fails the same-element proof and takes the dynamic helper.
                     var pairs = new RefPair[] { new RefPair { Value = value } };
                     Array.Copy(pairs, holder.PairBulk, 1);
-                    break;
-                default:
-                    Resize(ref holder.Resize, holder.Resize.Length + 1);
-                    holder.Resize[holder.Resize.Length - 1] = value;
                     break;
             }
         }
@@ -111,9 +111,61 @@ namespace IncrementalWriteBarrierSubset
                 6 => holder.Atomic,
                 7 => holder.Volatile,
                 8 => holder.Fill[0],
-                9 => holder.PairBulk[0].Value,
-                _ => holder.Resize[holder.Resize.Length - 1],
+                _ => holder.PairBulk[0].Value,
             };
+        }
+
+        private static void ExerciseResizeBarrier(byte[][] pressure)
+        {
+            var holders = new ResizeHolder[HolderCount];
+            for (int i = 0; i < holders.Length; i++)
+                holders[i] = new ResizeHolder();
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+
+            var arrayWeaks = new WeakReference<Payload[]>[HolderCount];
+            var payloadWeaks = new WeakReference<Payload>[HolderCount];
+            int completed = GC.CollectionCount(0);
+            for (int cycle = 0; cycle < CollectionCount; cycle++)
+            {
+                int target = completed + 1;
+                for (int i = 0; i < HolderCount; i++)
+                {
+                    ResizeHolder holder = holders[i];
+                    Resize(ref holder.Values, holder.Values.Length + 1);
+                    var payload = new Payload(cycle * HolderCount + i + 1);
+                    holder.Values[holder.Values.Length - 1] = payload;
+                    arrayWeaks[i] = new WeakReference<Payload[]>(holder.Values);
+                    payloadWeaks[i] = new WeakReference<Payload>(payload);
+                    pressure[i & (pressure.Length - 1)] = new byte[4096];
+                }
+
+                int allocations = 0;
+                while (GC.CollectionCount(0) < target && allocations < AllocationLimit)
+                {
+                    pressure[allocations & (pressure.Length - 1)] = new byte[4096];
+                    allocations++;
+                }
+                if (GC.CollectionCount(0) < target)
+                    throw new InvalidOperationException("allocation pressure did not complete a resize GC cycle");
+                completed = GC.CollectionCount(0);
+
+                for (int i = 0; i < HolderCount; i++)
+                {
+                    Payload[] values = holders[i].Values;
+                    Payload payload = values[values.Length - 1];
+                    if (!arrayWeaks[i].TryGetTarget(out Payload[] weakValues)
+                        || !ReferenceEquals(values, weakValues))
+                        throw new InvalidOperationException("resized array became weakly unreachable");
+                    if (payload is null
+                        || !payloadWeaks[i].TryGetTarget(out Payload weakPayload)
+                        || !ReferenceEquals(payload, weakPayload))
+                        throw new InvalidOperationException("resized array lost its payload");
+                }
+            }
+
+            GC.KeepAlive(holders);
         }
 
         private static void Mutate(Holder[] holders, int[,] expected,
@@ -194,7 +246,14 @@ namespace IncrementalWriteBarrierSubset
             GC.KeepAlive(holders);
             GC.KeepAlive(pressure);
             Console.WriteLine("incremental write barriers: True");
-            Console.WriteLine("Array.Resize field barrier: True");
+        }
+
+        internal static void __ResizeGateEntry()
+        {
+            var pressure = new byte[64][];
+            ExerciseResizeBarrier(pressure);
+            GC.KeepAlive(pressure);
+            Console.WriteLine("Array.Resize field stress: True");
         }
     }
 }

--- a/samples/dotnet/WeakReferences/Program.cs
+++ b/samples/dotnet/WeakReferences/Program.cs
@@ -19,6 +19,7 @@ namespace WeakReferences
             IncrementalWriteBarrierSubset.Program.__GateEntry();
             InternBarrierSubset.Program.__GateEntry();
             PendingCallArgumentSubset.Program.__GateEntry();
+            IncrementalWriteBarrierSubset.Program.__ResizeGateEntry();
         }
     }
 }

--- a/src/Dn2Cpp.Transpiler/CppEmitter.cs
+++ b/src/Dn2Cpp.Transpiler/CppEmitter.cs
@@ -4172,7 +4172,12 @@ internal sealed partial class CppEmitter
             if (f is null)
                 return null;
             string cppT = CppTypes.Of(f.Type);
-            return cppT.EndsWith("*") ? $"o->{f.CppName} = ({cppT})({val});" : $"o->{f.CppName} = {val};";
+            string store = cppT.EndsWith("*")
+                ? $"o->{f.CppName} = ({cppT})({val});"
+                : $"o->{f.CppName} = {val};";
+            return f.Type.ContainsGcReferences()
+                ? store + " dn2cpp_gc_write_barrier((void*)o);"
+                : store;
         }
         var setter = cls.InstanceMethodOnBaseChain("set_" + name);
         if (setter is null || !_c.Reachable.Contains(setter)
@@ -4286,6 +4291,8 @@ internal sealed partial class CppEmitter
                 : $"Dn2CppArrayRef* {name} = dn2cpp_newarr_ref({elemExprs.Count});");
             for (int i = 0; i < elemExprs.Count; i++)
                 pre.Add($"{name}->data[{i}] = (Dn2CppObject*)({elemExprs[i]});");
+            if (elemExprs.Count > 0)
+                pre.Add($"dn2cpp_gc_write_barrier((void*){name});");
         }
         else if (hdr == "Dn2CppArrayI4*")
         {
@@ -5489,6 +5496,7 @@ internal sealed partial class CppEmitter
             sb.AppendLine("    dg->f_target = dn2cpp_box(&dn2cpp_intptr_type, &ip, sizeof(intptr_t));");
             sb.AppendLine($"    dg->f_method = (void*)&dn2cpp_fpfwd_{cls.CppName};");
             sb.AppendLine("    dg->f_prev = nullptr;");
+            sb.AppendLine("    dn2cpp_gc_write_barrier((void*)dg);");
             sb.AppendLine("    return (Dn2CppObject*)dg;");
             sb.AppendLine("}");
         }
@@ -5942,7 +5950,11 @@ internal sealed partial class CppEmitter
             o.Data.AppendLine($"void dn2cpp_marshalout_{cls.CppName}({tn}* src, {tm}* dst, {tn}* insnap)");
             o.Data.AppendLine("{");
             foreach (var f in fields)
+            {
                 o.Data.AppendLine("    " + MarshalOutField(f, unicode));
+                if (f.Type.ContainsGcReferences())
+                    o.Data.AppendLine("    dn2cpp_gc_write_barrier_if_heap((void*)dst);");
+            }
             o.Data.AppendLine("}");
         }
         o.Header.AppendLine();

--- a/src/Dn2Cpp.Transpiler/MethodCompiler.Arithmetic.cs
+++ b/src/Dn2Cpp.Transpiler/MethodCompiler.Arithmetic.cs
@@ -1405,6 +1405,8 @@ internal sealed partial class MethodCompiler
                 string vt = NewTemp(elemCt);
                 Emit($"{vt} = {Cast(value, elemCt)};");
                 Emit($"for ({i} = 0; {i} < {sp}->f__length; {i}++) (({elemSt}*){sp}->f__reference)[{i}] = ({elemSt})({vt});");
+                if (elem.ContainsGcReferences())
+                    Emit($"dn2cpp_gc_write_barrier_if_heap((void*)({sp}->f__reference));");
                 return true;
             }
             case "CopyTo":
@@ -1416,6 +1418,8 @@ internal sealed partial class MethodCompiler
                 Emit($"{dt} = {(dest.Kind == StackKind.Ptr ? $"*({destCt}*)({dest.Expr})" : Cast(dest, destCt))};");
                 Emit($"if ({sp}->f__length > {dt}.f__length) dn2cpp_fail(\"Destination too short (Span.CopyTo)\");");
                 Emit($"for ({i} = 0; {i} < {sp}->f__length; {i}++) (({elemSt}*){dt}.f__reference)[{i}] = (({elemSt}*){sp}->f__reference)[{i}];");
+                if (elem.ContainsGcReferences())
+                    Emit($"dn2cpp_gc_write_barrier_if_heap((void*)({dt}.f__reference));");
                 return true;
             }
             // TryCopyTo(destination) — like CopyTo but returns false instead of throwing
@@ -1433,6 +1437,8 @@ internal sealed partial class MethodCompiler
                 Emit($"{okT} = ({sp}->f__length <= {dt}.f__length) ? 1 : 0;");
                 Emit($"if ({okT}) for ({i} = 0; {i} < {sp}->f__length; {i}++) "
                     + $"(({elemSt}*){dt}.f__reference)[{i}] = (({elemSt}*){sp}->f__reference)[{i}];");
+                if (elem.ContainsGcReferences())
+                    Emit($"if ({okT}) dn2cpp_gc_write_barrier_if_heap((void*)({dt}.f__reference));");
                 Push(StackKind.I4, "int32_t", okT);
                 return true;
             }
@@ -1455,6 +1461,8 @@ internal sealed partial class MethodCompiler
                 Emit($"    {bt} = {baseExpr};");
                 Emit($"    for ({i} = 0; {i} < {lenT}; {i}++) {bt}[{i}] = (({elemSt}*){sp}->f__reference)[{i}];");
                 Emit("}");
+                if (elem.ContainsGcReferences())
+                    Emit($"dn2cpp_gc_write_barrier((void*)({arr.Expr}));");
                 _stack.Add(arr);
                 return true;
             }

--- a/src/Dn2Cpp.Transpiler/MethodCompiler.EmitIntrinsic.AwaitersTasks.cs
+++ b/src/Dn2Cpp.Transpiler/MethodCompiler.EmitIntrinsic.AwaitersTasks.cs
@@ -338,6 +338,7 @@ internal sealed partial class MethodCompiler
                     string awaiter = ValueTaskSourceAwaiter(vtsItf);
                     var vtsSelf = Pop(); // ref this (address of the ValueTask being initialized)
                     Emit($"*(Dn2CppTaskAwaiter*)({vtsSelf.Expr}) = {awaiter};");
+                    Emit($"dn2cpp_gc_write_barrier_if_heap((void*)({vtsSelf.Expr}));");
                     return true;
                 }
                 if (sig.ParameterTypes.Length != 1)
@@ -353,6 +354,7 @@ internal sealed partial class MethodCompiler
                     : StampTask($"dn2cpp_task_from_result({EmitTaskResultStore(arg)})",
                         TaskTypeForResult(sig.ParameterTypes[0]));
                 Emit($"*(Dn2CppTaskAwaiter*)({self.Expr}) = Dn2CppTaskAwaiter{{ {task} }};");
+                Emit($"dn2cpp_gc_write_barrier_if_heap((void*)({self.Expr}));");
                 return true;
             }
             case ("System.Threading.Tasks.ValueTask", "GetAwaiter"):
@@ -551,6 +553,7 @@ internal sealed partial class MethodCompiler
                 var self = Pop(); // ref this
                 EmitCanceledExcRegistration();
                 Emit($"*(Dn2CppCancelToken*)({self.Expr}) = Dn2CppCancelToken{{ ({arg.Expr}) ? dn2cpp_cts_canceled() : nullptr }};");
+                Emit($"dn2cpp_gc_write_barrier_if_heap((void*)({self.Expr}));");
                 return true;
             }
             case ("System.Threading.CancellationToken", "get_None"):

--- a/src/Dn2Cpp.Transpiler/MethodCompiler.EmitIntrinsic.Concurrent.cs
+++ b/src/Dn2Cpp.Transpiler/MethodCompiler.EmitIntrinsic.Concurrent.cs
@@ -116,6 +116,8 @@ internal sealed partial class MethodCompiler
                     Emit($"*(({st}*)({itemRef.Expr})) = ({st})0;"); // default(T) on the !ok path
                     Emit($"if ({ok}) *(({st}*)({itemRef.Expr})) = ({st})(*(({ct}*)dn2cpp_unbox({box}, {ti})));");
                 }
+                if (elemT.ContainsGcReferences())
+                    Emit($"if ({ok}) dn2cpp_gc_write_barrier_if_heap((void*)({itemRef.Expr}));");
                 Push(StackKind.I4, "int32_t", ok);
                 return true;
             }

--- a/src/Dn2Cpp.Transpiler/MethodCompiler.EmitIntrinsic.EnumArray.cs
+++ b/src/Dn2Cpp.Transpiler/MethodCompiler.EmitIntrinsic.EnumArray.cs
@@ -182,6 +182,7 @@ internal sealed partial class MethodCompiler
                 string ok = NewTemp("int32_t");
                 Emit($"{ok} = dn2cpp_enum_try_parse_type({Cast(t, "Dn2CppType*")}, {Cast(s, "Dn2CppString*")}, {icExpr}, &{res});");
                 Emit($"*({Cast(outRef, "Dn2CppObject**")}) = {res};");
+                Emit($"dn2cpp_gc_write_barrier_if_heap((void*)({outRef.Expr}));");
                 Push(StackKind.I4, "int32_t", ok);
                 return true;
             }
@@ -201,6 +202,7 @@ internal sealed partial class MethodCompiler
                 Emit($"{ok} = dn2cpp_enum_try_parse_type({Cast(t, "Dn2CppType*")}, "
                     + $"dn2cpp_string_from_chars((const char16_t*){sv}.f__reference, {sv}.f__length), {icExpr}, &{res});");
                 Emit($"*({Cast(outRef, "Dn2CppObject**")}) = {res};");
+                Emit($"dn2cpp_gc_write_barrier_if_heap((void*)({outRef.Expr}));");
                 Push(StackKind.I4, "int32_t", ok);
                 return true;
             }

--- a/src/Dn2Cpp.Transpiler/MethodCompiler.EmitIntrinsic.Numbers.cs
+++ b/src/Dn2Cpp.Transpiler/MethodCompiler.EmitIntrinsic.Numbers.cs
@@ -151,6 +151,8 @@ internal sealed partial class MethodCompiler
                     Emit($"{recv}->message = {message};");
                 if (inner != "nullptr")
                     Emit($"{recv}->inner = {inner};");
+                if (message != "nullptr" || inner != "nullptr")
+                    Emit($"dn2cpp_gc_write_barrier((void*)({recv}));");
                 return true;
             }
             // System.Exception.set_HResult: store the int32 onto the hresult slot of
@@ -1212,6 +1214,7 @@ internal sealed partial class MethodCompiler
                 string arr = NewTemp("Dn2CppArrayRef*");
                 Emit($"{arr} = dn2cpp_newarr_ref_t(1, {PreciseArrayTypeInfoExpr(cultElem)});");
                 Emit($"{arr}->data[0] = dn2cpp_nfi_wrap(dn2cpp_nfi_invariant(), DN2CPP_NFI_KIND_CULTURE);");
+                Emit($"dn2cpp_gc_write_barrier((void*)({arr}));");
                 Push(StackKind.Ref, "Dn2CppArrayRef*", arr, TypeDesc.MakeSZArray(cultElem));
                 return true;
             }
@@ -1396,6 +1399,7 @@ internal sealed partial class MethodCompiler
                 string val = Cast(Pop(), "Dn2CppString*");
                 string recv = Cast(Pop(), "Dn2CppNumberFormatInfo*");
                 Emit($"{recv}->currencyDecimal = {val};");
+                Emit($"dn2cpp_gc_write_barrier((void*)({recv}));");
                 return true;
             }
             case ("System.Globalization.NumberFormatInfo", "set_CurrencyGroupSeparator"):
@@ -1403,6 +1407,7 @@ internal sealed partial class MethodCompiler
                 string val = Cast(Pop(), "Dn2CppString*");
                 string recv = Cast(Pop(), "Dn2CppNumberFormatInfo*");
                 Emit($"{recv}->currencyGroup = {val};");
+                Emit($"dn2cpp_gc_write_barrier((void*)({recv}));");
                 return true;
             }
             // set_CurrencyDecimalDigits(int) — PLAIN FIELD WRITE (the currencyDigits slot

--- a/src/Dn2Cpp.Transpiler/MethodCompiler.EnumAsync.cs
+++ b/src/Dn2Cpp.Transpiler/MethodCompiler.EnumAsync.cs
@@ -132,6 +132,8 @@ internal sealed partial class MethodCompiler
                 Emit($"{arr} = dn2cpp_newarr_ref_t({ordered.Count}, {PreciseArrayTypeInfoExpr(strElem)});");
                 for (int i = 0; i < ordered.Count; i++)
                     Emit($"{arr}->data[{i}] = (Dn2CppObject*){_literals.GetOrAdd(ordered[i].name)};");
+                if (ordered.Count > 0)
+                    Emit($"dn2cpp_gc_write_barrier((void*)({arr}));");
                 Push(StackKind.Ref, "Dn2CppArrayRef*", arr);
                 _stack[^1] = _stack[^1] with { StaticType = TypeDesc.MakeSZArray(strElem) };
                 return;
@@ -659,7 +661,8 @@ internal sealed partial class MethodCompiler
                     ? $"{{ {smCpp}* __sm = ({smCpp}*)({smRef.Expr}); " +
                       $"if (__sm->{builderField.CppName}.boxed == nullptr) {{ " +
                       $"{smCpp}* __h = ({smCpp}*)dn2cpp_alloc(sizeof({smCpp})); *__h = *__sm; " +
-                      $"__h->{builderField.CppName}.boxed = __h; __sm = __h; }} " +
+                      $"__h->{builderField.CppName}.boxed = __h; " +
+                      "dn2cpp_gc_write_barrier((void*)__h); __sm = __h; } " +
                       $"{resume} }}"
                     : $"{{ {smCpp}* __sm = {StateMachinePtr(sm, smRef)}; {resume} }}");
                 return;
@@ -709,7 +712,8 @@ internal sealed partial class MethodCompiler
              + $"((Dn2CppObject*)__act)->type = &{action.CppTypeInfoName}; "
              + $"__act->f_target = (Dn2CppObject*)__sm; "
              + $"__act->f_method = (void*)&{moveNext.Emittable.CppName}; "
-             + $"__act->f_prev = nullptr; ";
+             + $"__act->f_prev = nullptr; "
+             + "dn2cpp_gc_write_barrier((void*)__act); ";
         // An interface-typed awaiter (a GetAwaiter whose declared return type is
         // an awaiter interface) only declares the registration method — on
         // itself or an inherited INotifyCompletion — so dispatch it through

--- a/src/Dn2Cpp.Transpiler/MethodCompiler.GenericIntrinsic.cs
+++ b/src/Dn2Cpp.Transpiler/MethodCompiler.GenericIntrinsic.cs
@@ -1366,6 +1366,9 @@ internal sealed partial class MethodCompiler
                 sameElementByConstruction: true, elementType: t);
             Emit("}");
             Emit($"{slot} = {nw};");
+            // The ref may name a heap field; the conditional helper also accepts
+            // local and static slots.
+            Emit($"dn2cpp_gc_write_barrier_if_heap((void*)({arrRef.Expr}));");
             return;
         }
 

--- a/src/Dn2Cpp.Transpiler/MethodCompiler.Newobj.cs
+++ b/src/Dn2Cpp.Transpiler/MethodCompiler.Newobj.cs
@@ -451,7 +451,10 @@ internal sealed partial class MethodCompiler
             foreach (var (sb, buf, uni) in sbWritebacks)
                 Emit($"dn2cpp_pinvoke_sb_from_buffer({sb}, {buf}, {(uni ? 1 : 0)});");
             foreach (var (slot, tmp, inbuf, enc) in byrefStrWritebacks)
+            {
                 Emit($"*{slot} = dn2cpp_pinvoke_byref_str_result({tmp}, {inbuf}, {enc});");
+                Emit($"dn2cpp_gc_write_barrier_if_heap((void*)({slot}));");
+            }
             foreach (var (arr, buf) in charArrWritebacks)
                 Emit($"dn2cpp_pinvoke_chararr_from_ansi({arr}, {buf});");
             foreach (var (arr, buf) in structArrWritebacks)
@@ -2004,6 +2007,7 @@ internal sealed partial class MethodCompiler
             Emit($"((Dn2CppObject*){dg})->type = &{cls.CppTypeInfoName};");
             Emit($"{dg}->f_target = {Cast(target, "Dn2CppObject*")};");
             Emit($"{dg}->f_method = {Cast(fnPtr, "void*")};");
+            Emit($"dn2cpp_gc_write_barrier((void*)({dg}));");
             _stack.Add(new StackEntry(dg, StackKind.Ref, cls.CppStructName + "*"));
             return;
         }

--- a/src/Dn2Cpp.Transpiler/MethodCompiler.Operands.cs
+++ b/src/Dn2Cpp.Transpiler/MethodCompiler.Operands.cs
@@ -605,6 +605,7 @@ internal sealed partial class MethodCompiler
             Emit($"{arr} = dn2cpp_newarr_ref({n});");
             for (int i = 0; i < n; i++)
                 Emit($"{arr}->data[{i}] = {elems[i]};");
+            Emit($"dn2cpp_gc_write_barrier((void*)({arr}));");
             return arr;
         }
         throw new NotSupportedException(


### PR DESCRIPTION
## Summary

- emit an incremental-GC write barrier after `Array.Resize<T>` publishes its new array through the byref destination
- exercise a field-backed resize while incremental collections advance
- assert the dedicated generated method contains exactly one conditional heap barrier

## Background

Thrive's Microbe Benchmark repeatedly failed under the dn2cpp Godot export with corrupted `CommandBuffer` and `Stack<AudioStreamPlayer3D>` backing arrays. The same benchmark completed under Mono and with `DN2CPP_GC_INCREMENTAL=0`. Adding the missing barriers to the generated `Array.Resize` write-backs allowed the benchmark to complete with incremental GC enabled.

## Testing

- `dotnet build src/Dn2Cpp.Cli -c Release`
- `DN2CPP_GATE_CACHE=0 ./gates/build-and-run-weak-references.sh`
- `./gates/build-and-run-array-core.sh`
- `SKIP_GODOT=1 ./gates/run-all-gates.sh`
  - 127 of 128 gates passed, 0 failed
  - iOS simulator skipped because Xcode is unavailable on Windows
  - Godot gates intentionally not run by this smoke configuration