### PR TITLE
Add configurable incremental GC startup policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,12 @@ template; the fork changes editor tooling only.**
   the Visual Studio C++ workload *installed* — but no particular shell, as
   the editor locates MSVC itself. Web and Android need neither, each
   bringing its own compiler.
+- **GC mode.** Supported native export targets show
+  `dotnet/dn2cpp/incremental_gc` when the dn2cpp backend is selected. It defaults
+  to incremental GC. At startup, `DN2CPP_GC_INCREMENTAL=0|1` overrides the
+  exported default, and the Godot user argument
+  `-- --dn2cpp-gc-incremental=0|1` overrides both. Web has no page-protection
+  VDB, does not show the option, and always uses stop-the-world collection.
 - **Verified.** In the real engine, end to end: all virtuals, input,
   `[Export]`, `[Signal]`, `ToSignal`, `RefCounted` lifetime stress, and
   **async interop** (`Task` continuations marshal back to the main thread
@@ -574,7 +580,9 @@ site rather than hiding it.
   `ArrayPool<T>.Shared` is a real size-bucketed pool. Modes: classic
   stop-the-world (console default) and Boehm incremental (Godot default,
   bounded frame pauses), with `DN2CPP_GC_INCREMENTAL` /
-  `DN2CPP_GC_TIME_LIMIT_MS` / `DN2CPP_GC_STATS` overrides; `DN2CPP_NO_GC=1`
+  `DN2CPP_GC_TIME_LIMIT_MS` / `DN2CPP_GC_STATS` overrides. Godot exports also
+  accept `--dn2cpp-gc-incremental=0|1` as a user argument, with argument over
+  environment over exported-default precedence; `DN2CPP_NO_GC=1`
   opts out to a calloc fallback. `-DDN2CPP_GC_BACKEND=upstream` swaps in
   vendored upstream bdwgc (`third_party/bdwgc-upstream/`) instead of the
   fork — a dev-only cross-check, not shipped.

--- a/docs/EDITOR-EXPORT-DESIGN.md
+++ b/docs/EDITOR-EXPORT-DESIGN.md
@@ -67,6 +67,20 @@ A new export-preset enum option `dotnet/export_backend`:
 | `NativeAOT` | Inject `PublishAot=true`; the existing native-output probe in `_ExportBeginImpl` handles the result. The A/B baseline. |
 | `dn2cpp` | Transpile the published IL to a drop-in library. |
 
+On every Incremental-GC-capable target, selecting `dn2cpp` also reveals the
+boolean `dotnet/dn2cpp/incremental_gc` option, default `true`. Web does not
+publish the option because its collector has no page-protection VDB and forces
+incremental mode off. The backend option owns the visibility callback; changing
+away from dn2cpp hides the dependent setting without discarding its preset
+value.
+
+The .NET-module resolves the effective mode before GC initialization in this
+order: exported default, `DN2CPP_GC_INCREMENTAL`, then the last valid Godot user
+argument `--dn2cpp-gc-incremental=0|1`. In a normal command line that argument
+follows Godot's separator (`game -- --dn2cpp-gc-incremental=0|1`). An invalid
+value is warned about and ignored, leaving the current effective value in force.
+The Web platform force-off is applied last.
+
 Declared in `GodotTools/GodotTools/Export/ExportPlugin.cs::_GetExportOptions`.
 The pipeline is `GodotTools/GodotTools/Export/Dn2CppExporter.cs`, invoked from
 `_ExportBeginImpl` after `PublishProjectBlocking` produces `{Assembly}.dll`.
@@ -128,6 +142,13 @@ through `PublishProjectBlocking`.
    covers that, and bumping it makes the next editor's first export drop all
    four. Export logs are bounded likewise, newest
    `Dn2CppExporter.LogGenerations` kept.
+
+   Every configure also passes
+   `-DDN2CPP_GC_INCREMENTAL_DEFAULT=ON|OFF`, including the default form. The
+   build directory persists, so omission after an OFF export would retain the
+   stale CMake cache value. This definition reaches only the app-specific
+   .NET-module translation unit; it does not change the prebuilt runtime archive
+   or its cache key.
 
 4. **Stage**: copy the produced library as `{Assembly}.{soExt}` into a fresh
    staging dir and point the existing `RecursePublishContents` /
@@ -734,7 +755,8 @@ condition so an unstamped or differently stamped zip is relinked.
   registers an empty static-data range. The collector is single-threaded (no
   `GC_THREADS`), incremental mode is forced off (no page-protection VDB), and
   finalizers drain manually (no finalizer thread). `DN2CPP_NO_GC=1` and
-  `-DDN2CPP_USE_GC=OFF` remain the calloc escape hatch.
+  `-DDN2CPP_USE_GC=OFF` remain the calloc escape hatch. Neither the environment
+  override nor `--dn2cpp-gc-incremental` can enable incremental mode here.
 - **There are no threads.** `Task.Run`, `Thread` and `Timer` throw.
 - **`System.Net.Http` has no transport.** A browser has no TCP socket layer, so
   `DN2CPP_USE_CURL` — on by default everywhere else — is forced off on this arm

--- a/docs/EDITOR-GUIDE.ja.md
+++ b/docs/EDITOR-GUIDE.ja.md
@@ -130,6 +130,8 @@ Node.js の列が無いのは、`emcc` がリンクのたびに起動する **No
 
 プロジェクト → エクスポート → プリセットを選択 → **`dotnet/export_backend`** を **`dn2cpp`** に設定し、あとは通常どおりエクスポートするだけです。上の[動作要件](#動作要件)以外に必要なものはありません。トランスパイラ、ランタイムのソース、エクスポートしたゲームがリンクする vendored ライブラリは、すべてエディタに同梱されています。
 
+Incremental GC に対応するターゲットでは、dn2cpp を選ぶと **`dotnet/dn2cpp/incremental_gc`** が表示されます。既定は ON です。エクスポート後も、環境変数 **`DN2CPP_GC_INCREMENTAL=0|1`**、または Godot のユーザー引数 **`-- --dn2cpp-gc-incremental=0|1`** で起動ごとに上書きできます。優先順位は「起動引数 → 環境変数 → エクスポート設定」です。同じ起動引数を複数指定した場合は最後の有効値が使われ、不正な値は警告して無視されます。Web は Incremental GC に対応しないため設定が表示されず、これらの指定にかかわらず stop-the-world GC を使います。
+
 エディタ設定 → **`dotnet/export/dn2cpp_toolchain_path`** で別のツールチェーンレイアウトを指定できます。同梱のものではなく自分でビルドした dn2cpp を使用したい場合は、ここで指定します。同様に **`dotnet/export/dn2cpp_cmake_path`** と **`dotnet/export/dn2cpp_ninja_path`** で、同梱の cmake / ninja を自前のものに差し替えられます。
 
 ## エクスポートテンプレート

--- a/gates/build-and-run-godot-dotnet-handshake.sh
+++ b/gates/build-and-run-godot-dotnet-handshake.sh
@@ -95,38 +95,63 @@ chmod +x "$RUN/godot$EXE_EXT"
 mkdir -p "$RUN/data_DotnetSample_${GODOT_DOTNET_PLATFORM}_$ARCH"
 cp -f "$DYLIB" "$RUN/data_DotnetSample_${GODOT_DOTNET_PLATFORM}_$ARCH/DotnetSample.$LIB_EXT"
 
-echo "== 6/6 Running the handshake scene in the real engine =="
-LOG="$RUN/handshake.log"
-rc=0
-run_with_watchdog 120 env DN2CPP_DM_TRACE=1 "$PWD/$RUN/godot$EXE_EXT" --headless \
-    --quit-after 5 >"$LOG" 2>&1 || rc=$?
-cat "$LOG"
-if [ "$rc" -ne 0 ]; then
-    echo "FAIL: engine exited with $rc (137 = watchdog kill — a hung run)" >&2
-    exit 1
-fi
-# Positive markers: every init stage reached, and the engine's main loop drove
-# the wrapped FrameCallback at least once.
-for marker in \
-    "dn2cpp-dm: interop received" \
-    "dn2cpp-dm: managed callbacks written" \
-    "dn2cpp-dm: init ok" \
-    "dn2cpp-dm: frame"; do
-    grep -q "$marker" "$LOG" \
-        || { echo "FAIL: missing marker: $marker" >&2; exit 1; }
-done
-# Negative markers: the mono module must not have fallen over (it only logs and
-# keeps running, so these never affect the exit code).
-for bad in \
-    "GodotPlugins initialization failed" \
-    "Failed to load hostfxr" \
-    "ERROR" \
-    "SCRIPT ERROR" \
-    "ObjectDB instances leaked"; do
-    if grep -q "$bad" "$LOG"; then
-        echo "FAIL: log contains \"$bad\"" >&2
+echo "== 6/6 Running the handshake scene and GC startup-policy matrix =="
+# run_gc_mode TAG EXPECTED ENV_VALUE [USER_ARG ...] — run the same default-ON
+# .NET-module image with only startup inputs changed. Godot exposes arguments
+# after `--` through OS.get_cmdline_user_args(), which is the contract the
+# module reads before initializing the collector.
+run_gc_mode() {
+    local tag="$1" expected="$2" env_value="$3"
+    shift 3
+    local log="$RUN/handshake-$tag.log" rc=0 marker bad
+    local env_args=(env -u DN2CPP_GC_INCREMENTAL DN2CPP_DM_TRACE=1 DN2CPP_GC_STATS=1)
+    local game_args=("$PWD/$RUN/godot$EXE_EXT" --headless --quit-after 5)
+    [ -n "$env_value" ] && env_args+=("DN2CPP_GC_INCREMENTAL=$env_value")
+    if [ "$#" -gt 0 ]; then
+        game_args+=(-- "$@")
+    fi
+    run_with_watchdog 120 "${env_args[@]}" "${game_args[@]}" >"$log" 2>&1 || rc=$?
+    cat "$log"
+    if [ "$rc" -ne 0 ]; then
+        echo "FAIL: $tag engine run exited with $rc (137 = watchdog kill — a hung run)" >&2
         exit 1
     fi
-done
+    grep -qF "[dn2cpp] GC mode: $expected" "$log" \
+        || { echo "FAIL: $tag run did not report GC mode $expected" >&2; exit 1; }
+    # Positive markers: every init stage reached, and the engine's main loop
+    # drove the wrapped FrameCallback at least once.
+    for marker in \
+        "dn2cpp-dm: interop received" \
+        "dn2cpp-dm: managed callbacks written" \
+        "dn2cpp-dm: init ok" \
+        "dn2cpp-dm: frame"; do
+        grep -q "$marker" "$log" \
+            || { echo "FAIL: $tag run is missing marker: $marker" >&2; exit 1; }
+    done
+    # The mono module only logs initialization failures and keeps running, so
+    # an exit code alone is not an oracle.
+    for bad in \
+        "GodotPlugins initialization failed" \
+        "Failed to load hostfxr" \
+        "ERROR" \
+        "SCRIPT ERROR" \
+        "ObjectDB instances leaked"; do
+        if grep -q "$bad" "$log"; then
+            echo "FAIL: $tag log contains \"$bad\"" >&2
+            exit 1
+        fi
+    done
+}
+
+run_gc_mode default incremental ""
+run_gc_mode environment-off stop-the-world 0
+run_gc_mode argument-over-environment-on incremental 0 --dn2cpp-gc-incremental=1
+run_gc_mode argument-over-environment-off stop-the-world 1 --dn2cpp-gc-incremental=0
+run_gc_mode last-valid-argument-wins stop-the-world "" \
+    --dn2cpp-gc-incremental=1 --dn2cpp-gc-incremental=0
+run_gc_mode invalid-argument-falls-back stop-the-world 0 --dn2cpp-gc-incremental=invalid
+grep -qF "[dn2cpp] invalid --dn2cpp-gc-incremental value" \
+    "$RUN/handshake-invalid-argument-falls-back.log" \
+    || { echo "FAIL: invalid startup argument was ignored without a warning" >&2; exit 1; }
 gate_cache_commit
 echo "OK"

--- a/gates/build-and-run-godot-editor-export.sh
+++ b/gates/build-and-run-godot-editor-export.sh
@@ -32,11 +32,12 @@
 #      a desktop target compiles with a host clang++/cl.exe and can never be
 #      hermetic — so it is read out of the log instead, and it has to be read out
 #      of the log: a regression to the host's cmake builds the same game.
-#   3. The SECOND release export of a work dir works, and is incremental. 3/14 keeps the
-#      work dir deliberately — the persisting .godot/mono/dn2cpp/build tree is
-#      what stops a re-export recompiling the whole game — and every export a
-#      user performs after the first takes that path. 7/14 exports again and
-#      asserts the runtime was reused; 8/14 points that cache at another source
+#   3. Re-exporting a work dir works and is incremental. 3/14 keeps the work dir
+#      deliberately — the persisting .godot/mono/dn2cpp/build tree is what stops
+#      a re-export recompiling the whole runtime — and every export after the
+#      first takes that path. 7/14 flips the Incremental-GC preset OFF then ON in
+#      that same slot, asserting both the CMake cache and real runtime mode while
+#      the runtime archive is reused. 8/14 points the cache at another source
 #      tree (which is what a moved or re-pointed toolchain leaves behind) and
 #      asserts the export recovers, says so, and names both trees.
 #   4. On Windows, the debug field selects the independently built debug
@@ -328,6 +329,42 @@ if [ "$DN2CPP_OS" = linux ]; then
         || { echo "FAIL: could not set the Linux preset architecture to $ARCH" >&2; exit 1; }
 fi
 
+# The first export deliberately omits the setting: absence is the compatibility
+# case for existing presets and must select the documented default (ON).
+if awk -v preset="$PRESET" '
+    /^name=/ { selected = ($0 == "name=\"" preset "\"") }
+    selected && /^dotnet\/dn2cpp\/incremental_gc=/ { found = 1 }
+    END { exit found ? 0 : 1 }
+' "$PROJ/export_presets.cfg"; then
+    echo "FAIL: the fixture already spells dotnet/dn2cpp/incremental_gc; the first export" >&2
+    echo "      would no longer prove the default for an existing preset" >&2
+    exit 1
+fi
+
+# set_incremental_gc_preset VALUE — update only the active desktop preset. The
+# option is inserted next to export_backend on its first use, then rewritten in
+# place so OFF -> ON exercises one persistent CMake build slot.
+set_incremental_gc_preset() {
+    local value="$1" tmp
+    tmp="$(mktemp)"
+    awk -v preset="$PRESET" -v value="$value" '
+        /^name=/ { selected = ($0 == "name=\"" preset "\"") }
+        selected && /^dotnet\/dn2cpp\/incremental_gc=/ {
+            print "dotnet/dn2cpp/incremental_gc=" value
+            written = 1
+            next
+        }
+        { print }
+        selected && /^dotnet\/export_backend=/ && !written {
+            print "dotnet/dn2cpp/incremental_gc=" value
+            written = 1
+        }
+        END { exit written ? 0 : 1 }
+    ' "$PROJ/export_presets.cfg" > "$tmp" \
+        || { rm -f "$tmp"; echo "FAIL: could not set incremental GC on preset $PRESET" >&2; exit 1; }
+    mv "$tmp" "$PROJ/export_presets.cfg"
+}
+
 echo "== 4/14 Importing the project (fork editor, headless) =="
 # The first import may abort in editor doc-gen teardown (Godot headless bug,
 # harmless — the import data is already written), so tolerate a non-zero exit.
@@ -399,6 +436,7 @@ godot_fork_assert_bundled_buildtools "$OUT/export.log" "$EXPORTER_LOG" \
 # of a 40-line marker list is what drifts.
 assert_export_artifact_and_run() {
     local LOG="$1"
+    local expected_gc="${2:-incremental}"
     local DROPIN_NAME expected_staged staged rc n marker once bad
     DROPIN_NAME="$(basename "$DROPIN")"
     [ -f "$DROPIN" ] || { echo "FAIL: no drop-in library at $DROPIN" >&2; ls -R "$(dirname "$DATA_DIR")" >&2; exit 1; }
@@ -431,13 +469,16 @@ $WINDOWS_DEPENDENCY_NAME.dll"
     fi
 
     rc=0
-    run_with_watchdog 120 "$GAME_EXE" --headless --quit-after 900 \
+    run_with_watchdog 120 env -u DN2CPP_GC_INCREMENTAL DN2CPP_GC_STATS=1 \
+        "$GAME_EXE" --headless --quit-after 900 \
         >"$LOG" 2>&1 || rc=$?
     cat "$LOG"
     if [ "$rc" -ne 0 ]; then
         echo "FAIL: the exported game exited with $rc (137 = watchdog kill — a hung run)" >&2
         exit 1
     fi
+    grep -qF "[dn2cpp] GC mode: $expected_gc" "$LOG" \
+        || { echo "FAIL: exported game did not report GC mode $expected_gc" >&2; exit 1; }
     # The scripted node was constructed, tied to its native object (the scene's baked
     # Answer override arrived through the instance Set bridge), and driven by the
     # engine's main loop until it quit itself.
@@ -561,6 +602,17 @@ CMAKE_CACHE="$BUILD_DIR/CMakeCache.txt"
 [ -f "$CMAKE_CACHE" ] \
     || { echo "FAIL: no CMakeCache.txt in the build slot $BUILD_DIR" >&2; ls -la "$BUILD_DIR" >&2; exit 1; }
 
+assert_incremental_gc_cache() {
+    local expected="$1" actual
+    actual="$(sed -n 's/^DN2CPP_GC_INCREMENTAL_DEFAULT:BOOL=//p' "$CMAKE_CACHE")"
+    if [ "$actual" != "$expected" ]; then
+        echo "FAIL: persistent CMake cache has DN2CPP_GC_INCREMENTAL_DEFAULT=" \
+            "${actual:-<absent>}, expected $expected" >&2
+        exit 1
+    fi
+}
+assert_incremental_gc_cache ON
+
 # A host SDK newer than the export target otherwise becomes clang's implicit
 # deployment target. That makes the drop-in unloadable on systems the preset and
 # template still support, while a successful build says nothing about the drift.
@@ -617,14 +669,29 @@ if [ -z "$GC_LIB" ]; then
              exit 1; }
 fi
 
-echo "== 7/14 Incremental release re-export into the persisting build tree =="
-# A plain second --export-release, nothing broken: the runtime must be REUSED (the
-# GC library untouched) and the artifact must still work. An export that quietly
-# did nothing cannot satisfy that pair — assert_export_succeeded requires this
-# export's own log to carry all three dn2cpp stage markers, and
-# assert_export_artifact_and_run rebuilds nothing but runs what came out.
+echo "== 7/14 Re-exporting both GC defaults in the persisting build tree =="
+# Flip the preset OFF and back ON in the same slot. The exporter must explicitly
+# configure both values: relying on the CMake default would leave OFF cached on
+# the final export. The runtime archive remains reusable because this default is
+# compiled only into the app-specific .NET-module translation unit.
 GC_SIG_BEFORE=""
 [ -n "$GC_LIB" ] && GC_SIG_BEFORE="$(file_sig "$GC_LIB")"
+set_incremental_gc_preset false
+GC_OFF_LOG="$OUT/export-incremental-gc-off.log"
+rm -rf "$APP" "$DATA_DIR"
+if ! godot_export_step 1200 "$GC_OFF_LOG" "$APP" \
+    "$FORK_EDITOR" --headless \
+    --path "$PWD/$PROJ" --export-release "$PRESET" "$APP"; then
+    echo "FAIL: the incremental-GC-OFF re-export failed (see below)" >&2
+    cat "$GC_OFF_LOG" >&2
+    exit 1
+fi
+assert_export_succeeded "$GC_OFF_LOG" "the incremental-GC-OFF re-export"
+assert_incremental_gc_cache OFF
+godot_editor_export_layout "$APP"
+assert_export_artifact_and_run "$OUT/run-incremental-gc-off.log" stop-the-world
+
+set_incremental_gc_preset true
 REEXPORT_LOG="$OUT/export-incremental.log"
 rm -rf "$APP" "$DATA_DIR"
 if ! godot_export_step 1200 "$REEXPORT_LOG" "$APP" \
@@ -635,6 +702,7 @@ if ! godot_export_step 1200 "$REEXPORT_LOG" "$APP" \
     exit 1
 fi
 assert_export_succeeded "$REEXPORT_LOG" "the incremental re-export"
+assert_incremental_gc_cache ON
 if grep -qF "dn2cpp: stale build cache reset" "$REEXPORT_LOG"; then
     echo "FAIL: the re-export discarded a build cache that was still current — the" >&2
     echo "      staleness test now fires on an unchanged toolchain, so every export" >&2

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -107,6 +107,7 @@ option(DN2CPP_GODOT       "Build the Godot GDExtension runtime library"         
 option(DN2CPP_GDEXTENSION "Build the app (DN2CPP_APP_DIR) as a shared library"    OFF)
 option(DN2CPP_SHARED      "Build the app (DN2CPP_APP_DIR) as a plain shared library (no Godot runtime; exports the [UnmanagedCallersOnly] entry points)" OFF)
 option(DN2CPP_DOTNET_MODULE "Build the Godot .NET-module host runtime library, and the app (DN2CPP_APP_DIR) as a mono-module shared library" OFF)
+option(DN2CPP_GC_INCREMENTAL_DEFAULT "Default the .NET-module app to incremental GC" ON)
 set(DN2CPP_APP_DIR        ""    CACHE PATH     "Transpiler output dir to build into a final binary")
 set(DN2CPP_APP_NAME       "app" CACHE STRING   "Name of the app target (and of the output file in every lane but DN2CPP_GDEXTENSION)")
 set(DN2CPP_APP_LINK_FLAGS ""    CACHE STRING   "Extra link flags for the app (e.g. -L<dir>)")
@@ -1166,6 +1167,8 @@ if(DN2CPP_APP_DIR)
             _dn2cpp_add_dotnetmodule_target(dn2cpp::dn2cpp_runtime)
         endif()
         add_library(${DN2CPP_APP_NAME} SHARED ${DN2CPP_APP_SRCS})
+        target_compile_definitions(${DN2CPP_APP_NAME} PRIVATE
+            DN2CPP_GC_INCREMENTAL_DEFAULT=$<BOOL:${DN2CPP_GC_INCREMENTAL_DEFAULT}>)
         target_link_libraries(${DN2CPP_APP_NAME} PRIVATE dn2cpp::dn2cpp_runtime dn2cpp::dn2cpp_dotnetmodule)
         if(EMSCRIPTEN)
             # The drop-in as an Emscripten SIDE MODULE: the engine's web export

--- a/runtime/core/dn2cpp_core.h
+++ b/runtime/core/dn2cpp_core.h
@@ -2406,10 +2406,14 @@ inline void dn2cpp_main_abort()
 }
 // Set the default GC collection mode applied by dn2cpp_runtime_init when the
 // DN2CPP_GC_INCREMENTAL env override is unset. Console leaves the default (0 =
-// stop-the-world); the Godot GDExtension calls this with 1 before managed init so
-// real-time builds get bounded incremental pauses out of the box. Inert under
-// DN2CPP_NO_GC. Call before dn2cpp_runtime_init runs.
+// stop-the-world); Godot hosts select their export default before managed init.
+// Inert under DN2CPP_NO_GC. Call before dn2cpp_runtime_init runs.
 void dn2cpp_gc_set_incremental_default(int on);
+// Override the environment-resolved incremental mode for this process. Embedding
+// hosts use this for their own startup argument syntax; call before
+// dn2cpp_runtime_init. Passing 0 or 1 selects the mode, while any other value
+// clears the override. The platform's force-off policy still applies last.
+void dn2cpp_gc_set_incremental_startup_override(int on);
 // Default the collector to Apple self-roots mode (default off): disable Boehm's
 // dynamic-library scanning and register only the runtime image's __DATA as
 // static roots. The Godot hosts call this with 1 before managed init — a

--- a/runtime/core/dn2cpp_gc.cpp
+++ b/runtime/core/dn2cpp_gc.cpp
@@ -203,14 +203,21 @@ bool dn2cpp_env_bool(const char* name, bool def)
 // GC collection mode default. Console keeps the classic stop-the-world collector
 // (lowest overhead for batch/throughput work); the Godot GDExtension flips this to
 // Boehm's incremental mode for bounded frame pauses by calling the setter below
-// before managed init runs. Either default is overridable at runtime via
-// DN2CPP_GC_INCREMENTAL (see dn2cpp_runtime_init). Defined unconditionally so the
-// setter links even under DN2CPP_NO_GC (where it is simply inert).
+// before managed init runs. DN2CPP_GC_INCREMENTAL overrides that default, and an
+// embedding host's startup option overrides the environment (see
+// dn2cpp_runtime_init). Defined unconditionally so the setters link even under
+// DN2CPP_NO_GC (where they are simply inert).
 static int g_gc_incremental_default = 0;
+static int g_gc_incremental_startup_override = -1;
 
 void dn2cpp_gc_set_incremental_default(int on)
 {
     g_gc_incremental_default = on ? 1 : 0;
+}
+
+void dn2cpp_gc_set_incremental_startup_override(int on)
+{
+    g_gc_incremental_startup_override = on == 0 || on == 1 ? on : -1;
 }
 
 // Apple static-roots mode default. Off, a binary keeps Boehm's stock
@@ -508,12 +515,15 @@ void dn2cpp_runtime_init(Dn2CppCpuFeaturesInit initCpuFeatures)
     GC_REGISTER_DISPLACEMENT(3);
 
     // GC collection mode. The default comes from g_gc_incremental_default (console
-    // = stop-the-world, Godot = incremental); the env vars below override it at
-    // startup, so the same binary can switch modes without a rebuild:
+    // = stop-the-world, Godot = incremental); the environment overrides it, then
+    // an embedding host's startup option wins over both. The same binary can thus
+    // switch modes without a rebuild:
     //   DN2CPP_GC_INCREMENTAL=0/1  force incremental off / on (overrides the default)
     //   DN2CPP_GC_TIME_LIMIT_MS    per-increment pause target in ms (default 5)
     //   DN2CPP_GC_STATS            report the active mode now + a pause summary at exit
     bool incremental = dn2cpp_env_bool("DN2CPP_GC_INCREMENTAL", g_gc_incremental_default != 0);
+    if (g_gc_incremental_startup_override >= 0)
+        incremental = g_gc_incremental_startup_override != 0;
 #ifdef __EMSCRIPTEN__
     // wasm has no mprotect/signal VDB, so bdwgc would fall back to DEFAULT_VDB
     // (every page reported always-dirty) — the incremental machinery then costs

--- a/src/Dn2Cpp.DotnetModule/DotnetModuleBackend.cs
+++ b/src/Dn2Cpp.DotnetModule/DotnetModuleBackend.cs
@@ -128,6 +128,9 @@ internal sealed class DotnetModuleBackend : IEmitBackend
     private MethodInfo? _syncCtxCtor;
     private MethodInfo? _syncCtxExecute;
     private ClassInfo? _unmanagedCallbacks;
+    private ClassInfo? _nativeString;
+    private ClassInfo? _nativeStringName;
+    private ClassInfo? _nativePackedStringArray;
     private ClassInfo? _exceptionClass;
     private MethodInfo? _logException;
     private MethodInfo? _pushError;
@@ -187,6 +190,9 @@ internal sealed class DotnetModuleBackend : IEmitBackend
         // EmitEpilogue). Resolved here, with the other roots, so a missing/renamed
         // one fails at the same loud place they do rather than inside the emit.
         _unmanagedCallbacks = ResolveNestedStruct(c, NativeFuncsType, "UnmanagedCallbacks");
+        _nativeString = ResolveType(c, "Godot.NativeInterop.godot_string");
+        _nativeStringName = ResolveType(c, "Godot.NativeInterop.godot_string_name");
+        _nativePackedStringArray = ResolveType(c, "Godot.NativeInterop.godot_packed_string_array");
         // The ManagedCallbacks slot the emitted entry wraps (the per-frame
         // callback), resolved BY NAME from the model — the same structural
         // resolution UnmanagedCallbacks gets above — so a GodotSharp re-pin that
@@ -304,6 +310,16 @@ internal sealed class DotnetModuleBackend : IEmitBackend
                 "is the real GodotSharp.dll passed with -r?");
         return cls;
     }
+
+    private static ClassInfo ResolveType(Compilation c, string fullName)
+        => c.FindClassByFullName(fullName)
+            ?? throw new NotSupportedException(
+                $"--dotnet-module: type {fullName} not found — is the real GodotSharp.dll passed with -r?");
+
+    private static FieldInfo ResolveInstanceField(ClassInfo cls, string fieldName)
+        => cls.Fields.FirstOrDefault(f => !f.IsStatic && !f.IsLiteral && f.Name == fieldName)
+            ?? throw new NotSupportedException(
+                $"--dotnet-module: field {cls.FullName}.{fieldName} not found (GodotSharp shape changed?)");
 
     /// <summary>The 0-based ordinal of <paramref name="fieldName"/> among
     /// <paramref name="cls"/>'s instance fields — for a sequential-layout struct of
@@ -557,6 +573,21 @@ internal sealed class DotnetModuleBackend : IEmitBackend
         sb.AppendLine();
         var unmanagedCallbacks = _unmanagedCallbacks
             ?? throw new InvalidOperationException("AdditionalRootMethods did not run before EmitEpilogue");
+        var nativeString = _nativeString!;
+        var nativeStringName = _nativeStringName!;
+        var nativePackedStringArray = _nativePackedStringArray!;
+        string stringPtrField = ResolveInstanceField(nativeString, "_ptr").CppName;
+        string packedBufferField = ResolveInstanceField(nativePackedStringArray, "_ptr").CppName;
+        string methodBindGetField = ResolveInstanceField(unmanagedCallbacks, "godotsharp_method_bind_get_method").CppName;
+        string singletonField = ResolveInstanceField(unmanagedCallbacks, "godotsharp_engine_get_singleton").CppName;
+        string stringNewField = ResolveInstanceField(unmanagedCallbacks, "godotsharp_string_new_with_utf16_chars").CppName;
+        string stringNameNewField = ResolveInstanceField(unmanagedCallbacks, "godotsharp_string_name_new_from_string").CppName;
+        string ptrcallField = ResolveInstanceField(unmanagedCallbacks, "godotsharp_method_bind_ptrcall").CppName;
+        string stringSizeField = ResolveInstanceField(unmanagedCallbacks, "godotsharp_string_size").CppName;
+        string packedSizeField = ResolveInstanceField(unmanagedCallbacks, "godotsharp_packed_string_array_size").CppName;
+        string packedDestroyField = ResolveInstanceField(unmanagedCallbacks, "godotsharp_packed_string_array_destroy").CppName;
+        string stringDestroyField = ResolveInstanceField(unmanagedCallbacks, "godotsharp_string_destroy").CppName;
+        string stringNameDestroyField = ResolveInstanceField(unmanagedCallbacks, "godotsharp_string_name_destroy").CppName;
         // Both entries below are the drop-in's public surface: the engine dlopens the
         // library and dlsyms godotsharp_game_main_init out of it. The two toolchains
         // spell the export differently, and a bare __attribute__ fails to compile on
@@ -569,6 +600,75 @@ internal sealed class DotnetModuleBackend : IEmitBackend
         sb.AppendLine("#else");
         sb.AppendLine("#define DN2CPP_DM_EXPORT extern \"C\" __attribute__((visibility(\"default\")))");
         sb.AppendLine("#endif");
+        sb.AppendLine();
+        sb.AppendLine("#ifndef DN2CPP_GC_INCREMENTAL_DEFAULT");
+        sb.AppendLine("#define DN2CPP_GC_INCREMENTAL_DEFAULT 1");
+        sb.AppendLine("#endif");
+        sb.AppendLine();
+        sb.AppendLine("// Read Godot's user arguments before the managed runtime initializes. Every");
+        sb.AppendLine("// callback member and native value layout below comes from the loaded");
+        sb.AppendLine("// GodotSharp model; no engine table index or hand-written value size is baked in.");
+        sb.AppendLine("static void dn2cpp_dm_apply_gc_startup_argument(");
+        sb.AppendLine("    const void** __raw, int32_t __raw_size)");
+        sb.AppendLine("{");
+        sb.AppendLine($"    using __Callbacks = {unmanagedCallbacks.CppStructName};");
+        sb.AppendLine($"    using __String = {nativeString.CppStructName};");
+        sb.AppendLine($"    using __StringName = {nativeStringName.CppStructName};");
+        sb.AppendLine($"    using __PackedStrings = {nativePackedStringArray.CppStructName};");
+        sb.AppendLine($"    if (__raw == nullptr || __raw_size < (int32_t)(offsetof(__Callbacks, {packedSizeField}) + sizeof(void*)))");
+        sb.AppendLine("        return;");
+        sb.AppendLine("    const __Callbacks* __f = reinterpret_cast<const __Callbacks*>(__raw);");
+        sb.AppendLine($"    auto __string_new = reinterpret_cast<void (*)(__String*, const char16_t*)>(__f->{stringNewField});");
+        sb.AppendLine($"    auto __string_name_new = reinterpret_cast<void (*)(__StringName*, const __String*)>(__f->{stringNameNewField});");
+        sb.AppendLine($"    auto __method_bind_get = reinterpret_cast<void* (*)(const __StringName*, const __StringName*)>(__f->{methodBindGetField});");
+        sb.AppendLine($"    auto __singleton_get = reinterpret_cast<void* (*)(const __String*)>(__f->{singletonField});");
+        sb.AppendLine($"    auto __ptrcall = reinterpret_cast<void (*)(void*, void*, const void**, void*)>(__f->{ptrcallField});");
+        sb.AppendLine($"    auto __string_size = reinterpret_cast<int64_t (*)(const __String*)>(__f->{stringSizeField});");
+        sb.AppendLine($"    auto __packed_size = reinterpret_cast<int64_t (*)(const __PackedStrings*)>(__f->{packedSizeField});");
+        sb.AppendLine($"    auto __packed_destroy = reinterpret_cast<void (*)(__PackedStrings*)>(__f->{packedDestroyField});");
+        sb.AppendLine($"    auto __string_destroy = reinterpret_cast<void (*)(__String*)>(__f->{stringDestroyField});");
+        sb.AppendLine($"    auto __string_name_destroy = reinterpret_cast<void (*)(__StringName*)>(__f->{stringNameDestroyField});");
+        sb.AppendLine("    if (__string_new == nullptr || __string_name_new == nullptr || __method_bind_get == nullptr");
+        sb.AppendLine("        || __singleton_get == nullptr || __ptrcall == nullptr || __string_size == nullptr || __packed_size == nullptr");
+        sb.AppendLine("        || __packed_destroy == nullptr || __string_destroy == nullptr || __string_name_destroy == nullptr)");
+        sb.AppendLine("        return;");
+        sb.AppendLine("    __String __os_text{}, __method_text{};");
+        sb.AppendLine("    __StringName __os_name{}, __method_name{};");
+        sb.AppendLine("    __string_new(&__os_text, u\"OS\");");
+        sb.AppendLine("    __string_new(&__method_text, u\"get_cmdline_user_args\");");
+        sb.AppendLine("    __string_name_new(&__os_name, &__os_text);");
+        sb.AppendLine("    __string_name_new(&__method_name, &__method_text);");
+        sb.AppendLine("    void* __bind = __method_bind_get(&__os_name, &__method_name);");
+        sb.AppendLine("    void* __os = __singleton_get(&__os_text);");
+        sb.AppendLine("    if (__bind != nullptr && __os != nullptr) {");
+        sb.AppendLine("        __PackedStrings __args{};");
+        sb.AppendLine("        __ptrcall(__bind, __os, nullptr, &__args);");
+        sb.AppendLine("        int64_t __count = __packed_size(&__args);");
+        sb.AppendLine($"        const __String* __items = static_cast<const __String*>(__args.{packedBufferField});");
+        sb.AppendLine("        if (__items == nullptr) __count = 0;");
+        sb.AppendLine("        static constexpr char32_t __prefix[] = U\"--dn2cpp-gc-incremental=\";");
+        sb.AppendLine("        constexpr size_t __prefix_len = sizeof(__prefix) / sizeof(__prefix[0]) - 1;");
+        sb.AppendLine("        for (int64_t __i = 0; __i < __count; ++__i) {");
+        sb.AppendLine($"            const char32_t* __p = reinterpret_cast<const char32_t*>(__items[__i].{stringPtrField});");
+        sb.AppendLine("            if (__p == nullptr) continue;");
+        sb.AppendLine("            int64_t __size = __string_size(&__items[__i]);");
+        sb.AppendLine("            size_t __len = __size > 0 ? (size_t)(__size - 1) : 0;");
+        sb.AppendLine("            if (__len < __prefix_len) continue;");
+        sb.AppendLine("            size_t __j = 0;");
+        sb.AppendLine("            while (__j < __prefix_len && __p[__j] == __prefix[__j]) ++__j;");
+        sb.AppendLine("            if (__j != __prefix_len) continue;");
+        sb.AppendLine("            if (__len == __prefix_len + 1 && (__p[__j] == U'0' || __p[__j] == U'1'))");
+        sb.AppendLine("                dn2cpp_gc_set_incremental_startup_override(__p[__j] == U'1' ? 1 : 0);");
+        sb.AppendLine("            else");
+        sb.AppendLine("                std::fprintf(stderr, \"[dn2cpp] invalid --dn2cpp-gc-incremental value; expected 0 or 1\\n\");");
+        sb.AppendLine("        }");
+        sb.AppendLine("        __packed_destroy(&__args);");
+        sb.AppendLine("    }");
+        sb.AppendLine("    __string_name_destroy(&__method_name);");
+        sb.AppendLine("    __string_name_destroy(&__os_name);");
+        sb.AppendLine("    __string_destroy(&__method_text);");
+        sb.AppendLine("    __string_destroy(&__os_text);");
+        sb.AppendLine("}");
         sb.AppendLine();
         sb.AppendLine("// ---- interop-table size probe ----");
         sb.AppendLine("// The entry below hands interop_funcs_size_bytes to NativeFuncs.Initialize, which");
@@ -598,7 +698,8 @@ internal sealed class DotnetModuleBackend : IEmitBackend
         sb.AppendLine("    // and self-roots mode: a windowed engine process loads hundreds of system");
         sb.AppendLine("    // frameworks, which overflows Boehm's per-image root-set table (\"Too many");
         sb.AppendLine("    // root sets\" abort), so only our image's __DATA is registered.");
-        sb.AppendLine("    dn2cpp_gc_set_incremental_default(1);");
+        sb.AppendLine("    dn2cpp_gc_set_incremental_default(DN2CPP_GC_INCREMENTAL_DEFAULT);");
+        sb.AppendLine("    dn2cpp_dm_apply_gc_startup_argument(interop_funcs, interop_funcs_size_bytes);");
         sb.AppendLine("    dn2cpp_gc_set_manual_finalizer_drain(1);");
         sb.AppendLine("    dn2cpp_gc_set_self_roots_default(1);");
         sb.AppendLine("    // A game may hand [UnmanagedCallersOnly] function pointers to a native");


### PR DESCRIPTION
## 概要

- .NET-module アプリ向けに Incremental GC のエクスポート既定値を追加
- `DN2CPP_GC_INCREMENTAL` と Godot ユーザー引数による起動時上書きを実装
- 優先順位を「起動引数 → 環境変数 → エクスポート既定値」として固定
- Web では Incremental GC を常に無効化
- 優先順位、永続 CMake キャッシュ、実ランタイム動作の回帰ゲートと文書を更新

対応する Godot fork 変更: https://github.com/takuma-komatsu/godot-dn2cpp/pull/9

## 検証

- `dotnet build src/Dn2Cpp.Cli -c Release --no-restore -v:minimal`
- `./gates/build-and-run-godot-dotnet-lib.sh`
- `./gates/build-and-run-godot-dotnet-handshake.sh`
- `./gates/selfhost-emit.sh`
- `./gates/build-and-run-godot-editor-export.sh`
- `./gates/build-and-run-godot-editor-export-web.sh`
- `bash -n` および `git diff --check`