### PR TITLE
Add NativeAOT-style lazy P/Invoke resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -611,7 +611,9 @@ site rather than hiding it.
   lock-free for statically-emitted types.
 - **P/Invoke** — `DllImport` end to end: `string[]` write-back, delegates
   as native function pointers, non-blittable structs, blittable
-  `[MarshalAs(ByValArray)]`. The supported marshalling surface is
+  `[MarshalAs(ByValArray)]`. User imports bind lazily through
+  `DllImportResolver` and the platform loader; `--direct-pinvoke` is the
+  static-link opt-in. The supported marshalling surface is
   enumerated one feature per row in `docs/PINVOKE-MARSHALLING.md`.
 - **Stack traces** — captured at throw and rendered against the reflection
   method tables; the opt-in `--shadow-stack` adds emitter-baked frame names

--- a/docs/EDITOR-EXPORT-DESIGN.md
+++ b/docs/EDITOR-EXPORT-DESIGN.md
@@ -786,8 +786,10 @@ condition so an unstamped or differently stamped zip is relinked.
 
 ### The size levers this lane turns on — and the one it deliberately does not
 
-`Dn2CppExporter.BuildDropIn` adds exactly two flags for Web:
-`--trim-reflection` and `--trim-godot-classes`. Both target
+`Dn2CppExporter.BuildDropIn` adds three flags for Web: `--direct-pinvoke '*'`,
+`--trim-reflection` and `--trim-godot-classes`. The direct-import flag is required
+because an Emscripten side module has no general-purpose OS loader; all imports
+must remain visible to wasm-ld. The two trim flags target
 `__wasm_apply_data_relocs`, the single function wasm-ld emits with one store per
 pointer in static data, against V8's compiled-in 7,654,321-byte per-function
 ceiling. That is not an optimization: over the ceiling the module does not

--- a/docs/PINVOKE-MARSHALLING.md
+++ b/docs/PINVOKE-MARSHALLING.md
@@ -6,6 +6,19 @@ shapes below. Each row is a feature of the low-level interop surface, and the
 native side of every one of them is exercised by
 `samples/native/dn2cpptest/dn2cpptest.c`.
 
+User imports bind lazily on their first call. The declaring assembly's registered
+`DllImportResolver` runs first; a zero handle falls through to the platform loader,
+then the requested export is looked up. Concurrent unresolved callers may each run the
+resolver; the ABI-typed call site atomically publishes and caches a result for later
+calls. Direct IL calls to one imported MethodDef share a cache; its address-taken
+forwarder has the separate cache CoreCLR gives the delegate/function-pointer stub.
+`--direct-pinvoke <module[!entrypoint]>` keeps a
+selected import on the static-link path, and `--direct-pinvoke '*'` selects all
+imports for static-only targets. Framework imports retain their intrinsic/refusal
+boundary unless the runtime provides their module or a direct selector admits them.
+Matching is ordinal and exact. Only direct imports are written to `pinvoke-libs.txt`
+and `pinvoke-symbols.txt`.
+
 **The last column attributes each row to a bucket and a section, never to a gate
 script**: a gate name is what a fold retires, while the section name is what a fold
 carries over. Every section named below is a `.cs` file of the one
@@ -27,8 +40,8 @@ section and says the wrong thing about it.
 
 | Feature | Managed shape | Native shape | Notes | Asserted by (`PInvokeNative` section) |
 |---|---|---|---|---|
-| Marshalling envelope | blittable scalars (integer/float, IntPtr/UIntPtr, pointers, blittable-underlying enums) | precise native-ABI-width cast | The core envelope over system libc. | `PInvokeLibcSubset` (the libc arm, which binds no custom library), `PInvokeCustomLibSubset` |
-| Non-system library linking | `[DllImport("mylib")]` | the library's `extern "C"` symbol | Only adds the linking path; marshalling is the same envelope. | `PInvokeCustomLibSubset` |
+| Marshalling envelope | blittable scalars (integer/float, IntPtr/UIntPtr, pointers, blittable-underlying enums) | precise native-ABI-width cast | The core envelope over the platform C library. | `PInvokeLibcSubset` (whose resolver maps logical `libc` to the host's concrete C-library name), `PInvokeCustomLibSubset` |
+| Non-system library loading | `[DllImport("mylib")]` | the library's `extern "C"` symbol | Resolver-first lazy loading changes only binding; marshalling is the same envelope. | `PInvokeCustomLibSubset` |
 | Default/Ansi strings | `string` under default/Ansi/Auto CharSet | NUL-terminated buffer — host code page on Windows, UTF-8 on Unix | Managed→native in; a `string` return is decoded and its buffer freed (matching .NET's default marshaller). | `PInvokeStringSubset` |
 | Unicode strings | `string` under `CharSet.Unicode` | NUL-terminated UTF-16 (`LPWStr`) | Same in/return contract as the Ansi row. | `PInvokeWideStringSubset` |
 | Blittable arrays | `int[]`, `byte[]`, … | pointer to element 0 (pinned, no copy) | `[In]` reads and `[In,Out]` write-backs both hit the managed buffer; null array → null pointer. | `PInvokeArraySubset` |
@@ -69,12 +82,28 @@ asserts the transpile does too).
 
 Three further sections of the same bucket assert a P/Invoke **mechanism** rather
 than a marshalling shape, so they have no row: `PInvokeCrossAsmSubset` (imports
-declared by a *referenced* assembly, admitted only by `--pinvoke-module <name>`;
-the native gate's step 5 asserts the flagless transpile still refuses them),
+declared by a *referenced* assembly),
 `NativeImplSubset` (`[Dn2Cpp.Runtime.NativeImplementation]` substituting transpiled
 C# for an import at transpile time, so the library is never referenced or linked),
 and `PInvokeStackallocUtf8Subset` (a `stackalloc` UTF-8 buffer passed as a raw
 `byte*` — no marshaller runs at all; it rides the envelope row's pointer case).
+
+The separate `samples/dotnet/PInvokeDynamic` bucket keeps dynamic-only behavior
+off the WASM/static build of `PInvokeNative`. Its native exact diff covers resolver
+redirection, multicast invocation, method/assembly search-path values, declaring
+assembly identity, resolver counts across a synchronized concurrent first wave and
+later calls through distinct managed call sites, zero fallback, duplicate
+registration, resolver exception propagation, catchable missing-library/export
+failures, exact-path and assembly/name `NativeLibrary` loads, null handle/name
+validation, empty paths, and zero-handle `Free`.
+
+The `NativeLibrary` Assembly overloads validate the Assembly argument and use the
+same filename candidates and search-path policy as lazy `[DllImport]`. The default
+policy and `AssemblyDirectory` probe the transpiled executable's `AppContext` base
+directory first. On Windows, the remaining `DllImportSearchPath` values map to their
+corresponding `LOAD_LIBRARY_SEARCH_*` flags; other hosts ignore those Windows-only
+bits as CoreCLR does. Unknown flag bits raise `PlatformNotSupportedException` rather
+than silently selecting ordinary loader probing.
 
 A further section is in this bucket for the TARGET the bucket is built for rather
 than for P/Invoke at all: `SequentialSizeSubset` measures the size of a

--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -22,16 +22,22 @@ normal case. The two exceptions are about which *managed* code the target's Core
 contains, not about the target itself, and both live in
 `src/Dn2Cpp.Transpiler/Compilation.cs`:
 
-- `Compilation.IsRuntimeProvidedPInvokeModule` — the allow-list of native modules
-  whose `[DllImport]`s the runtime answers. A Windows-family target satisfies most
-  of the .NET PAL by admitting the OS import libraries here rather than by writing
-  C++ (§2.2).
+- `Compilation.IsRuntimeProvidedPInvokeModule` — the framework PAL modules whose
+  imports stay direct because the runtime or target OS provides their symbols.
+  User imports are resolver-first and lazy independently of this set. A
+  Windows-family target satisfies most of the .NET PAL by admitting the OS import
+  libraries here rather than by writing C++ (§2.2).
 - the intrinsic route for a P/Invoke module the new target's CoreLib flavour names
   and no existing one does (H6.2).
 
 Everything else is the **C++ runtime under `runtime/`**. It has three per-target
 surfaces, plus a fourth thing people forget: the files that branch on the target
 *outside* the platform directory.
+
+Dynamic loading is the default on Windows, Linux, macOS and Android. A static-only
+target must arrange for `--direct-pinvoke '*'` at its exporter boundary; individual
+static SDKs may instead select their module or exact `module!entrypoint`. Packaging
+remains explicit: resolver-computed filenames are not inferred as shared objects.
 
 ---
 

--- a/gates/_common.sh
+++ b/gates/_common.sh
@@ -2584,7 +2584,12 @@ _corelib_gate_core() {
             || { echo "error: requested reference $name not found beside the CoreLib: $bcl/$name.dll" >&2; return 1; }
         refs+=(-r "$bcl/$name.dll")
     done
-    invoke_cli "$_CG_APP" "${refs[@]}" -o "$out"
+    local target_args=()
+    if [ -n "${IOS_SIM:-}" ] || [ -n "${IOS_DEV:-}" ]; then
+        target_args=(--direct-pinvoke '*')
+    fi
+    invoke_cli "$_CG_APP" "${refs[@]}" \
+        ${target_args[@]+"${target_args[@]}"} -o "$out"
 }
 
 # _corelib_gate_check OUT CONTEXT [EXTRA_KEY_INPUT...] — gate_cache_check over the

--- a/gates/build-and-run-cri-android.sh
+++ b/gates/build-and-run-cri-android.sh
@@ -15,7 +15,7 @@
 # by explicit path: the package selects flavors strictly by RuntimeIdentifier
 # machinery, and a plain (host-RID) build resolves the desktop one. The
 # transpile itself is the cross-assembly P/Invoke opt-in end to end:
-# --pinvoke-module cri_atom lowers a referenced assembly's imports to direct
+# --direct-pinvoke cri_atom lowers a referenced assembly's imports to direct
 # native calls and lands the module in pinvoke-libs.txt, where the CMake app
 # link picks it up as -lcri_atom.
 #
@@ -208,7 +208,7 @@ EOF
 # MainScene stays the entry scene and keeps exercising its UI path. The
 # [dotnet] append re-opens the sample's existing section (Godot's ConfigFile
 # merges repeated headers) to add the fork exporter's knobs: extra_transpile_args
-# is how --pinvoke-module cri_atom reaches the editor-driven transpile, and
+# is how --direct-pinvoke cri_atom reaches the editor-driven transpile, and
 # extra_link_flags is how the CRI link inputs reach the drop-in link — the -L
 # pointing pinvoke-libs.txt's -lcri_atom at the package's android-arm64 native
 # directory, plus -lcri_ware_android_le for the engine library the facade only
@@ -228,7 +228,7 @@ AutoVerify="*res://script/AutoVerify.cs"
 
 [dotnet]
 
-dn2cpp/extra_transpile_args=PackedStringArray("--pinvoke-module", "cri_atom")
+dn2cpp/extra_transpile_args=PackedStringArray("--direct-pinvoke", "cri_atom")
 dn2cpp/extra_link_flags=PackedStringArray("-L$(godot_fork_native_path "$CRI_NATIVE_DIR")", "-lcri_ware_android_le")
 
 [editor_plugins]
@@ -317,7 +317,7 @@ dotnet/include_debug_symbols=false
 dotnet/export_backend=2
 EOF
 
-echo "== 3/6 Transpiling with --pinvoke-module cri_atom (android-flavor managed DLL) =="
+echo "== 3/6 Transpiling with --direct-pinvoke cri_atom (android-flavor managed DLL) =="
 build_proj src/Dn2Cpp.Cli/Dn2Cpp.Cli.csproj
 dotnet build "$PROJ/$PROJECT_NAME.csproj" -c ExportRelease --nologo -v q
 APPDIR="$PROJ/.godot/mono/temp/bin/ExportRelease"
@@ -347,7 +347,7 @@ invoke_cli "$APPDIR/$PROJECT_NAME.dll" --dotnet-module \
     -r "$APPDIR/CriWare.CriAtomLE.dll" \
     -r "$APPDIR/SampleExtensions.dll" \
     --auto-ref \
-    --pinvoke-module cri_atom \
+    --direct-pinvoke cri_atom \
     -o "$GEN"
 
 # The whole point of the opt-in: the module reaches the link manifest, where
@@ -496,7 +496,7 @@ if grep -q "ERROR: Export .NET Project" "$OUT/export.log"; then
     cat "$OUT/export.log" >&2
     exit 1
 fi
-for marker in "dn2cpp: extra transpile args (project setting): --pinvoke-module cri_atom" \
+for marker in "dn2cpp: extra transpile args (project setting): --direct-pinvoke cri_atom" \
               "dn2cpp: transpiling" "dn2cpp: compiling the drop-in library" "dn2cpp: staged"; do
     grep -qF "$marker" "$OUT/export.log" \
         || { echo "FAIL: marker \"$marker\" missing from the export log" >&2

--- a/gates/build-and-run-cri-wasm-smoke.sh
+++ b/gates/build-and-run-cri-wasm-smoke.sh
@@ -2,7 +2,7 @@
 # CRI ADX LE console-wasm link smoke: prove symbol resolution and the P/Invoke
 # path against the REAL CRI archives before any engine is involved. The
 # browser-flavor CriWare.CriAtomLE.dll is transpiled with
-# `--pinvoke-module cri_atom`, linked as a wasm MAIN module against
+# `--direct-pinvoke '*'`, linked as a wasm MAIN module against
 # runtimes/browser-wasm/{cri_atom.a, libcri_ware_le.a} plus the package's three
 # Emscripten JS libraries (a main module links jslibs directly — the .targets
 # recipe: --js-library ×3 + -sDEFAULT_LIBRARY_FUNCS_TO_INCLUDE=$dynCall), and
@@ -119,8 +119,8 @@ echo "== 2/6 Building app assembly (references the browser-flavor CRI DLL) =="
 build_proj "samples/dotnet/$PROJECT/$PROJECT.csproj"
 app="samples/dotnet/$PROJECT/bin/$CONFIG/$TFM/$PROJECT.dll"
 
-echo "== 3/6 Transpiling app + real CoreLib + CriWare.CriAtomLE (--pinvoke-module cri_atom) =="
-invoke_cli "$app" -r "$corelib" -r "$BROWSER_DLL" --pinvoke-module cri_atom -o "$OUT"
+echo "== 3/6 Transpiling app + real CoreLib + CriWare.CriAtomLE (--direct-pinvoke '*') =="
+invoke_cli "$app" -r "$corelib" -r "$BROWSER_DLL" --direct-pinvoke '*' -o "$OUT"
 grep -qx 'cri_atom' <<<"$(strip_cr_win_file "$OUT/pinvoke-libs.txt")" \
     || { echo "FAIL: cri_atom missing from $OUT/pinvoke-libs.txt" >&2; exit 1; }
 

--- a/gates/build-and-run-cri-web.sh
+++ b/gates/build-and-run-cri-web.sh
@@ -329,7 +329,7 @@ EOF
 # Registered as an autoload so no scene edit is needed; the sample's own
 # MainScene stays the entry scene. The [dotnet] append re-opens the sample's
 # existing section (Godot's ConfigFile merges repeated headers) to add the fork
-# exporter's knob: extra_transpile_args is how --pinvoke-module cri_atom
+# exporter's knob: extra_transpile_args is how --direct-pinvoke cri_atom
 # reaches the editor-driven transpile. No link knobs, on purpose — the side
 # module must NOT link the (non-PIC) CRI archives; the template's main module
 # carries them (see the header).
@@ -341,7 +341,7 @@ AutoVerify="*res://script/AutoVerify.cs"
 
 [dotnet]
 
-dn2cpp/extra_transpile_args=PackedStringArray("--pinvoke-module", "cri_atom")
+dn2cpp/extra_transpile_args=PackedStringArray("--direct-pinvoke", "cri_atom")
 EOF
 
 # The export preset: the Web dlink preset against dotnet/export_backend = 2
@@ -392,7 +392,7 @@ dotnet/embed_build_outputs=false
 dotnet/export_backend=2
 EOF
 
-echo "== 3/6 Transpiling with --pinvoke-module cri_atom (browser-flavor managed DLL) =="
+echo "== 3/6 Transpiling with --direct-pinvoke cri_atom (browser-flavor managed DLL) =="
 build_proj src/Dn2Cpp.Cli/Dn2Cpp.Cli.csproj
 dotnet build "$PROJ/$PROJECT_NAME.csproj" -c ExportRelease --nologo -v q
 APPDIR="$PROJ/.godot/mono/temp/bin/ExportRelease"
@@ -419,7 +419,7 @@ invoke_cli "$APPDIR/$PROJECT_NAME.dll" --dotnet-module \
     -r "$APPDIR/CriWare.CriAtomLE.dll" \
     -r "$APPDIR/SampleExtensions.dll" \
     --auto-ref \
-    --pinvoke-module cri_atom \
+    --direct-pinvoke cri_atom \
     -o "$GEN"
 
 # The opt-in's manifest half: the module reaches pinvoke-libs.txt. On this
@@ -489,7 +489,7 @@ if grep -q "ERROR: Export .NET Project" "$OUT/export.log"; then
     cat "$OUT/export.log" >&2
     exit 1
 fi
-for marker in "dn2cpp: extra transpile args (project setting): --pinvoke-module cri_atom" \
+for marker in "dn2cpp: extra transpile args (project setting): --direct-pinvoke cri_atom" \
               "dn2cpp: transpiling" "dn2cpp: compiling the drop-in library" "dn2cpp: staged"; do
     grep -qF "$marker" "$OUT/export.log" \
         || { echo "FAIL: marker \"$marker\" missing from the export log" >&2

--- a/gates/build-and-run-file-real.sh
+++ b/gates/build-and-run-file-real.sh
@@ -38,12 +38,10 @@
 #                       ProcessName/StartTime/MainModule; those lower to the
 #                       always-linked libSystem, so step 6 asserts no libproc row
 #                       is reported bounded.
-#   BoundedImportSubset both ends of the per-row bounded-import verdict, at RUN
-#                       time: a LOUD row (NativeLibrary.Load) must throw a catchable
-#                       exception naming the module, a SILENT one
-#                       (Debugger.IsAttached) must keep answering its default. Both
-#                       lines are written to diff identically against real .NET even
-#                       though the two hosts fail differently — see the file. Plus
+#   BoundedImportSubset the implemented dynamic loader and a bounded import at RUN
+#                       time: NativeLibrary.Load must throw DllNotFoundException for
+#                       a missing path, while the SILENT Debugger.IsAttached row keeps
+#                       answering its truthful default. Plus
 #                       the bound's OTHER mouth: an import reached as a METHOD
 #                       GROUP rather than called, which is why this gate's
 #                       transpile carries a --cut (see step 3) and why step 6
@@ -358,7 +356,7 @@ invoke_cli "$app" -r "$corelib" \
 tail -10 "$bounded_measure.log"
 bounded_tsv="$bounded_measure/s0-bounded-imports.tsv"
 
-# ---- The host-independent half: the two QCall rows BoundedImportSubset reaches ----
+# ---- The host-independent bounded imports BoundedImportSubset reaches ----
 # These are in CoreLib, which every host has, so this arm carries the verdict assert
 # and the Darwin arm below only adds libproc — keeping the verdict column off a
 # Darwin-only path. The "report is silent at zero" negative control lives in
@@ -374,15 +372,10 @@ bad_cols=${bad_cols%%$'\n'*}
     echo "FAIL: $bounded_tsv has a row without exactly 4 columns (module/entry/method/verdict):" >&2
     printf '%s\n' "$bad_cols" >&2
     exit 1; }
-# The LOUD row. NativeLibrary.Load's QCall: real .NET throws DllNotFoundException from
-# the native side, dn2cpp cannot load anything at run time at all, and its zero handle
-# is checked by nobody (measured — neither Load(string) nor the LoadFromPath
-# marshalling wrapper contains a throw opcode). Asserting the verdict WORD, not just
-# the row: a regression to `silent` keeps the row and loses the whole point.
-[ -n "$(awk -F'\t' '$2 == "NativeLibrary_LoadFromPath" && $4 == "throws"' "$bounded_tsv")" ] || {
-    echo "FAIL: $bounded_tsv carries no throwing NativeLibrary_LoadFromPath row — either" >&2
-    echo "      BoundedImportSubset stopped reaching NativeLibrary.Load, or its verdict" >&2
-    echo "      went back to silent (which step 4's diff would also have caught)" >&2
+# NativeLibrary.Load is no longer a bounded QCall. It is implemented by the
+# platform loader and must not appear in this report.
+[ -z "$(awk -F'\t' '$2 ~ /^NativeLibrary_Load/' "$bounded_tsv")" ] || {
+    echo "FAIL: NativeLibrary.Load regressed to a bounded QCall" >&2
     cat "$bounded_tsv" >&2
     exit 1; }
 # The SILENT row, asserted just as hard: `false` is the correct answer for a managed
@@ -394,16 +387,13 @@ bad_cols=${bad_cols%%$'\n'*}
     exit 1; }
 # The ordinary path says the same thing in one line, and the split is what a reader
 # acts on: "N bounded" alone does not say whether their program will throw.
-grep -qE '^dn2cpp: [0-9]+ native imports bounded \(.*QCall.*\) — [1-9][0-9]* throw PlatformNotSupportedException naming the module, [0-9]+ answer 0/null silently.*pass --verbose to name them$' \
+grep -qE '^dn2cpp: [0-9]+ native imports bounded \(.*\) — 0 throw PlatformNotSupportedException naming the module, [1-9][0-9]* answer 0/null silently.*pass --verbose to name them$' \
     "$transpile_log" || {
     echo "FAIL: the ordinary transpile's bounded-import line does not carry the throwing/silent split" >&2
     grep -n 'native imports bounded' "$transpile_log" >&2 || echo "      (no such line at all)" >&2
     exit 1; }
-grep -qE -- '-- native imports bounded: [0-9]+ \([1-9][0-9]* throwing, [0-9]+ silent\) --' "$bounded_measure.log" || {
+grep -qE -- '-- native imports bounded: [0-9]+ \(0 throwing, [1-9][0-9]* silent\) --' "$bounded_measure.log" || {
     echo "FAIL: the --measure summary does not carry the bounded-import count and split beside the gap histograms" >&2
-    exit 1; }
-grep -q 'NativeLibrary_LoadFromPath.*\[throws\]' "$bounded_measure.log" || {
-    echo "FAIL: --verbose did not name the bounded imports (with verdicts) in the --measure summary" >&2
     exit 1; }
 
 # ---- libproc must be ABSENT from the report, on every host ----
@@ -437,20 +427,19 @@ if grep -q 'libproc' "$transpile_log"; then
     grep -n 'libproc' "$transpile_log" >&2
     exit 1
 fi
-# Three rows exactly: the two QCalls — the substituted set is precisely the calls into
-# a CoreCLR a transpiled image does not have — plus the one this gate MANUFACTURES
+# Two rows exactly: the Debugger QCall plus the one this gate MANUFACTURES
 # with step 3's --cut, whose whole purpose is to be reached as a method group and by
 # nothing else (asserted row by row below). An extra row is not necessarily wrong, but
 # it is always a decision somebody made, and this is where it gets noticed. The count
 # is host-independent: the cut module and both QCalls are named by CoreLib.
 bounded_row_count=$(grep -c . "$bounded_tsv" || true)
-[ "${bounded_row_count:-0}" -eq 3 ] || {
-    echo "FAIL: $bounded_tsv has ${bounded_row_count:-0} rows, want 3 (the two QCalls" >&2
-    echo "      BoundedImportSubset reaches, plus step 3's --cut method-group import)" >&2
+[ "${bounded_row_count:-0}" -eq 2 ] || {
+    echo "FAIL: $bounded_tsv has ${bounded_row_count:-0} rows, want 2 (the Debugger QCall" >&2
+    echo "      plus step 3's --cut method-group import)" >&2
     cat "$bounded_tsv" >&2
     exit 1; }
-echo "OK: 3 imports reported with verdicts — QCall NativeLibrary_LoadFromPath throws,"
-echo "    QCall Debugger silent, the --cut dn2cpp-absent-module silent (reached only"
+echo "OK: 2 imports reported with verdicts — QCall Debugger silent and the --cut"
+echo "    dn2cpp-absent-module silent (reached only"
 echo "    as a method group); no libproc row on any host"
 
 # ---- The bound's OTHER mouth: an import reached as a METHOD GROUP ----

--- a/gates/build-and-run-godot-dotnet-wasm.sh
+++ b/gates/build-and-run-godot-dotnet-wasm.sh
@@ -98,7 +98,8 @@ echo "== 2/7 Transpiling (--dotnet-module --trim-reflection, real GodotSharp + n
 build_proj src/Dn2Cpp.Cli/Dn2Cpp.Cli.csproj
 CORELIB=$(resolve_net10_corelib)
 rm -rf "$OUT"
-invoke_cli "$APP" --dotnet-module -r "$CORELIB" -r "$GODOT_DOTNET_GODOTSHARP" --auto-ref --trim-reflection -o "$OUT"
+invoke_cli "$APP" --dotnet-module -r "$CORELIB" -r "$GODOT_DOTNET_GODOTSHARP" \
+    --auto-ref --trim-reflection --direct-pinvoke '*' -o "$OUT"
 
 # That premise, as a tripwire — and it sits above the cache check so it is asserted
 # on a warm hit too. Manifest-resource blobs are carried only when an emitted body

--- a/gates/build-and-run-godot-editor-export-web-hermetic.sh
+++ b/gates/build-and-run-godot-editor-export-web-hermetic.sh
@@ -316,6 +316,23 @@ grep -qF "using the prebuilt runtime" "$EXPORTER_LOG" || {
     echo "FAIL: the Web slot did not import the bundle's prebuilt runtime ($EXPORTER_LOG)" >&2
     grep -i "prebuilt" "$EXPORTER_LOG" >&2 || echo "  (the configure said nothing about a prebuilt at all)" >&2
     exit 1; }
+# Command records start with `$` and join argv with spaces. These two option
+# tokens contain no whitespace, so require them as adjacent fields on the same
+# --dotnet-module record; an unrelated transcript mention cannot satisfy this.
+awk '
+    $1 == "$" {
+        transpile = direct_all = 0
+        for (i = 2; i <= NF; i++) {
+            if ($i == "--dotnet-module") transpile = 1
+            if (i < NF && $i == "--direct-pinvoke" && $(i + 1) == "*") direct_all = 1
+        }
+        if (transpile && direct_all) found = 1
+    }
+    END { exit found ? 0 : 1 }
+' "$EXPORTER_LOG" || {
+    echo "FAIL: the Web transpiler invocation lacks the literal '--direct-pinvoke *' argv pair" >&2
+    grep -F -- '--dotnet-module' "$EXPORTER_LOG" >&2 || true
+    exit 1; }
 
 # Which cmake and ninja it configured through. There is no other candidate on
 # this PATH, so a bundle short either would have died above — what this catches

--- a/gates/build-and-run-godot-editor-export-web.sh
+++ b/gates/build-and-run-godot-editor-export-web.sh
@@ -313,6 +313,23 @@ grep -qF "using the prebuilt runtime" "$EXPORTER_LOG" || {
     echo "FAIL: the Web slot did not import the bundle's prebuilt runtime ($EXPORTER_LOG)" >&2
     grep -i "prebuilt" "$EXPORTER_LOG" >&2 || echo "  (the configure said nothing about a prebuilt at all)" >&2
     exit 1; }
+# Command records start with `$` and join argv with spaces. These two option
+# tokens contain no whitespace, so require them as adjacent fields on the same
+# --dotnet-module record; an unrelated transcript mention cannot satisfy this.
+awk '
+    $1 == "$" {
+        transpile = direct_all = 0
+        for (i = 2; i <= NF; i++) {
+            if ($i == "--dotnet-module") transpile = 1
+            if (i < NF && $i == "--direct-pinvoke" && $(i + 1) == "*") direct_all = 1
+        }
+        if (transpile && direct_all) found = 1
+    }
+    END { exit found ? 0 : 1 }
+' "$EXPORTER_LOG" || {
+    echo "FAIL: the Web transpiler invocation lacks the literal '--direct-pinvoke *' argv pair" >&2
+    grep -F -- '--dotnet-module' "$EXPORTER_LOG" >&2 || true
+    exit 1; }
 # And it compiled through the SDK inside that bundle, not one this host happens to
 # carry. Nothing downstream can tell the two apart -- a host SDK of the same
 # version produces the same artifacts -- so a bundle that quietly stopped shipping

--- a/gates/build-and-run-godot-editor-export.sh
+++ b/gates/build-and-run-godot-editor-export.sh
@@ -247,7 +247,7 @@ if [ "$DN2CPP_OS" = windows ]; then
     awk -v dependency="$WINDOWS_DEPENDENCY_NAME" '
         { print }
         $0 == "project/assembly_name=\"EditorExportSample\"" {
-            print "dn2cpp/extra_transpile_args=PackedStringArray(\"--pinvoke-module\", \"" dependency "\")"
+            print "dn2cpp/extra_transpile_args=PackedStringArray(\"--direct-pinvoke\", \"" dependency "\")"
             print "dn2cpp/extra_link_libs=PackedStringArray(\"res://native/" dependency ".lib\")"
             print "dn2cpp/extra_shared_objects=PackedStringArray(\"res://native/" dependency ".dll\")"
         }

--- a/gates/build-and-run-godot-ios-export.sh
+++ b/gates/build-and-run-godot-ios-export.sh
@@ -50,7 +50,7 @@ invoke_cli \
     "samples/godot/GodotSample/bin/$CONFIG/$TFM/GodotSample.dll" \
     -r "samples/godot/GodotSample/bin/$CONFIG/$TFM/GodotSharp.dll" \
     -r "$corelib" \
-    -o "$OUT" --gdextension
+    -o "$OUT" --gdextension --direct-pinvoke '*'
 
 # Cache: beyond the generated output + inputs, the exported Xcode project also
 # depends on the Xcode toolchain, the iOS SDK, and the Godot iOS export

--- a/gates/build-and-run-godot-ios-sim.sh
+++ b/gates/build-and-run-godot-ios-sim.sh
@@ -78,7 +78,7 @@ invoke_cli \
     "samples/godot/GodotSample/bin/$CONFIG/$TFM/GodotSample.dll" \
     -r "samples/godot/GodotSample/bin/$CONFIG/$TFM/GodotSharp.dll" \
     -r "$corelib" \
-    -o "$OUT" --gdextension
+    -o "$OUT" --gdextension --direct-pinvoke '*'
 
 # Cache: beyond the generated output + inputs, the simulator run also depends
 # on the Xcode toolchain, the iOS SDK, and the Godot iOS export template, so

--- a/gates/build-and-run-magiconion-yetanotherhttphandler.sh
+++ b/gates/build-and-run-magiconion-yetanotherhttphandler.sh
@@ -66,7 +66,7 @@ build_proj src/Dn2Cpp.Cli/Dn2Cpp.Cli.csproj
 refs=(-r "$corelib" -r "$YAHA_MANAGED" -r "$YAHA_PIPELINES" "${package_refs[@]}")
 rm -rf "$OUT"
 ( export DN2CPP_MAX_INSTANTIATIONS=30000
-  invoke_cli "$app" "${refs[@]}" --auto-ref --pinvoke-module "$YAHA_MODULE" \
+  invoke_cli "$app" "${refs[@]}" --auto-ref --direct-pinvoke "$YAHA_MODULE" \
       --max-heap-mb 1024 -o "$OUT" )
 native_link_manifest=$(native_path "$PWD/$YAHA_NATIVE")
 printf '%s\n' "$native_link_manifest" > "$OUT/native-assets.txt"
@@ -79,7 +79,7 @@ echo "== 4/7 ASSERT: combined closure is gap-free and uses the generated proxy =
 rm -rf "$MEASURE"
 measure_output=$( \
     export DN2CPP_MAX_INSTANTIATIONS=30000
-    invoke_cli "$app" "${refs[@]}" --auto-ref --pinvoke-module "$YAHA_MODULE" \
+    invoke_cli "$app" "${refs[@]}" --auto-ref --direct-pinvoke "$YAHA_MODULE" \
         --max-heap-mb 1024 --measure -o "$MEASURE" 2>&1 )
 printf '%s\n' "$measure_output"
 [ -f "$MEASURE/s0-gaps.tsv" ] || { echo "FAIL: combined --measure produced no gap report" >&2; exit 1; }

--- a/gates/build-and-run-native-asset-publish.sh
+++ b/gates/build-and-run-native-asset-publish.sh
@@ -209,10 +209,10 @@ if [ "$DN2CPP_OS:$(uname -m)" = macos:arm64 ]; then
 fi
 
 echo "== 3/6 Publishing through Dn2Cpp.Build =="
-PINVOKE_ARGS="--auto-ref --pinvoke-module dn2cpp_native_asset"
+PINVOKE_ARGS="--auto-ref --direct-pinvoke dn2cpp_native_asset"
 PUBLISH_ARGS=()
 if [ -n "$SHARED_LIB" ]; then
-    PINVOKE_ARGS="$PINVOKE_ARGS --pinvoke-module dn2cpp_shared_asset"
+    PINVOKE_ARGS="$PINVOKE_ARGS --direct-pinvoke dn2cpp_shared_asset"
     PUBLISH_ARGS+=("-p:DefineConstants=NATIVE_ASSET_SHARED")
 fi
 PUBLISH="$FIXTURE/App/bin/$CONFIG/$TFM/$RID/publish"

--- a/gates/build-and-run-pinvoke-native.sh
+++ b/gates/build-and-run-pinvoke-native.sh
@@ -6,9 +6,9 @@
 # in/out, bool marshalling, byref strings, char & wide-char/string marshalling,
 # string & StringBuilder, [StructLayout] structs, GetLastWin32Error, custom-lib
 # linking, runtime-primitive interop, and cross-assembly P/Invoke: the
-# PInvokeRefLib reference assembly declares its own [DllImport("dn2cpptest")]s,
-# admitted by `--pinvoke-module dn2cpptest` — with a negative arm asserting the
-# flagless transpile still refuses them (the opt-in stays an opt-in), and a
+# PInvokeRefLib reference assembly declares its own [DllImport("dn2cpptest")]s.
+# Both app and referenced-assembly imports use resolver/OS-loader lazy binding;
+# neither contributes a static link manifest. A
 # second negative arm (step 6) asserting a struct whose field carries
 # a [MarshalAs] descriptor the struct marshaller does not implement (ByValTStr)
 # REFUSES at transpile, naming the field — the shape used to cross as a pointer
@@ -23,11 +23,10 @@
 # verdict rather than citing a measurement.
 #
 # Also the system-libc section (PInvokeLibcSubset, folded in from its own gate):
-# [DllImport] into always-linked libc/libSystem with blittable primitives,
-# pointers and an ASCII string. Each pinvokeimpl method lowers to a direct native
-# call into an extern "C" entry point declared once by the emitter (aliased via an
-# asm label so it never collides with the libc prototype the runtime header already
-# includes).
+# [DllImport] into libc/libSystem with blittable primitives, pointers and an ASCII
+# string. These user declarations take the same resolver-first lazy path as every
+# other app import; their resolver maps the logical `libc` name to the host's
+# concrete C-library filename. CoreLib PAL declarations remain direct runtime calls.
 # Covers int/long integer returns (abs/llabs), a double return (atof/strtod — NOT
 # sqrt/pow/floor/ceil, which glibc keeps in libm, not libc.so.6; the double ARGUMENT
 # crossing is PInvokeCustomLibSubset's), implicit vs explicit EntryPoint, a
@@ -35,16 +34,12 @@
 # (strtod's end), and a void* (pointer) return aliasing its destination (memset) plus
 # a pointer == pointer compare. That section used to assert a hard-coded expected
 # string; folded here it is exact-diffed against real .NET instead. Its own
-# DllImportResolver redirects `libc` onto ucrtbase.dll on Windows, where the
-# platform C library carries those symbols under a name no default probe reaches —
-# the ORACLE needs it; the transpiled binary link-resolves them and drops it.
+# DllImportResolver redirects `libc` onto ucrtbase.dll, libc.so.6 or
+# libSystem.B.dylib. A bare `libc` is not a portable loader name.
 #
-# It adds NOTHING to this gate's link setup, which is why it can live here: `libc`
-# is in Compilation.IsRuntimeProvidedPInvokeModule, so the transpile admits it with
-# no --pinvoke-module opt-in, and the emitter writes no link token for a
-# runtime-provided module — the retired gate's own pinvoke-libs.txt was empty, and
-# this gate's still reads `dn2cpptest` alone. The -L/-rpath machinery below is the
-# custom library's and stays untouched.
+# It adds nothing to this gate's link setup, which is why it can live here: the OS
+# loader supplies libc and the lazy import writes no link token. The -L / loader-path
+# machinery below is only for the custom test library.
 #
 # Former gates: pinvoke-{array,bool,byrefstring,char,customlib,lasterror,string,
 # stringbuilder,struct,widechararray,widestring}, runtime-prim, pinvoke-libc-subset.
@@ -103,31 +98,24 @@ build_proj "samples/dotnet/$PROJECT/$PROJECT.csproj"
 app="samples/dotnet/$PROJECT/bin/$CONFIG/$TFM/$PROJECT.dll"
 reflib="samples/dotnet/$PROJECT/bin/$CONFIG/$TFM/PInvokeRefLib.dll"
 
-echo "== 4/11 Transpiling app + real CoreLib + PInvokeRefLib (--pinvoke-module dn2cpptest) =="
-invoke_cli "$app" -r "$corelib" -r "$reflib" --pinvoke-module dn2cpptest -o "$OUT"
+echo "== 4/11 Transpiling app + real CoreLib + PInvokeRefLib (lazy P/Invoke) =="
+invoke_cli "$app" -r "$corelib" -r "$reflib" -o "$OUT"
 
-echo "== 5/11 Asserting the flagless transpile refuses the cross-assembly import =="
-# Deliberately NOT cached, and BEFORE the cache gate (the trim-reflection
-# typo-arm doctrine): the refusal leaves no output surface to key on, and the
-# regression this arm pins — a referenced module's [DllImport] lowering without
-# the opt-in (say, its module name hardcoded into IsRuntimeProvidedPInvokeModule)
-# — leaves the POSITIVE transpile's bytes identical, so a warm cache would
-# replay green right over it. Re-running the ~seconds transpile every time is
-# the insurance that keeps the opt-in an opt-in.
-NEG_OUT="artifacts/pinvokenative-noflag"
-rm -rf "$NEG_OUT"
-set +e
-neg_err=$(invoke_cli "$app" -r "$corelib" -r "$reflib" -o "$NEG_OUT" 2>&1)
-neg_code=$?
-set -e
-printf '%s\n' "$neg_err" | tail -2
-if [ "$neg_code" -ne 2 ]; then
-    echo "FAIL: flagless cross-assembly [DllImport] transpile exited $neg_code (want 2: the no-IL-body refusal)" >&2
-    exit 1
-fi
-grep -q "error: .*PInvokeRefLib.*dn2cpptest_.*no IL body and no intrinsic mapping" <<<"$neg_err" \
-    || { echo "FAIL: the refusal did not name the cross-assembly import" >&2; exit 1; }
-echo "flagless refusal OK: exit 2, named the cross-assembly import"
+echo "== 5/11 Asserting lazy imports stay out of the static link manifests =="
+[ ! -e "$OUT/pinvoke-libs.txt" ] \
+    || { echo "FAIL: lazy imports emitted pinvoke-libs.txt" >&2; exit 1; }
+[ ! -e "$OUT/pinvoke-symbols.txt" ] \
+    || { echo "FAIL: lazy imports emitted pinvoke-symbols.txt" >&2; exit 1; }
+
+# Entry-point selectors are ordinal metadata matches. Only the selected symbol
+# enters the static manifests; other imports of the same module stay lazy.
+DIRECT_SELECTOR_OUT="artifacts/pinvokenative-direct-selector"
+invoke_cli "$app" -r "$corelib" -r "$reflib" \
+    --direct-pinvoke 'dn2cpptest!dn2cpptest_add' -o "$DIRECT_SELECTOR_OUT"
+[ "$(tr -d '\r' < "$DIRECT_SELECTOR_OUT/pinvoke-libs.txt")" = 'dn2cpptest' ] \
+    || { echo "FAIL: entry-point selector emitted the wrong library manifest" >&2; exit 1; }
+[ "$(tr -d '\r' < "$DIRECT_SELECTOR_OUT/pinvoke-symbols.txt")" = $'dn2cpptest\tdn2cpptest_add' ] \
+    || { echo "FAIL: entry-point selector emitted symbols beyond its exact match" >&2; exit 1; }
 
 echo "== 6/11 Asserting the ByValTStr struct-field crossing refuses at transpile =="
 # SUBJECT: the P/Invoke STRUCT-FIELD [MarshalAs] descriptor gate
@@ -253,6 +241,64 @@ grep -q "error: .*DescribedEnum.*'T' carries \[MarshalAs(UnmanagedType.Struct)\]
     || { echo "FAIL: the refusal did not name the field and its Struct descriptor" >&2; printf '%s\n' "$sd_err" | tail -3 >&2; exit 1; }
 echo "Struct-on-enum crossing refusal OK: exit 2, named the field and descriptor"
 
+echo "== asserting an unmodelled framework QCall stays behind the refusal boundary =="
+build_proj samples/dotnet/PInvokeFrameworkQCallBad/PInvokeFrameworkQCallBad.csproj
+qcall_app="samples/dotnet/PInvokeFrameworkQCallBad/bin/$CONFIG/$TFM/System.PInvokeFrameworkQCallBad.dll"
+QCALL_OUT="artifacts/pinvokenative-framework-qcall-neg"
+rm -rf "$QCALL_OUT"
+qcall_rc=0
+qcall_err=$(invoke_cli "$qcall_app" -r "$corelib" -o "$QCALL_OUT" 2>&1) || qcall_rc=$?
+if [ "$qcall_rc" -ne 2 ]; then
+    echo "FAIL: an unmodelled framework QCall transpiled with exit $qcall_rc (want 2)" >&2
+    printf '%s\n' "$qcall_err" | tail -3 >&2
+    exit 1
+fi
+grep -q "error: .*PInvokeFrameworkQCallBad.*Probe.*no IL body and no intrinsic mapping" <<<"$qcall_err" \
+    || { echo "FAIL: the framework-QCall refusal did not name the unmodelled method" >&2; printf '%s\n' "$qcall_err" | tail -3 >&2; exit 1; }
+echo "framework QCall refusal OK: exit 2, before any runtime library lookup"
+
+echo "== dynamic resolver and NativeLibrary APIs (exact diff vs real .NET) =="
+build_proj samples/dotnet/PInvokeDynamic/PInvokeDynamic.csproj
+dynamic_app="samples/dotnet/PInvokeDynamic/bin/$CONFIG/$TFM/PInvokeDynamic.dll"
+dynamic_ref="samples/dotnet/PInvokeDynamic/bin/$CONFIG/$TFM/PInvokeRefLib.dll"
+dynamic_out="artifacts/pinvokedynamic"
+invoke_cli "$dynamic_app" -r "$corelib" -r "$dynamic_ref" -o "$dynamic_out"
+[ ! -e "$dynamic_out/pinvoke-libs.txt" ] \
+    || { echo "FAIL: dynamic imports emitted pinvoke-libs.txt" >&2; exit 1; }
+[ ! -e "$dynamic_out/pinvoke-symbols.txt" ] \
+    || { echo "FAIL: dynamic imports emitted pinvoke-symbols.txt" >&2; exit 1; }
+if [ "$DN2CPP_OS" = macos ]; then
+    # The selector matches the raw metadata name; only the emitted binding sees
+    # the Darwin ABI bridge rewrite.
+    darwin_selector_out="artifacts/pinvokedynamic-darwin-selector"
+    rm -rf "$darwin_selector_out"
+    invoke_cli "$dynamic_app" -r "$corelib" -r "$dynamic_ref" \
+        --direct-pinvoke 'libc!setattrlist' -o "$darwin_selector_out"
+    grep -Fq 'DN2CPP_PINVOKE_ASM("dn2cpp_setattrlist")' \
+        "$darwin_selector_out/generated.h" \
+        || { echo "FAIL: raw Darwin selector did not emit the rewritten ABI symbol" >&2; exit 1; }
+    if grep -Fq 'DN2CPP_PINVOKE_ASM("setattrlist")' \
+        "$darwin_selector_out/generated.h"; then
+        echo "FAIL: Darwin selector bound the raw metadata symbol" >&2
+        exit 1
+    fi
+fi
+compile_console "$dynamic_out" PInvokeDynamic
+assembly_lib_name=$(lib_name dn2cpptest_assembly)
+cp -f "$libtest" "$dynamic_out/$assembly_lib_name"
+dynamic_managed_dir=$(dirname "$dynamic_app")
+cp -f "$libtest" "$dynamic_managed_dir/$assembly_lib_name"
+if [ "$DN2CPP_OS" = windows ]; then
+    libdir_posix=$(cygpath -u "$LIBDIR")
+    libtest_native=$(native_path "$libtest")
+    dynamic_native=$(env "PATH=$libdir_posix:$PATH" DN2CPP_PINVOKE_TEST_LIBRARY="$libtest_native" "./$dynamic_out/PInvokeDynamic")
+    dynamic_dotnet=$(env "PATH=$libdir_posix:$PATH" DN2CPP_PINVOKE_TEST_LIBRARY="$libtest_native" dotnet "$dynamic_app")
+else
+    dynamic_native=$(env "$LIB_PATH_ENV=$LIBDIR" DN2CPP_PINVOKE_TEST_LIBRARY="$libtest" "./$dynamic_out/PInvokeDynamic")
+    dynamic_dotnet=$(env "$LIB_PATH_ENV=$LIBDIR" DN2CPP_PINVOKE_TEST_LIBRARY="$libtest" dotnet "$dynamic_app")
+fi
+assert_output "$dynamic_native" "$dynamic_dotnet"
+
 # The native test library's source dir is a key input beyond the transpile
 # surface: the run dlopens what step 1 built from it.
 if gate_cache_check "$OUT" "pinvoke-native|$corelib" \
@@ -263,19 +309,11 @@ if gate_cache_check "$OUT" "pinvoke-native|$corelib" \
 fi
 
 echo "== 11/11 Linking against libdn2cpptest and running (exact diff vs real .NET) =="
-extra_link_flags="$(libpath_flag "$LIBDIR")"
-consumer_rpath="$(consumer_rpath_flags "$LIBDIR")"
-[ -n "$consumer_rpath" ] && extra_link_flags="$extra_link_flags $consumer_rpath"
-DN2CPP_EXTRA_LINK_FLAGS="$extra_link_flags" compile_console "$OUT" "$PROJECT"
-# On macOS the native binary needs no runtime env change: install_name_flags
-# baked the absolute -install_name into libdn2cpptest at link time (step 1),
-# and that path is copied into the consumer's LC_LOAD_DYLIB, so the loader
-# finds it unassisted. On Linux there is no such propagation — the .so only
-# carries a DT_SONAME, so the consumer binary needs its own DT_RUNPATH,
-# which consumer_rpath_flags adds above via DN2CPP_EXTRA_LINK_FLAGS. Either
-# way, only the `dotnet` oracle needs DYLD_LIBRARY_PATH/LD_LIBRARY_PATH (a
-# dedicated var — replacing it outright is harmless). Windows has no rpath
-# equivalent, so BOTH the native binary and the oracle need $LIBDIR on PATH
+compile_console "$OUT" "$PROJECT"
+# Both POSIX binaries resolve the lazy import through the platform loader, so
+# the test library directory is supplied through DYLD_LIBRARY_PATH / LD_LIBRARY_PATH.
+# Windows has no rpath equivalent, so both the native binary and the oracle need
+# $LIBDIR on PATH
 # (the DLL search path) at run time — prepended, not replacing, since `env`'s
 # own PATH-based lookup of its argv[0] (dotnet/the native exe) also uses the
 # new PATH.
@@ -285,7 +323,7 @@ if [ "$DN2CPP_OS" = windows ]; then
     native_out=$(env "PATH=$libdir_posix:$PATH" "./$OUT/$PROJECT")
     dotnet_out=$(env "PATH=$libdir_posix:$PATH" dotnet "$app")
 else
-    native_out=$("./$OUT/$PROJECT")
+    native_out=$(env "$LIB_PATH_ENV=$LIBDIR" "./$OUT/$PROJECT")
     dotnet_out=$(env "$LIB_PATH_ENV=$LIBDIR" dotnet "$app")
 fi
 assert_output "$native_out" "$dotnet_out"

--- a/gates/build-and-run-pinvoke-wasm.sh
+++ b/gates/build-and-run-pinvoke-wasm.sh
@@ -2,7 +2,7 @@
 # WASM-axis sibling of the consolidated P/Invoke gate: the SAME multi-section
 # PInvokeNative program (every desktop section, cross-assembly PInvokeRefLib
 # included), transpiled once against the tree-shaken real CoreLib with
-# `--pinvoke-module dn2cpptest`, then built by em++ into a wasm32 module that
+# `--direct-pinvoke '*'`, then built by em++ into a wasm32 module that
 # statically links libdn2cpptest.a — dn2cpptest.c compiled by emcc into a
 # static archive, resolved through the same pinvoke-libs.txt ->
 # target_link_libraries token plus a gate-supplied -L via DN2CPP_APP_LINK_FLAGS
@@ -74,8 +74,8 @@ build_proj "samples/dotnet/$PROJECT/$PROJECT.csproj"
 app="samples/dotnet/$PROJECT/bin/$CONFIG/$TFM/$PROJECT.dll"
 reflib="samples/dotnet/$PROJECT/bin/$CONFIG/$TFM/PInvokeRefLib.dll"
 
-echo "== 3/5 Transpiling app + real CoreLib + PInvokeRefLib (--pinvoke-module dn2cpptest) =="
-invoke_cli "$app" -r "$corelib" -r "$reflib" --pinvoke-module dn2cpptest -o "$OUT"
+echo "== 3/5 Transpiling app + real CoreLib + PInvokeRefLib (--direct-pinvoke '*') =="
+invoke_cli "$app" -r "$corelib" -r "$reflib" --direct-pinvoke '*' -o "$OUT"
 
 # The native test library's source dir is a key input beyond the transpile
 # surface: both the linked archive and the oracle's host library are built

--- a/gates/build-and-run-yetanotherhttphandler.sh
+++ b/gates/build-and-run-yetanotherhttphandler.sh
@@ -32,7 +32,7 @@ corelib=$(resolve_net10_corelib)
 build_proj src/Dn2Cpp.Cli/Dn2Cpp.Cli.csproj
 refs=(-r "$corelib" -r "$YAHA_MANAGED" -r "$YAHA_PIPELINES")
 rm -rf "$OUT"
-invoke_cli "$app" "${refs[@]}" --auto-ref --pinvoke-module "$YAHA_MODULE" -o "$OUT"
+invoke_cli "$app" "${refs[@]}" --auto-ref --direct-pinvoke "$YAHA_MODULE" -o "$OUT"
 [ "$(strip_cr_win_file "$OUT/pinvoke-libs.txt")" = "$YAHA_MODULE" ] \
     || { echo "FAIL: pinvoke-libs.txt does not contain the exact module token" >&2; exit 1; }
 [ "$(wc -l < "$OUT/pinvoke-libs.txt" | tr -d ' ')" -eq 1 ] \
@@ -47,7 +47,7 @@ printf '%s\n' "$native_link_manifest" > "$OUT/native-assets.txt"
 
 echo "== 4/8 ASSERT: HTTP driver has ZERO gaps and ZERO dangling methods =="
 rm -rf "$MEASURE"
-measure_output=$(invoke_cli "$app" "${refs[@]}" --auto-ref --pinvoke-module "$YAHA_MODULE" --measure -o "$MEASURE" 2>&1)
+measure_output=$(invoke_cli "$app" "${refs[@]}" --auto-ref --direct-pinvoke "$YAHA_MODULE" --measure -o "$MEASURE" 2>&1)
 printf '%s\n' "$measure_output"
 [ -f "$MEASURE/s0-gaps.tsv" ] || { echo "FAIL: --measure produced no gap report" >&2; exit 1; }
 [ "$(wc -l < "$MEASURE/s0-gaps.tsv" | tr -d ' ')" -eq 0 ] \

--- a/gates/run-all-gates.sh
+++ b/gates/run-all-gates.sh
@@ -384,6 +384,8 @@ ORDERED_PROJECTS=(
     "samples/dotnet/TrimReflect/TrimReflect.csproj"
     "samples/dotnet/PInvokeRefLib/PInvokeRefLib.csproj"
     "samples/dotnet/PInvokeNative/PInvokeNative.csproj"
+    "samples/dotnet/PInvokeDynamic/PInvokeDynamic.csproj"
+    "samples/dotnet/PInvokeFrameworkQCallBad/PInvokeFrameworkQCallBad.csproj"
     "samples/dotnet/CustomAsyncTaskLib/CustomAsyncTaskLib.csproj"
     "samples/dotnet/CustomAsyncTaskType/CustomAsyncTaskType.csproj"
     "samples/dotnet/CustomAsyncTaskTypeExceed/CustomAsyncTaskTypeExceed.csproj"

--- a/runtime/core/dn2cpp_core.h
+++ b/runtime/core/dn2cpp_core.h
@@ -15,6 +15,7 @@
 #include <cstdio>
 #include <cmath>
 #include <atomic> // std::atomic — the static-constructor guard cell (dn2cpp_cctor_run_once)
+#include <mutex>  // P/Invoke resolver registry and runtime synchronization
 #include <exception>
 #include <type_traits>
 #include <limits>
@@ -2281,6 +2282,8 @@ extern Dn2CppTypeInfo dn2cpp_ambiguous_match_exception_type;
 // System.MissingMethodException: raised by the Activator/ConstructorInfo
 // helpers when constructor resolution finds no invokable match.
 extern Dn2CppTypeInfo dn2cpp_missing_method_exception_type;
+extern Dn2CppTypeInfo dn2cpp_dll_not_found_exception_type;
+extern Dn2CppTypeInfo dn2cpp_entry_point_not_found_exception_type;
 // System.Resources.MissingManifestResourceException: raised by ResourceManager when
 // the `<BaseName>.resources` set it was asked for is embedded in no loaded assembly.
 // Based on Exception rather than SystemException, like every other runtime-raised type
@@ -3935,6 +3938,31 @@ int32_t dn2cpp_marshal_get_last_error(void);
 // way. Reached from Path.GetTempPath's win-x64 GetTempPath2W feature probe (via
 // NativeLibrary.TryGetExport/GetExport).
 void* dn2cpp_native_library_get_symbol(void* handle, Dn2CppString* symbolName);
+
+// NativeAOT-style native-library binding. Resolver registrations are keyed by the
+// declaring assembly's simple-name handle and retain the managed delegate as a GC
+// root. A lazy [DllImport] asks resolver-first, then the platform loader, then looks
+// up the export. Direct calls share a MethodDef cell; an address-taken forwarder has
+// its own cell, matching CoreCLR's distinct delegate/function-pointer stub.
+using Dn2CppPInvokeResolverInvoke = intptr_t (*)(
+    Dn2CppObject* resolver, Dn2CppString* libraryName, const char* assemblyName,
+    int32_t searchPathHasValue, int32_t searchPathValue);
+void dn2cpp_pinvoke_set_resolver(const char* assemblyName, Dn2CppObject* resolver,
+    Dn2CppPInvokeResolverInvoke invoke);
+void* dn2cpp_pinvoke_resolve(const char* moduleName, const char* entryPoint,
+    const char* assemblyName, int32_t searchPathHasValue, int32_t searchPathValue);
+// The string-only NativeLibrary overload is a path load and probes exactly the
+// supplied spelling. The Assembly overload is a name load and applies the same
+// platform filename candidates and search-path policy as DllImport.
+void* dn2cpp_native_library_load(Dn2CppString* path, int32_t throwOnError);
+void* dn2cpp_native_library_load_by_name(Dn2CppString* name, int32_t throwOnError,
+    int32_t searchPathHasValue, int32_t searchPathValue);
+void* dn2cpp_native_library_load_name(const char* name, int32_t throwOnError,
+    int32_t searchPathHasValue, int32_t searchPathValue);
+void dn2cpp_native_library_free(void* handle);
+[[noreturn]] void dn2cpp_throw_dll_not_found(const char* moduleName);
+[[noreturn]] void dn2cpp_throw_entry_point_not_found(const char* entryPoint);
+[[noreturn]] void dn2cpp_throw_entry_point_not_found(Dn2CppString* entryPoint);
 
 // The non-cryptographic random source behind Interop.GetRandomBytes
 // (-> Sys::GetNonCryptographicallySecureRandomBytes on Unix), an InternalCall with

--- a/runtime/core/dn2cpp_exceptions.cpp
+++ b/runtime/core/dn2cpp_exceptions.cpp
@@ -574,6 +574,24 @@ void dn2cpp_throw_missing_method(const char* message)
         dn2cpp_string_from_utf8(message, static_cast<int32_t>(std::strlen(message))), nullptr));
 }
 
+[[noreturn]] void dn2cpp_throw_dll_not_found(const char* moduleName)
+{
+    std::string message = "Unable to load shared library '";
+    message += moduleName;
+    message += "'.";
+    dn2cpp_throw(dn2cpp_exception_new(&dn2cpp_dll_not_found_exception_type,
+        dn2cpp_string_from_utf8(message.c_str(), static_cast<int32_t>(message.size())), nullptr));
+}
+
+[[noreturn]] void dn2cpp_throw_entry_point_not_found(const char* entryPoint)
+{
+    std::string message = "Unable to find an entry point named '";
+    message += entryPoint;
+    message += "'.";
+    dn2cpp_throw(dn2cpp_exception_new(&dn2cpp_entry_point_not_found_exception_type,
+        dn2cpp_string_from_utf8(message.c_str(), static_cast<int32_t>(message.size())), nullptr));
+}
+
 // ResourceManager asked for a set no loaded assembly embeds. The TYPE is the point:
 // .NET's documentation tells callers to catch MissingManifestResourceException, so any
 // other family makes the documented `catch` silently not fire. The message stays

--- a/runtime/core/dn2cpp_marshal.cpp
+++ b/runtime/core/dn2cpp_marshal.cpp
@@ -1142,6 +1142,8 @@ int32_t dn2cpp_marshal_get_last_error(void) { return g_dn2cpp_last_pinvoke_error
 // managed (UTF-16) symbolName round-trips exactly.
 void* dn2cpp_native_library_get_symbol(void* handle, Dn2CppString* symbolName)
 {
+    if (handle == nullptr || symbolName == nullptr)
+        dn2cpp_throw_argument_null();
     int32_t n = dn2cpp_string_to_utf8(symbolName, nullptr, 0);
     std::string narrow(static_cast<size_t>(n), '\0');
     dn2cpp_string_to_utf8(symbolName, narrow.data(), n);
@@ -1150,4 +1152,274 @@ void* dn2cpp_native_library_get_symbol(void* handle, Dn2CppString* symbolName)
 #else
     return ::dlsym(handle, narrow.c_str());
 #endif
+}
+
+namespace
+{
+struct Dn2CppPInvokeResolverEntry
+{
+    const char* assemblyName;
+    Dn2CppObject* resolver;
+    Dn2CppPInvokeResolverInvoke invoke;
+    Dn2CppPInvokeResolverEntry* next;
+};
+
+DN2CPP_GC_STATIC_ROOT Dn2CppPInvokeResolverEntry* g_pinvoke_resolvers = nullptr;
+std::mutex g_pinvoke_resolver_mutex;
+
+static std::string dn2cpp_native_utf8(Dn2CppString* value)
+{
+    if (value == nullptr)
+        return {};
+    int32_t n = dn2cpp_string_to_utf8(value, nullptr, 0);
+    std::string result(static_cast<size_t>(n), '\0');
+    if (n > 0)
+        dn2cpp_string_to_utf8(value, result.data(), n);
+    return result;
+}
+
+static bool dn2cpp_native_is_path(const std::string& name)
+{
+#ifdef _WIN32
+    return name.find('/') != std::string::npos || name.find('\\') != std::string::npos
+        || (name.size() >= 2 && name[1] == ':');
+#else
+    return name.find('/') != std::string::npos;
+#endif
+}
+
+static void* dn2cpp_native_load_exact(const std::string& name, uint32_t flags = 0)
+{
+    if (name.empty())
+        return nullptr;
+#ifdef _WIN32
+    int chars = ::MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, name.c_str(),
+        static_cast<int>(name.size()), nullptr, 0);
+    if (chars <= 0)
+        return nullptr;
+    std::wstring wide(static_cast<size_t>(chars), L'\0');
+    ::MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, name.c_str(),
+        static_cast<int>(name.size()), wide.data(), chars);
+    return static_cast<void*>(::LoadLibraryExW(wide.c_str(), nullptr,
+        static_cast<DWORD>(flags)));
+#else
+    (void)flags;
+    return ::dlopen(name.c_str(), RTLD_LAZY | RTLD_LOCAL);
+#endif
+}
+
+static void* dn2cpp_native_load_self()
+{
+#ifdef _WIN32
+    return static_cast<void*>(::GetModuleHandleW(nullptr));
+#else
+    return ::dlopen(nullptr, RTLD_LAZY | RTLD_LOCAL);
+#endif
+}
+
+static std::vector<std::string> dn2cpp_native_candidates(const std::string& name)
+{
+    if (dn2cpp_native_is_path(name))
+        return { name };
+
+    std::vector<std::string> candidates;
+    candidates.push_back(name);
+#ifdef _WIN32
+    if (name.size() < 4 || name.substr(name.size() - 4) != ".dll")
+        candidates.push_back(name + ".dll");
+#elif defined(__APPLE__)
+    bool dylib = name.size() >= 6 && name.substr(name.size() - 6) == ".dylib";
+    if (!dylib)
+    {
+        candidates.push_back("lib" + name + ".dylib");
+        candidates.push_back(name + ".dylib");
+    }
+    if (name.rfind("lib", 0) != 0)
+        candidates.push_back("lib" + name);
+#else
+    bool so = name.find(".so") != std::string::npos;
+    if (!so)
+    {
+        candidates.push_back("lib" + name + ".so");
+        candidates.push_back(name + ".so");
+    }
+    if (name.rfind("lib", 0) != 0)
+        candidates.push_back("lib" + name);
+#endif
+    return candidates;
+}
+
+static bool dn2cpp_native_is_absolute_path(const std::string& name)
+{
+#ifdef _WIN32
+    return (!name.empty() && (name[0] == '/' || name[0] == '\\'))
+        || (name.size() >= 2 && name[1] == ':');
+#else
+    return !name.empty() && name[0] == '/';
+#endif
+}
+
+static std::string dn2cpp_native_app_base_directory()
+{
+    return dn2cpp_native_utf8(dn2cpp_app_base_directory());
+}
+
+static void* dn2cpp_native_load_candidates(const std::string& name,
+    int32_t searchPathHasValue, int32_t searchPathValue)
+{
+    if (name == "__Internal")
+        return dn2cpp_native_load_self();
+
+    constexpr int32_t assemblyDirectory = 0x00000002;
+    constexpr int32_t windowsSearchFlags = 0x00000100 | 0x00000200
+        | 0x00000400 | 0x00000800 | 0x00001000;
+    constexpr int32_t knownFlags = assemblyDirectory | windowsSearchFlags;
+    if (searchPathHasValue != 0 && (searchPathValue & ~knownFlags) != 0)
+        dn2cpp_throw_platform_not_supported(
+            "DllImportSearchPath contains unsupported flags");
+
+    uint32_t loaderFlags = 0;
+#ifdef _WIN32
+    // DllImportSearchPath intentionally assigns the Win32 LOAD_LIBRARY_SEARCH_*
+    // bit values, so no lossy translation is needed here.
+    loaderFlags = static_cast<uint32_t>(searchPathValue & windowsSearchFlags);
+#endif
+    if (dn2cpp_native_is_absolute_path(name))
+        return dn2cpp_native_load_exact(name, loaderFlags);
+
+    std::vector<std::string> candidates = dn2cpp_native_candidates(name);
+    bool assemblyFirst = searchPathHasValue == 0
+        || (searchPathValue & assemblyDirectory) != 0;
+    bool assemblyOnly = searchPathHasValue != 0
+        && searchPathValue == assemblyDirectory;
+    if (assemblyFirst)
+    {
+        std::string base = dn2cpp_native_app_base_directory();
+        if (!base.empty())
+            for (const std::string& candidate : candidates)
+            {
+                uint32_t exactFlags = loaderFlags;
+#ifdef _WIN32
+                if (exactFlags == 0)
+                    exactFlags = LOAD_WITH_ALTERED_SEARCH_PATH;
+#endif
+                if (void* handle = dn2cpp_native_load_exact(base + candidate, exactFlags);
+                    handle != nullptr)
+                    return handle;
+            }
+    }
+    if (assemblyOnly)
+        return nullptr;
+    for (const std::string& candidate : candidates)
+        if (void* handle = dn2cpp_native_load_exact(candidate, loaderFlags);
+            handle != nullptr)
+            return handle;
+    return nullptr;
+}
+} // namespace
+
+[[noreturn]] void dn2cpp_throw_entry_point_not_found(Dn2CppString* entryPoint)
+{
+    if (entryPoint == nullptr)
+        dn2cpp_throw_argument_null();
+    std::string narrow = dn2cpp_native_utf8(entryPoint);
+    dn2cpp_throw_entry_point_not_found(narrow.c_str());
+}
+
+void dn2cpp_pinvoke_set_resolver(const char* assemblyName, Dn2CppObject* resolver,
+    Dn2CppPInvokeResolverInvoke invoke)
+{
+    if (assemblyName == nullptr || resolver == nullptr || invoke == nullptr)
+        dn2cpp_throw_argument_null();
+    std::lock_guard<std::mutex> lock(g_pinvoke_resolver_mutex);
+    for (Dn2CppPInvokeResolverEntry* p = g_pinvoke_resolvers; p != nullptr; p = p->next)
+        if (std::strcmp(p->assemblyName, assemblyName) == 0)
+            dn2cpp_throw_invalid_operation();
+    auto* entry = static_cast<Dn2CppPInvokeResolverEntry*>(dn2cpp_alloc(
+        sizeof(Dn2CppPInvokeResolverEntry)));
+    entry->assemblyName = assemblyName;
+    dn2cpp_gc_store_ref(&entry->resolver, resolver);
+    entry->invoke = invoke;
+    dn2cpp_gc_store_ref(&entry->next, g_pinvoke_resolvers);
+    g_pinvoke_resolvers = entry;
+}
+
+void* dn2cpp_native_library_load_name(const char* name, int32_t throwOnError,
+    int32_t searchPathHasValue, int32_t searchPathValue)
+{
+    void* handle = dn2cpp_native_load_candidates(
+        name == nullptr ? std::string() : std::string(name),
+        searchPathHasValue, searchPathValue);
+    if (handle == nullptr && throwOnError != 0)
+        dn2cpp_throw_dll_not_found(name == nullptr ? "" : name);
+    return handle;
+}
+
+void* dn2cpp_native_library_load(Dn2CppString* path, int32_t throwOnError)
+{
+    if (path == nullptr)
+        dn2cpp_throw_argument_null();
+    std::string name = dn2cpp_native_utf8(path);
+    void* handle = dn2cpp_native_load_exact(name);
+    if (handle == nullptr && throwOnError != 0)
+        dn2cpp_throw_dll_not_found(name.c_str());
+    return handle;
+}
+
+void* dn2cpp_native_library_load_by_name(Dn2CppString* name, int32_t throwOnError,
+    int32_t searchPathHasValue, int32_t searchPathValue)
+{
+    if (name == nullptr)
+        dn2cpp_throw_argument_null();
+    std::string narrow = dn2cpp_native_utf8(name);
+    return dn2cpp_native_library_load_name(narrow.c_str(), throwOnError,
+        searchPathHasValue, searchPathValue);
+}
+
+void dn2cpp_native_library_free(void* handle)
+{
+    if (handle == nullptr)
+        return;
+#ifdef _WIN32
+    ::FreeLibrary(static_cast<HMODULE>(handle));
+#else
+    ::dlclose(handle);
+#endif
+}
+
+void* dn2cpp_pinvoke_resolve(const char* moduleName, const char* entryPoint,
+    const char* assemblyName, int32_t searchPathHasValue, int32_t searchPathValue)
+{
+    Dn2CppObject* resolver = nullptr;
+    Dn2CppPInvokeResolverInvoke invoke = nullptr;
+    {
+        std::lock_guard<std::mutex> lock(g_pinvoke_resolver_mutex);
+        for (Dn2CppPInvokeResolverEntry* p = g_pinvoke_resolvers; p != nullptr; p = p->next)
+            if (std::strcmp(p->assemblyName, assemblyName) == 0)
+            {
+                resolver = p->resolver;
+                invoke = p->invoke;
+                break;
+            }
+    }
+    void* handle = nullptr;
+    if (resolver != nullptr)
+    {
+        Dn2CppString* managedName = dn2cpp_string_from_utf8(moduleName,
+            static_cast<int32_t>(std::strlen(moduleName)));
+        handle = reinterpret_cast<void*>(invoke(resolver, managedName, assemblyName,
+            searchPathHasValue, searchPathValue));
+    }
+    if (handle == nullptr)
+        handle = dn2cpp_native_library_load_name(moduleName, 1,
+            searchPathHasValue, searchPathValue);
+#ifdef _WIN32
+    void* symbol = reinterpret_cast<void*>(::GetProcAddress(
+        static_cast<HMODULE>(handle), entryPoint));
+#else
+    void* symbol = ::dlsym(handle, entryPoint);
+#endif
+    if (symbol == nullptr)
+        dn2cpp_throw_entry_point_not_found(entryPoint);
+    return symbol;
 }

--- a/runtime/core/dn2cpp_typeinfo.cpp
+++ b/runtime/core/dn2cpp_typeinfo.cpp
@@ -636,6 +636,14 @@ extern const Dn2CppType dn2cpp_type_load_exception_type_obj;
 Dn2CppTypeInfo dn2cpp_type_load_exception_type =
     dn2cpp_ti_with_typeobject({ "System.TypeLoadException", &dn2cpp_exception_type, 0, nullptr, nullptr, 0 }, &dn2cpp_type_load_exception_type_obj);
 const Dn2CppType dn2cpp_type_load_exception_type_obj = { { &dn2cpp_type_type }, &dn2cpp_type_load_exception_type };
+extern const Dn2CppType dn2cpp_dll_not_found_exception_type_obj;
+Dn2CppTypeInfo dn2cpp_dll_not_found_exception_type =
+    dn2cpp_ti_with_typeobject({ "System.DllNotFoundException", &dn2cpp_type_load_exception_type, 0, nullptr, nullptr, 0 }, &dn2cpp_dll_not_found_exception_type_obj);
+const Dn2CppType dn2cpp_dll_not_found_exception_type_obj = { { &dn2cpp_type_type }, &dn2cpp_dll_not_found_exception_type };
+extern const Dn2CppType dn2cpp_entry_point_not_found_exception_type_obj;
+Dn2CppTypeInfo dn2cpp_entry_point_not_found_exception_type =
+    dn2cpp_ti_with_typeobject({ "System.EntryPointNotFoundException", &dn2cpp_type_load_exception_type, 0, nullptr, nullptr, 0 }, &dn2cpp_entry_point_not_found_exception_type_obj);
+const Dn2CppType dn2cpp_entry_point_not_found_exception_type_obj = { { &dn2cpp_type_type }, &dn2cpp_entry_point_not_found_exception_type };
 extern const Dn2CppType dn2cpp_not_supported_exception_type_obj;
 Dn2CppTypeInfo dn2cpp_not_supported_exception_type =
     dn2cpp_ti_with_typeobject({ "System.NotSupportedException", &dn2cpp_exception_type, 0, nullptr, nullptr, 0 }, &dn2cpp_not_supported_exception_type_obj);

--- a/samples/dotnet/FileReal/BoundedImportSubset.cs
+++ b/samples/dotnet/FileReal/BoundedImportSubset.cs
@@ -2,15 +2,12 @@
 using System;
 using System.Runtime.InteropServices;
 
-// The RUN-time half of the bounded-import contract: the gate's step 6 asserts what the
-// transpile SAYS about the imports it bounded, this section asserts what the substituted
-// call sites DO. There is no frozen snapshot here, so the exact diff against real .NET is
-// the assertion and every line printed must be one both hosts can agree on.
+// The run-time half of two native-import contracts: NativeLibrary.Load exercises the
+// implemented dynamic loader, while Debugger.IsAttached exercises a bounded import's
+// substituted call site. There is no frozen snapshot here, so the exact diff against real
+// .NET is the assertion and every line printed must be one both hosts can agree on.
 //
-//   LOUD  — NativeLibrary.Load over a module no host has. Real .NET throws
-//           DllNotFoundException, dn2cpp's bounded thunk PlatformNotSupportedException
-//           naming the module and entry point; the printed agreement is "it failed
-//           loudly", so a row flipped to Silent prints False against real .NET's True.
+//   LOAD   — NativeLibrary.Load over a path no host has throws DllNotFoundException.
 //   SILENT — Debugger.IsAttached, bounded to its `false` default. That default is the truth
 //           on both hosts; flip the row to Loud and the native side throws instead.
 //
@@ -71,13 +68,11 @@ static class Program
 {
     internal static void __GateEntry()
     {
-        Console.WriteLine("-- a LOUD bounded import: NativeLibrary.Load --");
+        Console.WriteLine("-- a missing dynamic library: NativeLibrary.Load --");
         bool loud;
         try
         {
-            // A name no loader can resolve on any host. Not a path — LoadByName and
-            // LoadFromPath are two rows and a bare name takes the one the public
-            // single-argument overload binds.
+            // An exact path spelling no loader can resolve on any host.
             NativeLibrary.Load("dn2cpp-no-such-native-library");
             loud = false;
         }
@@ -86,13 +81,6 @@ static class Program
             // Real .NET.
             loud = true;
         }
-        catch (PlatformNotSupportedException e)
-        {
-            // dn2cpp. The module is "QCall" and the entry point names the CoreCLR
-            // function — both have to be in the sentence for it to be actionable.
-            loud = e.Message.Contains("QCall") && e.Message.Contains("NativeLibrary_LoadFromPath");
-        }
-
         Console.WriteLine("Load fails loudly: " + loud);
 
         Console.WriteLine("-- a SILENT bounded import: Debugger.IsAttached --");

--- a/samples/dotnet/PInvokeByValTStrBad/Program.cs
+++ b/samples/dotnet/PInvokeByValTStrBad/Program.cs
@@ -20,7 +20,7 @@ public struct FixedName
 
 public static class Program
 {
-    // libc needs no --pinvoke-module opt-in, so the transpile reaches marshalling
+    // Every user import is admitted, so the transpile reaches marshalling
     // validation instead of stopping at module admission. The entry point is never
     // resolved: the transpile fails before anything links.
     [DllImport("libc")]

--- a/samples/dotnet/PInvokeDynamic/PInvokeDynamic.csproj
+++ b/samples/dotnet/PInvokeDynamic/PInvokeDynamic.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../PInvokeRefLib/PInvokeRefLib.csproj" />
+  </ItemGroup>
+</Project>

--- a/samples/dotnet/PInvokeDynamic/Program.cs
+++ b/samples/dotnet/PInvokeDynamic/Program.cs
@@ -1,0 +1,225 @@
+using System.Globalization;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Threading;
+using PInvokeRefLib;
+
+namespace PInvokeDynamic;
+
+internal static class Program
+{
+    private const int ConcurrentCallers = 8;
+    private const int WaitTimeoutMilliseconds = 10_000;
+
+    private static readonly Barrier s_firstResolverWave = new(ConcurrentCallers);
+    private static int s_resolverCalls;
+    private static int s_multicastObserverCalls;
+    private static int s_wrongAssembly;
+    private static int s_wrongMethodSearchPath;
+    private static int s_wrongAssemblySearchPath;
+    private static int s_observedAssemblySearchPath;
+    private static int s_wrongAssemblyDirectorySearchPath;
+    private static int s_observedAssemblyDirectorySearchPath;
+    private static int s_wrongSystem32SearchPath;
+    private static int s_observedSystem32SearchPath;
+    private static int s_barrierTimedOut;
+
+    [DllImport("dn2cpp_absent_library")]
+    private static extern int MissingLibrary();
+
+    [DllImport("dn2cpptest", EntryPoint = "dn2cpptest_absent_export")]
+    private static extern int MissingExport();
+
+    private static IntPtr Resolve(string libraryName, Assembly assembly,
+        DllImportSearchPath? searchPath)
+    {
+        Interlocked.Increment(ref s_resolverCalls);
+        if (assembly != typeof(NativeBridge).Assembly)
+            Volatile.Write(ref s_wrongAssembly, 1);
+        if (libraryName == "logical_dn2cpptest")
+        {
+            if (searchPath != DllImportSearchPath.AssemblyDirectory)
+                Volatile.Write(ref s_wrongMethodSearchPath, 1);
+            // Keep every first-wave callback in flight until all callers have entered.
+            // CoreCLR permits each unresolved caller to run the resolver; this makes the
+            // exact count deterministic while a later call proves the published cache.
+            if (!s_firstResolverWave.SignalAndWait(WaitTimeoutMilliseconds))
+                Volatile.Write(ref s_barrierTimedOut, 1);
+            return NativeLibrary.Load(
+                Environment.GetEnvironmentVariable("DN2CPP_PINVOKE_TEST_LIBRARY")!);
+        }
+        if (libraryName == "dn2cpptest_assembly")
+        {
+            Volatile.Write(ref s_observedAssemblyDirectorySearchPath, 1);
+            if (searchPath != DllImportSearchPath.AssemblyDirectory)
+                Volatile.Write(ref s_wrongAssemblyDirectorySearchPath, 1);
+            return IntPtr.Zero;
+        }
+        if (libraryName == "kernel32.dll")
+        {
+            Volatile.Write(ref s_observedSystem32SearchPath, 1);
+            if (searchPath != DllImportSearchPath.System32)
+                Volatile.Write(ref s_wrongSystem32SearchPath, 1);
+            return IntPtr.Zero;
+        }
+        if (searchPath != DllImportSearchPath.LegacyBehavior)
+            Volatile.Write(ref s_wrongAssemblySearchPath, 1);
+        if (libraryName == "resolver_throw")
+        {
+            Volatile.Write(ref s_observedAssemblySearchPath, 1);
+            throw new ApplicationException("resolver exception");
+        }
+        return IntPtr.Zero;
+    }
+
+    private static IntPtr ObserveResolver(string libraryName, Assembly assembly,
+        DllImportSearchPath? searchPath)
+    {
+        Interlocked.Increment(ref s_multicastObserverCalls);
+        return IntPtr.Zero;
+    }
+
+    private static void Main()
+    {
+        CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+        CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+        NativeBridge.ReachDarwinSelectorProbe();
+
+        try { NativeLibrary.SetDllImportResolver(null!, Resolve); }
+        catch (ArgumentNullException) { Console.WriteLine("null assembly"); }
+        try { NativeLibrary.SetDllImportResolver(typeof(Program).Assembly, null!); }
+        catch (ArgumentNullException) { Console.WriteLine("null resolver"); }
+
+        DllImportResolver resolver = ObserveResolver;
+        resolver += Resolve;
+        NativeLibrary.SetDllImportResolver(typeof(NativeBridge).Assembly, resolver);
+        resolver = null!;
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        var threads = new Thread[ConcurrentCallers];
+        var redirected = new int[threads.Length];
+        for (int i = 0; i < threads.Length; i++)
+        {
+            int slot = i;
+            threads[i] = new Thread(() => redirected[slot] = NativeBridge.RedirectedAdd(slot, 10))
+            {
+                IsBackground = true,
+            };
+        }
+        foreach (Thread thread in threads) thread.Start();
+        bool firstWaveCompleted = true;
+        foreach (Thread thread in threads)
+            firstWaveCompleted &= thread.Join(WaitTimeoutMilliseconds);
+        firstWaveCompleted &= Volatile.Read(ref s_barrierTimedOut) == 0;
+        Console.WriteLine("concurrent first wave completed: " + firstWaveCompleted);
+        if (!firstWaveCompleted)
+            return;
+        Console.WriteLine(string.Join(',', redirected));
+        Console.WriteLine("resolver first-wave count: " + Volatile.Read(ref s_resolverCalls));
+        Console.WriteLine("cached redirected call: " + NativeBridge.RedirectedAdd(20, 22));
+        Console.WriteLine("first method-group call: " + NativeBridge.RedirectedAddViaDelegate(18, 24));
+        Console.WriteLine("resolver after method group: " + Volatile.Read(ref s_resolverCalls));
+        Console.WriteLine("cached method-group call: " + NativeBridge.RedirectedAddViaDelegate(17, 25));
+        Console.WriteLine("second managed call site: " + NativeBridge.RedirectedAddAgain(19, 23));
+        Console.WriteLine("resolver final count: " + Volatile.Read(ref s_resolverCalls));
+        Console.WriteLine("multicast observer count: "
+            + Volatile.Read(ref s_multicastObserverCalls));
+        Console.WriteLine("resolver assembly identity: "
+            + (Volatile.Read(ref s_wrongAssembly) == 0));
+        Console.WriteLine("resolver method search path: "
+            + (Volatile.Read(ref s_wrongMethodSearchPath) == 0));
+
+        Console.WriteLine("assembly-directory fallback: "
+            + NativeBridge.AssemblyDirectoryAdd(20, 22));
+        Console.WriteLine("assembly-directory search path: "
+            + (Volatile.Read(ref s_observedAssemblyDirectorySearchPath) != 0
+                && Volatile.Read(ref s_wrongAssemblyDirectorySearchPath) == 0));
+        Console.WriteLine("system32 fallback: " + NativeBridge.System32Probe());
+        Console.WriteLine("system32 search path: "
+            + (!OperatingSystem.IsWindows()
+                || (Volatile.Read(ref s_observedSystem32SearchPath) != 0
+                    && Volatile.Read(ref s_wrongSystem32SearchPath) == 0)));
+
+        // The registered resolver returns zero for this logical name, so binding
+        // falls through to the platform loader. Distinct entry points prove that
+        // caches belong to imported methods rather than modules.
+        Console.WriteLine(NativeBridge.Add(20, 22));
+        Console.WriteLine(NativeBridge.Mul(6, 7));
+
+        try
+        {
+            NativeLibrary.SetDllImportResolver(typeof(NativeBridge).Assembly, Resolve);
+            Console.WriteLine("duplicate missed");
+        }
+        catch (InvalidOperationException) { Console.WriteLine("duplicate resolver"); }
+
+        try
+        {
+            NativeBridge.ResolverThrows();
+            Console.WriteLine("resolver throw missed");
+        }
+        catch (ApplicationException e) { Console.WriteLine(e.Message); }
+        Console.WriteLine("resolver assembly search path: "
+            + (Volatile.Read(ref s_observedAssemblySearchPath) != 0
+                && Volatile.Read(ref s_wrongAssemblySearchPath) == 0));
+
+        string absolutePath = Environment.GetEnvironmentVariable("DN2CPP_PINVOKE_TEST_LIBRARY")!;
+        Console.WriteLine(NativeLibrary.TryLoad(absolutePath, out IntPtr pathHandle));
+        Console.WriteLine(NativeLibrary.TryGetExport(pathHandle, "dn2cpptest_add", out IntPtr export)
+            && export != IntPtr.Zero);
+        Console.WriteLine(!NativeLibrary.TryGetExport(pathHandle, "dn2cpptest_absent", out _));
+        try { NativeLibrary.GetExport(pathHandle, "dn2cpptest_absent"); }
+        catch (EntryPointNotFoundException e)
+        {
+            Console.WriteLine("get export missing symbol: "
+                + e.Message.Contains("dn2cpptest_absent", StringComparison.Ordinal));
+        }
+        try { NativeLibrary.TryGetExport(IntPtr.Zero, "dn2cpptest_add", out _); }
+        catch (ArgumentNullException) { Console.WriteLine("try export null handle"); }
+        try { NativeLibrary.GetExport(IntPtr.Zero, "dn2cpptest_add"); }
+        catch (ArgumentNullException) { Console.WriteLine("get export null handle"); }
+        try { NativeLibrary.TryGetExport(pathHandle, null!, out _); }
+        catch (ArgumentNullException) { Console.WriteLine("try export null name"); }
+        try { NativeLibrary.GetExport(pathHandle, null!); }
+        catch (ArgumentNullException) { Console.WriteLine("get export null name"); }
+        NativeLibrary.Free(pathHandle);
+        NativeLibrary.Free(IntPtr.Zero);
+        Console.WriteLine("free null handle");
+
+        IntPtr absoluteHandle = NativeLibrary.Load(absolutePath);
+        Console.WriteLine(NativeLibrary.TryGetExport(
+            absoluteHandle, "dn2cpptest_add", out IntPtr absoluteExport)
+            && absoluteExport != IntPtr.Zero);
+        NativeLibrary.Free(absoluteHandle);
+
+        Console.WriteLine(NativeLibrary.TryLoad("dn2cpptest", typeof(Program).Assembly,
+            null, out IntPtr nameHandle));
+        Console.WriteLine(NativeLibrary.TryGetExport(
+            nameHandle, "dn2cpptest_add", out IntPtr nameExport)
+            && nameExport != IntPtr.Zero);
+        NativeLibrary.Free(nameHandle);
+
+        IntPtr assemblyDirectoryHandle = NativeLibrary.Load("dn2cpptest_assembly",
+            typeof(Program).Assembly, DllImportSearchPath.AssemblyDirectory);
+        Console.WriteLine(NativeLibrary.TryGetExport(
+            assemblyDirectoryHandle, "dn2cpptest_add", out IntPtr assemblyDirectoryExport)
+            && assemblyDirectoryExport != IntPtr.Zero);
+        NativeLibrary.Free(assemblyDirectoryHandle);
+
+        try { NativeLibrary.TryLoad("dn2cpptest", null!, null, out _); }
+        catch (ArgumentNullException) { Console.WriteLine("try load null assembly"); }
+        try { NativeLibrary.Load("dn2cpptest", null!, null); }
+        catch (ArgumentNullException) { Console.WriteLine("load null assembly"); }
+
+        Console.WriteLine(!NativeLibrary.TryLoad("", out _));
+        try { NativeLibrary.Load(""); }
+        catch (DllNotFoundException) { Console.WriteLine("empty path missing"); }
+
+        try { MissingLibrary(); }
+        catch (DllNotFoundException) { Console.WriteLine("dll not found"); }
+        try { MissingExport(); }
+        catch (EntryPointNotFoundException) { Console.WriteLine("entry point not found"); }
+    }
+}

--- a/samples/dotnet/PInvokeFnPtrDescriptorBad/Program.cs
+++ b/samples/dotnet/PInvokeFnPtrDescriptorBad/Program.cs
@@ -11,7 +11,7 @@ public static unsafe class Program
     /// <c>MarshalDirectiveException</c> at the call ("pointers must not have a MarshalAs
     /// attribute set"), and the transpile refuses before the descriptor can be ignored.
     /// Transpiled by the negative arm of gates/build-and-run-pinvoke-native.sh, never
-    /// run. libc needs no --pinvoke-module opt-in, so validation reaches the
+    /// run. Every user import is admitted, so validation reaches the
     /// descriptor.</summary>
     [DllImport("libc")]
     private static extern void dn2cpp_never_linked_fnptr_descriptor(

--- a/samples/dotnet/PInvokeFrameworkQCallBad/PInvokeFrameworkQCallBad.csproj
+++ b/samples/dotnet/PInvokeFrameworkQCallBad/PInvokeFrameworkQCallBad.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <AssemblyName>System.PInvokeFrameworkQCallBad</AssemblyName>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/samples/dotnet/PInvokeFrameworkQCallBad/Program.cs
+++ b/samples/dotnet/PInvokeFrameworkQCallBad/Program.cs
@@ -1,0 +1,17 @@
+using System.Globalization;
+using System.Runtime.InteropServices;
+
+namespace PInvokeFrameworkQCallBad;
+
+internal static class Program
+{
+    [DllImport("QCall", EntryPoint = "Dn2CppFrameworkQCallAdmissionProbe")]
+    private static extern int Probe();
+
+    private static int Main()
+    {
+        CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+        CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+        return Probe();
+    }
+}

--- a/samples/dotnet/PInvokeNative/PInvokeCrossAsmSubset.cs
+++ b/samples/dotnet/PInvokeNative/PInvokeCrossAsmSubset.cs
@@ -3,8 +3,7 @@ using System;
 using PInvokeRefLib;
 
 // Every import this section reaches is declared in the referenced PInvokeRefLib assembly,
-// not the app module, so it needs `--pinvoke-module dn2cpptest` to admit that module into
-// the direct-native-call lowering. The gate's negative arm asserts the refusal without it.
+// not the app module. Referenced-assembly imports use the same lowering as app imports.
 namespace PInvokeCrossAsmSubset;
 
 internal static class Program

--- a/samples/dotnet/PInvokeNative/PInvokeLibcSubset.cs
+++ b/samples/dotnet/PInvokeNative/PInvokeLibcSubset.cs
@@ -4,8 +4,7 @@ using System.Runtime.InteropServices;
 
 namespace PInvokeLibcSubset;
 
-// Blittable primitives, pointers and an ASCII string into the always-linked libc, so no
-// link flag is emitted — unlike every other section in this bucket.
+// Blittable primitives, pointers and an ASCII string into the platform C library.
 internal static unsafe class Program
 {
     // Implicit entry point: the method name is the symbol.
@@ -36,15 +35,22 @@ internal static unsafe class Program
     [DllImport("libc", EntryPoint = "memset")]
     private static extern void* MemSet(void* dst, int value, nuint count);
 
-    // "libc" names the always-linked platform C library, which on Windows is the UCRT —
-    // a name no default probe of "libc" reaches. The transpiled binary resolves these
-    // symbols at LINK time, so it needs no resolver and drops the registration; this
-    // exists so real .NET, the oracle this section is diffed against, resolves the same
-    // ucrtbase entry points the C++ link does.
-    private static IntPtr ResolveLibc(string libraryName, Assembly assembly, DllImportSearchPath? searchPath) =>
-        libraryName == "libc" && OperatingSystem.IsWindows()
-            ? NativeLibrary.Load("ucrtbase.dll", assembly, searchPath)
-            : IntPtr.Zero;
+    // "libc" is a logical name shared by the section. Resolve it to the concrete
+    // platform library so the resolver-first path does not depend on a loader's
+    // non-portable alias set.
+    private static IntPtr ResolveLibc(string libraryName, Assembly assembly,
+        DllImportSearchPath? searchPath)
+    {
+        if (libraryName != "libc")
+            return IntPtr.Zero;
+        if (OperatingSystem.IsWindows())
+            return NativeLibrary.Load("ucrtbase.dll", assembly, searchPath);
+        if (OperatingSystem.IsLinux())
+            return NativeLibrary.Load("libc.so.6", assembly, searchPath);
+        if (OperatingSystem.IsMacOS())
+            return NativeLibrary.Load("libSystem.B.dylib", assembly, searchPath);
+        return IntPtr.Zero;
+    }
 
     internal static void __GateEntry()
     {

--- a/samples/dotnet/PInvokeNative/Program.cs
+++ b/samples/dotnet/PInvokeNative/Program.cs
@@ -48,7 +48,7 @@ namespace PInvokeNative
             PInvokeVariantByRefSubset.Program.__GateEntry();
             PInvokeSingleFieldStructSubset.Program.__GateEntry();
             PInvokeStackallocUtf8Subset.Program.__GateEntry();
-            // The one section binding no custom library, so it needs no link flag.
+            // The one section binding the platform C library rather than dn2cpptest.
             PInvokeLibcSubset.Program.__GateEntry();
         }
     }

--- a/samples/dotnet/PInvokePointerDescriptorBad/Program.cs
+++ b/samples/dotnet/PInvokePointerDescriptorBad/Program.cs
@@ -15,7 +15,7 @@ public unsafe struct DescribedPointer
 
 public static class Program
 {
-    // libc needs no --pinvoke-module opt-in, so validation reaches the field descriptor.
+    // Every user import is admitted, so validation reaches the field descriptor.
     [DllImport("libc")]
     private static extern void dn2cpp_never_linked_pointer_descriptor(DescribedPointer value);
 

--- a/samples/dotnet/PInvokeRefLib/NativeBridge.cs
+++ b/samples/dotnet/PInvokeRefLib/NativeBridge.cs
@@ -1,10 +1,12 @@
 #nullable enable
+using System;
 using System.Runtime.InteropServices;
 
+[assembly: DefaultDllImportSearchPaths(DllImportSearchPath.LegacyBehavior)]
+
 // The [DllImport] declarations live in this SEPARATE assembly, pulled in with
-// -r, never in the app module. Lowering them to direct native calls is opt-in
-// via `--pinvoke-module dn2cpptest`; without the flag the transpile fails
-// loudly. The gate asserts both arms.
+// -r, never in the app module. They use the same lazy resolver/OS-loader path
+// as imports declared by the application assembly.
 namespace PInvokeRefLib;
 
 public static class NativeBridge
@@ -21,6 +23,24 @@ public static class NativeBridge
     [DllImport("dn2cpptest")]
     private static extern int dn2cpptest_strlen(string s);
 
+    [DllImport("logical_dn2cpptest", EntryPoint = "dn2cpptest_add")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.AssemblyDirectory)]
+    private static extern int redirected_add(int a, int b);
+
+    [DllImport("dn2cpptest_assembly", EntryPoint = "dn2cpptest_add")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.AssemblyDirectory)]
+    private static extern int assembly_directory_add(int a, int b);
+
+    [DllImport("kernel32.dll", EntryPoint = "GetCurrentProcessId")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    private static extern uint get_current_process_id();
+
+    [DllImport("libc", EntryPoint = "setattrlist")]
+    private static extern int darwin_selector_probe();
+
+    [DllImport("resolver_throw", EntryPoint = "never_reached")]
+    private static extern int resolver_throw();
+
     public static int Add(int a, int b) => dn2cpptest_add(a, b);
 
     public static long Mul(long a, long b) => dn2cpptest_mul(a, b);
@@ -30,6 +50,30 @@ public static class NativeBridge
     // dn2cpptest_strlen is plain strlen, so this is the marshalled string's
     // UTF-8 byte length.
     public static int Utf8Length(string s) => dn2cpptest_strlen(s);
+
+    public static int RedirectedAdd(int a, int b) => redirected_add(a, b);
+
+    public static int RedirectedAddAgain(int a, int b) => redirected_add(a, b);
+
+    private static BinOpDelegate? _redirectedDelegate;
+
+    public static int RedirectedAddViaDelegate(int a, int b)
+    {
+        _redirectedDelegate ??= redirected_add;
+        return _redirectedDelegate(a, b);
+    }
+
+    public static int AssemblyDirectoryAdd(int a, int b) => assembly_directory_add(a, b);
+
+    public static bool System32Probe() => !OperatingSystem.IsWindows()
+        || get_current_process_id() != 0;
+
+    public static void ReachDarwinSelectorProbe()
+    {
+        _ = (Func<int>)darwin_selector_probe;
+    }
+
+    public static int ResolverThrows() => resolver_throw();
 
     public delegate int BinOpDelegate(int a, int b);
 

--- a/samples/dotnet/PInvokeStructDescriptorBad/Program.cs
+++ b/samples/dotnet/PInvokeStructDescriptorBad/Program.cs
@@ -33,7 +33,7 @@ public static class Program
         [MarshalAs(UnmanagedType.Struct)] public Inner I;
     }
 
-    // libc needs no --pinvoke-module opt-in, so the transpile reaches marshalling
+    // Every user import is admitted, so the transpile reaches marshalling
     // validation instead of stopping at module admission. Neither entry point exists:
     // the transpile fails before anything links, and real .NET reports the struct
     // before it reports the missing symbol.

--- a/samples/dotnet/PInvokeWidthMismatchBad/Program.cs
+++ b/samples/dotnet/PInvokeWidthMismatchBad/Program.cs
@@ -18,7 +18,7 @@ public struct MisWidth
 
 public static class Program
 {
-    // libc needs no --pinvoke-module opt-in, so the transpile reaches marshalling
+    // Every user import is admitted, so the transpile reaches marshalling
     // validation instead of stopping at module admission. The entry point is never
     // resolved: the transpile fails before anything links.
     [DllImport("libc")]

--- a/src/Dn2Cpp.Cli/Program.cs
+++ b/src/Dn2Cpp.Cli/Program.cs
@@ -32,7 +32,7 @@ bool trimReflection = false;
 var reflectionRoots = new List<string>();
 var noManifestResources = new List<string>();
 var manifestResourceRoots = new List<string>();
-var pinvokeModules = new List<string>();
+var directPInvokes = new List<string>();
 var projectRoots = new List<string>();
 var linkFeatures = new List<string>();
 bool trimGodotClasses = false;
@@ -312,16 +312,12 @@ for (int i = 0; i < args.Length; i++)
         // dropped assembly is a hard error, for the --reflection-root reason.
         manifestResourceRoots.Add(args[++i]);
     }
-    else if (args[i] == "--pinvoke-module" && i + 1 < args.Length)
+    else if (args[i] == "--direct-pinvoke" && i + 1 < args.Length)
     {
-        // Lower one named [DllImport] module's P/Invokes to direct native calls from
-        // any loaded assembly (repeatable) — the opt-in for an external binding
-        // library pulled in with -r, whose imports otherwise stay on the
-        // intrinsic/throw boundary. The name is matched by ordinal equality against
-        // the exact [DllImport] module string (no normalization), and the module
-        // reaches the pinvoke-libs.txt link manifest like an app-module import.
-        // A FLAG, not an env var: it changes the C++ a successful transpile emits.
-        pinvokeModules.Add(args[++i]);
+        // Keep one module or module!entrypoint on the static-link path. The default
+        // for user imports is lazy binding through the registered resolver and then
+        // the platform loader. '*' selects every import for static-only targets.
+        directPInvokes.Add(args[++i]);
     }
     else if (args[i] == "--trim-godot-classes")
     {
@@ -492,7 +488,7 @@ if (generateBindings)
 
 if (string.IsNullOrEmpty(input))
 {
-    Console.Error.WriteLine("Usage: dn2cpp <assembly.dll> [-o <output-dir>] [-r <ref.dll>] [--no-default-ref <DnZlib|DnBrotli|DnHttp>] [--pinvoke-module <name>] [--auto-ref] [--project-root <dir>] [--link-feature <com|sre|remoting>] [--jobs <n>] [--no-shared-generics] [--shadow-stack] [--trim-reflection] [--reflection-root <Type.Full.Name>] [--no-manifest-resources <Assembly>] [--manifest-resource-root <manifest.name>] [--trim-godot-classes] [--godot-class-root <Godot.Full.Name>] [--max-heap-mb <n>] [--verbose] [--dump-isa-surface <file>] [--gdextension [--godot-api <extension_api.json>]] [--dotnet-module] [--hotupdate-base] [--emit-patch <patch.dll> --base-abi <base-abi.json> [--patch-version <n>] [--patch-stackcode]] [--generate-bindings <extension_api.json>] [--check-wasm-imports <side.wasm> <main.wasm> [<main.js>] [--peer-module <peer.wasm>]...] [--print-runtime-dir]");
+    Console.Error.WriteLine("Usage: dn2cpp <assembly.dll> [-o <output-dir>] [-r <ref.dll>] [--no-default-ref <DnZlib|DnBrotli|DnHttp>] [--direct-pinvoke <module[!entrypoint]|*>] [--auto-ref] [--project-root <dir>] [--link-feature <com|sre|remoting>] [--jobs <n>] [--no-shared-generics] [--shadow-stack] [--trim-reflection] [--reflection-root <Type.Full.Name>] [--no-manifest-resources <Assembly>] [--manifest-resource-root <manifest.name>] [--trim-godot-classes] [--godot-class-root <Godot.Full.Name>] [--max-heap-mb <n>] [--verbose] [--dump-isa-surface <file>] [--gdextension [--godot-api <extension_api.json>]] [--dotnet-module] [--hotupdate-base] [--emit-patch <patch.dll> --base-abi <base-abi.json> [--patch-version <n>] [--patch-stackcode]] [--generate-bindings <extension_api.json>] [--check-wasm-imports <side.wasm> <main.wasm> [<main.js>] [--peer-module <peer.wasm>]...] [--print-runtime-dir]");
     return 1;
 }
 
@@ -571,7 +567,7 @@ return TranspileDriver.Run(new TranspileOptions
     ReflectionRoots = reflectionRoots,
     NoManifestResources = noManifestResources,
     ManifestResourceRoots = manifestResourceRoots,
-    PInvokeModules = pinvokeModules,
+    DirectPInvokes = directPInvokes,
     ProjectRoots = projectRoots,
     LinkFeatures = linkFeatures,
     ShadowStack = shadowStack,

--- a/src/Dn2Cpp.Transpiler/Compilation.Reachability.cs
+++ b/src/Dn2Cpp.Transpiler/Compilation.Reachability.cs
@@ -4419,7 +4419,7 @@ internal sealed partial class Compilation
                 ImplAttributes = md.ImplAttributes,
                 Rva = md.RelativeVirtualAddress,
                 Context = ctx,
-                PInvoke = ReadPInvoke(reader, md),
+                PInvoke = ReadPInvoke(module, md),
             };
             spec.Methods.Add(mi);
             spec.MethodByTemplate[mdh] = mi;

--- a/src/Dn2Cpp.Transpiler/Compilation.Resolve.cs
+++ b/src/Dn2Cpp.Transpiler/Compilation.Resolve.cs
@@ -597,7 +597,14 @@ internal sealed partial class Compilation
                 }
                 // Non-generic parent: reach the real method when it resolves to a
                 // loaded (non-intrinsic) BCL type; otherwise treat as intrinsic.
-                return TryResolveMemberRefMethod(module, (MemberReferenceHandle)handle, ctx);
+                MethodInfo? resolved = TryResolveMemberRefMethod(
+                    module, (MemberReferenceHandle)handle, ctx);
+                if (resolved is not null
+                    && resolved.DeclaringClass.FullName
+                        == "System.Runtime.InteropServices.NativeLibrary"
+                    && CoreIntrinsics.MdRuntimePrimitive.Matches(resolved))
+                    return null;
+                return resolved;
             }
             default:
                 return null;
@@ -726,7 +733,7 @@ internal sealed partial class Compilation
             ImplAttributes = md.ImplAttributes,
             Rva = md.RelativeVirtualAddress,
             Context = ctx,
-            PInvoke = ReadPInvoke(defModule.Reader, md),
+            PInvoke = ReadPInvoke(defModule, md),
             NameSuffix = "__" + string.Join("_", methodArgs.Select(MangleArg)),
         };
         byKey.Add(mkey, mi);

--- a/src/Dn2Cpp.Transpiler/Compilation.cs
+++ b/src/Dn2Cpp.Transpiler/Compilation.cs
@@ -494,7 +494,8 @@ internal sealed partial class Compilation
             options.NoManifestResources ?? Array.Empty<string>(), StringComparer.Ordinal);
         _manifestResourceRoots = new HashSet<string>(
             options.ManifestResourceRoots ?? Array.Empty<string>(), StringComparer.Ordinal);
-        _pinvokeModules = new HashSet<string>(options.PInvokeModules ?? Array.Empty<string>(), StringComparer.Ordinal);
+        _directPInvokes = new HashSet<string>(
+            options.DirectPInvokes ?? Array.Empty<string>(), StringComparer.Ordinal);
         // Snapshot before Build(): the reachability drain consults IsBoundedMethod.
         _backendBoundedMethods = options.Backend is null
             ? new() : new(options.Backend.AdditionalBoundedMethods);
@@ -1297,11 +1298,29 @@ internal sealed partial class Compilation
 
     public void NoteCctorEnsure(MethodInfo cctor) => CctorEnsureTargets.Add(cctor);
 
-    /// <summary>P/Invoke methods whose call site actually lowered to a native call.
+    /// <summary>Direct P/Invoke methods whose call site actually lowered to a native call.
     /// A P/Invoke method has no IL body, so it never enters the normal
     /// <see cref="Reachable"/> set (Reach cuts Rva==0); the emitter walks this set
     /// instead to declare each distinct entry-point symbol <c>extern "C"</c>.</summary>
     public HashSet<MethodInfo> PInvokeCalls { get; } = new();
+
+    /// <summary>Program-wide lazy P/Invoke resolution cells. Direct IL calls share a
+    /// MethodDef cell; the address-taken forwarder has a second cell, matching CoreCLR's
+    /// distinct delegate/function-pointer stub while still sharing across all users of
+    /// each route.</summary>
+    public HashSet<string> LazyPInvokeCaches { get; } = new(StringComparer.Ordinal);
+
+    public string NoteLazyPInvokeCall(MethodInfo method, bool ftnWrapper)
+    {
+        string name = LazyPInvokeCacheName(method, ftnWrapper);
+        LazyPInvokeCaches.Add(name);
+        return name;
+    }
+
+    internal void ResetLazyPInvokeCallsForEmission() => LazyPInvokeCaches.Clear();
+
+    private static string LazyPInvokeCacheName(MethodInfo method, bool ftnWrapper) =>
+        "dn2cpp_pinvoke_cache_" + method.CppName + (ftnWrapper ? "_ftn" : "");
 
     /// <summary>Managed implementations of native P/Invoke entry points, keyed by the
     /// <c>[DllImport]</c> (module, entry point) they replace: static methods carrying
@@ -1910,7 +1929,7 @@ internal sealed partial class Compilation
                     Attributes = md.Attributes,
                     ImplAttributes = md.ImplAttributes,
                     Rva = md.RelativeVirtualAddress,
-                    PInvoke = ReadPInvoke(reader, md),
+                    PInvoke = ReadPInvoke(module, md),
                     IsUnmanagedCallersOnly = isUco,
                     UnmanagedEntryPoint = ucoEntryPoint,
                 };
@@ -5553,15 +5572,17 @@ internal sealed partial class Compilation
     /// import's explicit name, falling back to the method's own name when unspecified.
     /// Per-parameter / return <c>[MarshalAs(UnmanagedType.*)]</c> overrides are decoded
     /// from the marshalling descriptors.</summary>
-    private static PInvokeInfo? ReadPInvoke(MetadataReader reader, MethodDefinition md)
+    private static PInvokeInfo? ReadPInvoke(Module module, MethodDefinition md)
     {
+        var reader = module.Reader;
         if ((md.Attributes & MethodAttributes.PinvokeImpl) == 0)
             return null;
         var import = md.GetImport();
         if (import.Module.IsNil)
             return null; // malformed / vararg pinvoke with no module ref — leave as extern
         string moduleName = reader.GetString(reader.GetModuleReference(import.Module).Name);
-        string entryPoint = import.Name.IsNil ? reader.GetString(md.Name) : reader.GetString(import.Name);
+        string rawEntryPoint = import.Name.IsNil ? reader.GetString(md.Name) : reader.GetString(import.Name);
+        string entryPoint = rawEntryPoint;
 
         // Darwin [f]setattrlist take a `struct attrlist*` whose leading u_short
         // pair the emitted managed AttrList layout cannot reproduce (sub-int32
@@ -5595,7 +5616,35 @@ internal sealed partial class Compilation
                 paramMarshal[p.SequenceNumber - 1] = u;
         }
 
-        return new PInvokeInfo(moduleName, entryPoint, import.Attributes, retMarshal, paramMarshal);
+        int? searchPath = ReadDefaultDllImportSearchPath(reader, md.GetCustomAttributes());
+        if (searchPath is null && reader.IsAssembly)
+            searchPath = ReadDefaultDllImportSearchPath(
+                reader, reader.GetAssemblyDefinition().GetCustomAttributes());
+
+        return new PInvokeInfo(moduleName, rawEntryPoint, entryPoint, import.Attributes,
+            searchPath, retMarshal, paramMarshal);
+    }
+
+    /// <summary>The first <c>[DefaultDllImportSearchPaths]</c> value in a metadata
+    /// attribute set, or null when the attribute is absent. The value blob is the ECMA-335
+    /// custom-attribute prolog followed by the enum's Int32 value; decoding it directly
+    /// keeps P/Invoke discovery from resolving an otherwise-unused attribute type.</summary>
+    private static int? ReadDefaultDllImportSearchPath(
+        MetadataReader reader, CustomAttributeHandleCollection attributes)
+    {
+        foreach (var cah in attributes)
+        {
+            var ca = reader.GetCustomAttribute(cah);
+            if (AttributeTypeName(reader, ca)
+                != "System.Runtime.InteropServices.DefaultDllImportSearchPathsAttribute")
+                continue;
+            var blob = reader.GetBlobReader(ca.Value);
+            if (blob.Length < 6 || blob.ReadUInt16() != 0x0001)
+                throw new NotSupportedException(
+                    "DefaultDllImportSearchPathsAttribute has an invalid value blob");
+            return blob.ReadInt32();
+        }
+        return null;
     }
 
     /// <summary>Distinct linker library tokens (sorted) for the app-module P/Invoke
@@ -5681,40 +5730,50 @@ internal sealed partial class Compilation
         };
     }
 
-    /// <summary><c>--pinvoke-module</c>: the [DllImport] module names opted in to the
-    /// direct-native-call lowering from any loaded assembly (see
-    /// <see cref="IsOptedInPInvokeModule"/>).</summary>
-    private readonly HashSet<string> _pinvokeModules;
+    /// <summary>The exact selectors supplied by <c>--direct-pinvoke</c>. They are
+    /// intentionally not normalized: a selector names metadata, not a filename
+    /// candidate produced by the platform loader.</summary>
+    private readonly HashSet<string> _directPInvokes;
 
-    /// <summary>True for a <c>[DllImport]</c> module the run opted in with
-    /// <c>--pinvoke-module</c>, so a P/Invoke declared in a referenced assembly (an
-    /// external binding library pulled in with <c>-r</c>, e.g. CriWare's
-    /// <c>cri_atom</c>) lowers to a direct native call exactly like an app-module
-    /// P/Invoke, and its library token reaches the pinvoke-libs.txt link manifest.
-    /// The name is matched by ordinal equality against the exact [DllImport] module
-    /// string — no case folding, no lib-prefix/extension normalization — keeping the
-    /// contract as simple as the declaration it names. A CLI flag rather than an
-    /// environment variable on purpose: it changes the C++ a successful transpile
-    /// emits (the <c>--trim-reflection</c> doctrine). The per-run counterpart of
-    /// <see cref="IsRuntimeProvidedPInvokeModule"/>'s fixed platform set.</summary>
-    public bool IsOptedInPInvokeModule(string module) => _pinvokeModules.Contains(module);
+    public bool IsDirectPInvoke(MethodInfo method)
+    {
+        if (method.PInvoke is not { } pinv)
+            return false;
+        if (_directPInvokes.Contains("*")
+            || _directPInvokes.Contains(pinv.ModuleName)
+            || _directPInvokes.Contains(pinv.ModuleName + "!" + pinv.RawEntryPoint))
+            return true;
+
+        // These imports bind to symbols supplied by the runtime or the target OS
+        // itself. Keep only framework/shim declarations direct; an application or
+        // third-party assembly importing the same module still gets resolver-first
+        // lazy binding, which is observable (notably a user "libc" resolver on Windows).
+        string assembly = method.DeclaringClass.Module.AssemblyName;
+        bool framework = IsFrameworkAssemblyName(assembly)
+            || assembly is "DnZlib" or "DnBrotli" or "DnHttp";
+        return framework && IsRuntimeProvidedPInvokeModule(pinv.ModuleName);
+    }
 
     /// <summary>True for a bodyless <c>[DllImport]</c> method whose call sites lower to a
-    /// direct native call: an app-module import, a runtime-provided module
-    /// (<see cref="IsRuntimeProvidedPInvokeModule"/>), or a per-run opt-in
-    /// (<see cref="IsOptedInPInvokeModule"/>). The ONE predicate every asker shares —
+    /// P/Invoke lowering, either lazy or explicitly direct. The ONE predicate every asker shares —
     /// the call route (<c>MethodCompiler.TranslateCall</c>) and the address-taken path
     /// (the ldftn arm noting <see cref="NotePInvokeFtnTarget"/>) — so the set of imports
     /// that lower cannot drift between a call site and a delegate method group over the
     /// same import.</summary>
-    public bool LowersToDirectNativeCall(MethodInfo m) =>
-        m.Rva == 0 && m.PInvoke is { } pinv
-        && (m.DeclaringClass.Module == AppModule
-            || IsRuntimeProvidedPInvokeModule(pinv.ModuleName)
-            || IsOptedInPInvokeModule(pinv.ModuleName));
+    public bool LowersToPInvoke(MethodInfo m)
+    {
+        if (m.Rva != 0 || m.PInvoke is null)
+            return false;
+
+        // User/library imports are the dynamic-loading surface. Framework imports
+        // remain behind their existing intrinsic/refusal boundary unless the
+        // runtime provides that PAL module or the caller explicitly selects them.
+        return !IsFrameworkAssemblyName(m.DeclaringClass.Module.AssemblyName)
+            || IsDirectPInvoke(m);
+    }
 
     /// <summary>ldftn/delegate targets that are bodyless P/Invokes whose call sites
-    /// lower to direct native calls (<see cref="LowersToDirectNativeCall"/>), e.g.
+    /// use the same lazy/direct lowering (<see cref="LowersToPInvoke"/>), e.g.
     /// CriWare's <c>new CbFunc(NativeMethods.criErr_SetCallback)</c> — a delegate over
     /// the [DllImport] method itself. A call site lowers inline, but taking the address
     /// needs a function; CppEmitter synthesizes each body as a forwarder built from the
@@ -5808,9 +5867,9 @@ internal sealed partial class Compilation
     /// runtime-internal QCalls — stays on the intrinsic/throw boundary, same posture
     /// as POSIX. This fixed set names only modules the runtime/platform itself
     /// provides; the per-run opt-in path coexists with it —
-    /// <see cref="IsOptedInPInvokeModule"/> (<c>--pinvoke-module</c>) admits a named
-    /// module from any loaded assembly, which is how an external binding library's
-    /// imports lower without its module name ever being hardcoded here.</para></summary>
+    /// User declarations do not use this fixed set to decide admission: all reachable
+    /// imports are accepted and bind lazily unless <c>--direct-pinvoke</c> selects them.
+    /// </para></summary>
     public static bool IsRuntimeProvidedPInvokeModule(string module) =>
         module is "libSystem.Native" or "libc" or "libSystem.IO.Compression.Native"
             // macOS process self-inspection. Interop.libproc's `proc_pidinfo` /

--- a/src/Dn2Cpp.Transpiler/CoreIntrinsics.cs
+++ b/src/Dn2Cpp.Transpiler/CoreIntrinsics.cs
@@ -698,13 +698,6 @@ internal static partial class CoreIntrinsics
         // buffered loop instead, exactly as on Unix.
         [("System.IO.Strategies.AsyncWindowsFileStreamStrategy", "CopyToAsync")]
             = BoundedVerdict.Silent,
-        // NativeLibrary.SetDllImportResolver — a resolver registration lives in a
-        // ConditionalWeakTable<Assembly, DllImportResolver> (DependentHandle
-        // InternalCalls, not modeled), and a transpiled image resolves its
-        // P/Invokes at link time — a registered resolver can never be consulted,
-        // so dropping the registration is behavior-neutral on every lane.
-        [("System.Runtime.InteropServices.NativeLibrary", "SetDllImportResolver")]
-            = BoundedVerdict.Silent,
         // win-x64 CoreLib's COM-interop-aware weak reference path (absent from Unix CoreLib
         // entirely). dn2cpp never creates a COM RCW or registers a ComWrappers object — COM
         // interop is a permanent non-goal (docs/STATUS.md) — so PossiblyComObject is always
@@ -740,17 +733,15 @@ internal static partial class CoreIntrinsics
             = BoundedVerdict.Silent,
         [("System.Runtime.InteropServices.ComWrappers", "<GetIUnknownImplInternal>g____PInvoke|1_0")]
             = BoundedVerdict.Silent,
-        // NativeLibrary.Load's two dlopen P/Invoke thunks. Reached only as the body of a
-        // DllImportResolver delegate; SetDllImportResolver is itself bounded above, so the
-        // registration is dropped and a transpiled image resolves its P/Invokes at LINK
-        // time — the resolver can never be consulted at run time.
-        //
-        // LOUD, because neither `Load` nor `LoadFromPath` contains a throw opcode:
+        // NativeLibrary.Load's fallback dlopen P/Invoke thunks. Supported public
+        // NativeLibrary overloads are intercepted before reaching these bodies; keep an
+        // unexpected CoreLib path loud because neither `Load` nor `LoadFromPath` contains
+        // a throw opcode:
         // `throwOnError` is honoured on the NATIVE side of the QCall, so a bounded zero
         // would make the public, documented-to-throw NativeLibrary.Load hand back
         // IntPtr.Zero without a word and the first symptom would be whatever the caller does
-        // with a null module handle. A transpiled image cannot load a library at run time at
-        // all, so the honest substitute is the loud one.
+        // with a null module handle. These QCall thunks are not the implemented loader seam,
+        // so an unexpected path that reaches one must stay loud.
         [("System.Runtime.InteropServices.NativeLibrary", "<LoadFromPath>g____PInvoke|1_0")]
             = BoundedVerdict.Loud,
         [("System.Runtime.InteropServices.NativeLibrary", "<LoadByName>g____PInvoke|2_0")]
@@ -1084,7 +1075,9 @@ internal static partial class CoreIntrinsics
         // NativeLibrary.GetSymbol -> dn2cpp_native_library_get_symbol. Its real body is the
         // raw compiler-generated `<GetSymbol>g____PInvoke` QCall stub — module "QCall", no
         // managed implementation to link against.
-        "System.Runtime.InteropServices.NativeLibrary" => name == "GetSymbol",
+        "System.Runtime.InteropServices.NativeLibrary" => name is "GetSymbol"
+            or "Load" or "TryLoad" or "Free" or "GetExport"
+            or "TryGetExport" or "SetDllImportResolver",
         // Interop.GetRandomBytes -> a deterministic fixed-seed fill. It is the IL forwarder to
         // the bodyless InternalCall Interop+Sys::GetNonCryptographicallySecureRandomBytes;
         // cutting the forwarder is what makes that InternalCall unreachable.
@@ -1207,6 +1200,8 @@ internal static partial class CoreIntrinsics
         ["System.OutOfMemoryException"] = "&dn2cpp_out_of_memory_exception_type",
         ["System.InvalidCastException"] = "&dn2cpp_invalid_cast_exception_type",
         ["System.TypeLoadException"] = "&dn2cpp_type_load_exception_type",
+        ["System.DllNotFoundException"] = "&dn2cpp_dll_not_found_exception_type",
+        ["System.EntryPointNotFoundException"] = "&dn2cpp_entry_point_not_found_exception_type",
         ["System.NotSupportedException"] = "&dn2cpp_not_supported_exception_type",
         ["System.PlatformNotSupportedException"] = "&dn2cpp_platform_not_supported_exception_type",
         ["System.FormatException"] = "&dn2cpp_format_exception_type",

--- a/src/Dn2Cpp.Transpiler/CppEmitter.cs
+++ b/src/Dn2Cpp.Transpiler/CppEmitter.cs
@@ -654,6 +654,7 @@ internal sealed partial class CppEmitter
             // rebuild them from scratch so the emitted tables hold exactly the
             // retained shared bodies' slots in deterministic compile order.
             _c.ResetRgctxForEmission();
+            _c.ResetLazyPInvokeCallsForEmission();
             _c.ResetSharedPlanningState();
             Timing.Mark("finalize-shared");
         }
@@ -839,6 +840,7 @@ internal sealed partial class CppEmitter
         // field-by-field marshal-in/out helpers (-> data).
         EmitPInvokeMarshalStructs(o);
         EmitPInvokeDeclarations(o.Header);
+        EmitLazyPInvokeCaches(o.Header);
         EmitStaticFields(o);
 
         // Method prototypes go in the header (external linkage): a body in any TU may call
@@ -6086,6 +6088,20 @@ internal sealed partial class CppEmitter
         sb.AppendLine("// ---- P/Invoke native entry points ----");
         foreach (var kv in decls.OrderBy(kv => kv.Key, StringComparer.Ordinal))
             sb.AppendLine(kv.Value);
+        sb.AppendLine();
+    }
+
+    /// <summary>Program-wide fixup cells for lazy imported MethodDefs and their optional
+    /// address-taken forwarders. Inline variables keep the header usable from split body
+    /// TUs while stable names and a sorted walk make the emitted bytes independent of
+    /// call-site discovery order.</summary>
+    private void EmitLazyPInvokeCaches(StringBuilder sb)
+    {
+        if (_c.LazyPInvokeCaches.Count == 0)
+            return;
+        sb.AppendLine("// ---- lazy P/Invoke method caches ----");
+        foreach (string cache in _c.LazyPInvokeCaches.OrderBy(n => n, StringComparer.Ordinal))
+            sb.AppendLine($"inline std::atomic<void*> {cache}{{nullptr}};");
         sb.AppendLine();
     }
 

--- a/src/Dn2Cpp.Transpiler/MethodCompiler.Call.cs
+++ b/src/Dn2Cpp.Transpiler/MethodCompiler.Call.cs
@@ -1089,6 +1089,11 @@ internal sealed partial class MethodCompiler
                 // intrinsic table.
                 if (_c.TryResolveMemberRefMethod(_module, (MemberReferenceHandle)handle, _method.Context) is { } real)
                 {
+                    // Runtime primitives referenced across assemblies need the same
+                    // route as an intra-CoreLib MethodDef. NativeLibrary is the
+                    // important case: a user resolver calls Load through a MemberRef.
+                    if (TryEmitMethodDefIntercept(CoreIntrinsics.MdRuntimePrimitive, real))
+                        return;
                     // The framework EventSource tracing guards, reached as a
                     // MemberReference too: ConcurrentDictionary lives in
                     // System.Collections.Concurrent.dll (pulled in via --auto-ref),
@@ -2065,23 +2070,22 @@ internal sealed partial class MethodCompiler
             return;
         }
 
-        // A P/Invoke (`[DllImport]`) method has no IL body; lower a call to it to a
-        // direct native call into its extern "C" entry point. Bounded to the
-        // app module — a real CoreLib pulled in with -r keeps its own P/Invokes on the
-        // intrinsic/throw boundary (their native symbols are runtime-internal, modeled
-        // by hand-written intrinsics, not linked) — EXCEPT the .NET PAL
+        // A P/Invoke (`[DllImport]`) method has no IL body; lower a call through the
+        // shared marshaller to lazy resolution or a selected direct native bind. Framework
+        // imports stay on the intrinsic/throw boundary unless explicitly selected or backed
+        // by a runtime-provided module. The latter includes the .NET PAL
         // (`libSystem.Native`, the SystemNative_* POSIX wrappers, which the dn2cpp
         // runtime implements itself in runtime/core/platform/posix/) and plain `libc`
         // imports (always-linked platform symbols, e.g. macOS `clonefile`). Those two
         // modules make the real BCL file-I/O bodies (FileStream / SafeFileHandle /
         // RandomAccess behind System.IO.File) transpilable as ordinary native calls.
-        // A module the run opted in with `--pinvoke-module` lowers the same way from
-        // any loaded assembly — the route for an external binding library pulled in
-        // with -r. Which modules lower is Compilation.LowersToDirectNativeCall, the
+        // User imports from any loaded assembly lower through the same marshaller;
+        // binding is lazy unless --direct-pinvoke selects the metadata pair. Which
+        // methods lower is Compilation.LowersToPInvoke, the
         // one predicate this route shares with the address-taken (ldftn) path
         // (an address-taken import synthesizes its body from this same lowering),
         // so the two cannot drift.
-        if (callee.PInvoke is { } pinv && _c.LowersToDirectNativeCall(callee))
+        if (callee.PInvoke is { } pinv && _c.LowersToPInvoke(callee))
         {
             EmitPInvokeCall(callee, pinv);
             return;

--- a/src/Dn2Cpp.Transpiler/MethodCompiler.EmitIntrinsic.Interop.cs
+++ b/src/Dn2Cpp.Transpiler/MethodCompiler.EmitIntrinsic.Interop.cs
@@ -392,7 +392,7 @@ internal sealed partial class MethodCompiler
             return;
         if (TryEmitRandomBytesEntryAssemblyPrimitive(callee))
             return;
-        if (TryEmitNativeLibraryGetSymbol(callee))
+        if (TryEmitNativeLibrary(callee))
             return;
         if (TryEmitOrdinalIgnoreCaseIntrinsic(callee))
             return;
@@ -490,6 +490,116 @@ internal sealed partial class MethodCompiler
             + "dn2cpp_fail(\"EntryPointNotFoundException\");");
         Push(StackKind.I8, "intptr_t", $"(intptr_t){symTmp}");
         return true;
+    }
+
+    private bool TryEmitNativeLibrary(MethodInfo callee)
+    {
+        if (callee.DeclaringClass.FullName != "System.Runtime.InteropServices.NativeLibrary")
+            return false;
+        if (callee.Name == "GetSymbol")
+            return TryEmitNativeLibraryGetSymbol(callee);
+
+        var ps = callee.Signature.ParameterTypes;
+        var values = new StackEntry[ps.Length];
+        for (int i = ps.Length - 1; i >= 0; i--)
+            values[i] = Pop();
+
+        if (callee.Name == "SetDllImportResolver" && ps.Length == 2
+            && ps[1] is { Kind: TypeKind.Class, Class: { } resolverClass })
+        {
+            var invoke = resolverClass.Methods.FirstOrDefault(m => m.Name == "Invoke")
+                ?? throw new NotSupportedException("DllImportResolver.Invoke metadata is unavailable");
+            if (invoke.Signature.ParameterTypes.Length != 3)
+                throw new NotSupportedException("DllImportResolver.Invoke has an unsupported signature");
+            TypeDesc search = invoke.Signature.ParameterTypes[2];
+            if (NullableLayout(search) is not (_, { } hasValueField, { } valueField))
+                throw new NotSupportedException(
+                    "DllImportResolver.Invoke search path is not a Nullable<T>");
+            _c.DelegateInvokerUses.Add(resolverClass);
+            string searchType = CppTypes.Of(search);
+            string callback = "+[](Dn2CppObject* __resolver, Dn2CppString* __name, "
+                + "const char* __assembly, int32_t __has_search_path, "
+                + "int32_t __search_path) -> intptr_t { "
+                + searchType + " __search{}; __search." + hasValueField
+                + " = (uint8_t)__has_search_path; __search." + valueField
+                + " = __search_path; return dginvoke_" + resolverClass.CppName
+                + "((" + resolverClass.CppStructName
+                + "*)__resolver, __name, __assembly, __search); }";
+            Emit($"dn2cpp_pinvoke_set_resolver({Cast(values[0], "const char*")}, "
+                + $"{Cast(values[1], "Dn2CppObject*")}, {callback});");
+            return true;
+        }
+
+        if (callee.Name is "Load" or "TryLoad"
+            && ps.Length >= 1 && ps[0].IsString)
+        {
+            bool trying = callee.Name == "TryLoad";
+            bool byName = ps.Length == (trying ? 4 : 3);
+            bool byPath = ps.Length == (trying ? 2 : 1);
+            if (!byName && !byPath)
+                throw new NotSupportedException($"NativeLibrary.{callee.Name} has an unsupported signature");
+            string searchPathHasValue = "0";
+            string searchPathValue = "0";
+            if (byName)
+            {
+                Emit($"if ({Cast(values[1], "const char*")} == nullptr) dn2cpp_throw_argument_null();");
+                if (NullableLayout(ps[2]) is not (_, { } hasValueField, { } valueField))
+                    throw new NotSupportedException(
+                        $"NativeLibrary.{callee.Name} search path is not a Nullable<T>");
+                string searchPath = StructLValue(values[2]);
+                searchPathHasValue = $"(int32_t){searchPath}.{hasValueField}";
+                searchPathValue = $"(int32_t){searchPath}.{valueField}";
+            }
+            string handle = NewTemp("void*");
+            string load = byName
+                ? "dn2cpp_native_library_load_by_name"
+                : "dn2cpp_native_library_load";
+            Emit($"{handle} = {load}("
+                + $"{Cast(values[0], "Dn2CppString*")}, {(trying ? 0 : 1)}"
+                + (byName ? $", {searchPathHasValue}, {searchPathValue}" : "") + ");");
+            if (trying)
+            {
+                int outIndex = ps.Length - 1;
+                if (ps[outIndex].Kind != TypeKind.ByRef)
+                    throw new NotSupportedException("NativeLibrary.TryLoad without an out handle");
+                Emit($"*{Cast(values[outIndex], "intptr_t*")} = (intptr_t){handle};");
+                Push(StackKind.I4, "int32_t", $"({handle} != nullptr ? 1 : 0)");
+            }
+            else
+            {
+                Push(StackKind.I8, "intptr_t", $"(intptr_t){handle}");
+            }
+            return true;
+        }
+
+        if (callee.Name == "Free" && ps.Length == 1)
+        {
+            Emit($"dn2cpp_native_library_free((void*){Cast(values[0], "intptr_t")});");
+            return true;
+        }
+
+        if (callee.Name is "GetExport" or "TryGetExport"
+            && ps.Length >= 2 && ps[1].IsString)
+        {
+            bool trying = callee.Name == "TryGetExport";
+            string symbol = NewTemp("void*");
+            Emit($"{symbol} = dn2cpp_native_library_get_symbol("
+                + $"(void*){Cast(values[0], "intptr_t")}, {Cast(values[1], "Dn2CppString*")});");
+            if (trying)
+            {
+                int outIndex = ps.Length - 1;
+                Emit($"*{Cast(values[outIndex], "intptr_t*")} = (intptr_t){symbol};");
+                Push(StackKind.I4, "int32_t", $"({symbol} != nullptr ? 1 : 0)");
+            }
+            else
+            {
+                Emit($"if ({symbol} == nullptr) dn2cpp_throw_entry_point_not_found("
+                    + $"{Cast(values[1], "Dn2CppString*")});");
+                Push(StackKind.I8, "intptr_t", $"(intptr_t){symbol}");
+            }
+            return true;
+        }
+        return false;
     }
 
     /// <summary>The GC surface, SpanHelpers.Memmove, and the Marshal last-error /

--- a/src/Dn2Cpp.Transpiler/MethodCompiler.Newobj.cs
+++ b/src/Dn2Cpp.Transpiler/MethodCompiler.Newobj.cs
@@ -79,7 +79,8 @@ internal sealed partial class MethodCompiler
     /// tabulated in docs/PINVOKE-MARSHALLING.md. Everything outside it (object
     /// marshalling, non-blittable structs, array returns, the COM-era [MarshalAs]
     /// kinds) is a precise NotSupportedException, never a silent default.</summary>
-    private void EmitPInvokeCall(MethodInfo callee, PInvokeInfo pinv)
+    private void EmitPInvokeCall(MethodInfo callee, PInvokeInfo pinv,
+        bool ftnWrapper = false)
     {
         string Where(string what) =>
             $"{_method.DeclaringClass.FullName}.{_method.Name}: P/Invoke {callee.DeclaringClass.FullName}.{callee.Name} {what}";
@@ -138,8 +139,10 @@ internal sealed partial class MethodCompiler
                         ? $"parameter {i} struct {pts[i]} cannot cross the P/Invoke boundary: {fr}"
                         : $"parameter {i} of type {pts[i]} is not marshallable — non-blittable array/struct or object marshalling is not supported yet"));
 
-        // Record for the emitter's one-per-symbol extern "C" declaration.
-        _c.PInvokeCalls.Add(callee);
+        bool direct = _c.IsDirectPInvoke(callee);
+        // Only static-link imports need an extern declaration and link manifest.
+        if (direct)
+            _c.PInvokeCalls.Add(callee);
 
         // P/Invoke methods are always static (no `this`). Pop args right-to-left and
         // marshal each: a string -> a GC-allocated NUL-terminated UTF-8 buffer cast to
@@ -431,7 +434,38 @@ internal sealed partial class MethodCompiler
                 args[i] = Cast(e, CppTypes.NativeAbiType(pts[i])!);
         }
 
-        string call = $"{pinv.CppAlias(callee.Signature)}({string.Join(", ", args)})";
+        string call;
+        if (direct)
+        {
+            call = $"{pinv.CppAlias(callee.Signature)}({string.Join(", ", args)})";
+        }
+        else
+        {
+            string fp = NewTemp("void*");
+            string cache = _c.NoteLazyPInvokeCall(callee, ftnWrapper);
+            string nativeRet = CppTypes.PInvokeNativeType(
+                ret, isReturn: true, charUnicode, retMa)!;
+            string nativeParams = string.Join(", ", pts.Select((p, i) =>
+                CppTypes.PInvokeNativeType(p, charUnicode: charUnicode, marshalAs: Ma(i))!));
+            if (nativeParams.Length == 0)
+                nativeParams = "void";
+            Emit($"{fp} = {cache}.load(std::memory_order_acquire);");
+            Emit($"if ({fp} == nullptr) {{");
+            int searchPath = pinv.DefaultDllImportSearchPath.GetValueOrDefault();
+            string resolved = NewTemp("void*");
+            string expected = NewTemp("void*");
+            Emit($"    {resolved} = dn2cpp_pinvoke_resolve(\"{CppString(pinv.ModuleName)}\", "
+                + $"\"{CppString(pinv.EntryPoint)}\", \"{CppString(callee.Module.AssemblyName)}\", "
+                + $"{(pinv.DefaultDllImportSearchPath.HasValue ? 1 : 0)}, {searchPath});");
+            Emit($"    {expected} = nullptr;");
+            Emit($"    if ({cache}.compare_exchange_strong({expected}, {resolved}, "
+                + "std::memory_order_acq_rel, std::memory_order_acquire))");
+            Emit($"        {fp} = {resolved};");
+            Emit("    else");
+            Emit($"        {fp} = {expected};");
+            Emit("}");
+            call = $"((({nativeRet} (*)({nativeParams})){fp})({string.Join(", ", args)}))";
+        }
 
         // SetLastError=true: capture the platform error (errno on POSIX, GetLastError() on
         // Windows — dn2cpp_pinvoke_capture_last_error picks the right one internally, see
@@ -518,6 +552,12 @@ internal sealed partial class MethodCompiler
                 : $"dn2cpp_pinvoke_char_from_ansi((uint8_t)({call}))";
         EmitCallResult(callee, call);
     }
+
+    private static string CppString(string value) => value
+        .Replace("\\", "\\\\", StringComparison.Ordinal)
+        .Replace("\"", "\\\"", StringComparison.Ordinal)
+        .Replace("\r", "\\r", StringComparison.Ordinal)
+        .Replace("\n", "\\n", StringComparison.Ordinal);
 
     /// <summary>True when the <paramref name="paramIndex"/>-th parameter of a P/Invoke
     /// is `out` (<c>[Out]</c> set, <c>[In]</c> not) rather than `ref` (<c>[In,Out]</c> /

--- a/src/Dn2Cpp.Transpiler/MethodCompiler.cs
+++ b/src/Dn2Cpp.Transpiler/MethodCompiler.cs
@@ -1119,7 +1119,7 @@ internal sealed partial class MethodCompiler : IEvalStack
             _method.DeclaringClass.CppStructName + "*",
             () =>
             {
-                EmitPInvokeCall(_method, pinv);
+                EmitPInvokeCall(_method, pinv, ftnWrapper: true);
                 return true;
             },
             "synthesized P/Invoke forwarder");
@@ -3276,7 +3276,7 @@ internal sealed partial class MethodCompiler : IEvalStack
                 // NATIVE-symbol dimension, which AssertCalledBodiesEmitted cannot see (it
                 // diffs managed symbols, and a P/Invoke has no emitted body).
                 if (!ftnBounded && m.Emittable is { Rva: 0, PInvoke: not null } fimpl
-                    && _c.LowersToDirectNativeCall(fimpl))
+                    && _c.LowersToPInvoke(fimpl))
                     _c.NotePInvokeFtnTarget(fimpl);
                 string expr;
                 if (ftnBounded)

--- a/src/Dn2Cpp.Transpiler/Model.cs
+++ b/src/Dn2Cpp.Transpiler/Model.cs
@@ -800,15 +800,18 @@ internal sealed class MethodInfo
 }
 
 /// <summary>The decoded `[DllImport]` metadata of a P/Invoke method:
-/// the native module/library name (e.g. <c>"libc"</c>), the entry-point symbol
-/// (the explicit <c>EntryPoint</c> or, when unspecified, the method name), the
+/// the native module/library name (e.g. <c>"libc"</c>), the raw metadata entry-point
+/// name, the entry-point symbol after any platform rewrite, the
 /// raw import flags (calling convention, charset, SetLastError), and any explicit
 /// per-parameter / return <c>[MarshalAs(UnmanagedType.*)]</c> override (
 /// <see cref="ReturnMarshalAs"/> for the return, <see cref="ParamMarshalAs"/>
 /// keyed by 0-based parameter index — both absent when no <c>[MarshalAs]</c> is
-/// present, in which case the marshalling follows the parameter type + CharSet).</summary>
+/// present, in which case the marshalling follows the parameter type + CharSet).
+/// <see cref="DefaultDllImportSearchPath"/> is the method-level
+/// <c>[DefaultDllImportSearchPaths]</c> value, falling back to the assembly-level value.</summary>
 internal sealed record PInvokeInfo(
-    string ModuleName, string EntryPoint, MethodImportAttributes ImportAttributes,
+    string ModuleName, string RawEntryPoint, string EntryPoint,
+    MethodImportAttributes ImportAttributes, int? DefaultDllImportSearchPath,
     UnmanagedType? ReturnMarshalAs,
     IReadOnlyDictionary<int, UnmanagedType> ParamMarshalAs)
 {

--- a/src/Dn2Cpp.Transpiler/TranspileDriver.cs
+++ b/src/Dn2Cpp.Transpiler/TranspileDriver.cs
@@ -374,7 +374,7 @@ public static class TranspileDriver
     /// <para>The line states the substitution AND the verdict, because the bounded leaves
     /// no longer all do the same thing. A <c>Loud</c> row throws a catchable
     /// <c>PlatformNotSupportedException</c> naming the module — used where the caller does
-    /// not check the zero, e.g. the <c>NativeLibrary.Load</c> QCalls. A <c>Silent</c> row's
+    /// not check the substituted zero. A <c>Silent</c> row's
     /// default is simply the truth about a transpiled binary (no managed debugger, no COM,
     /// one assembly load context). Which rows are bodyless imports at all depends on the
     /// host's CoreLib flavour; a <c>--measure</c> run's <c>s0-bounded-imports.tsv</c>

--- a/src/Dn2Cpp.Transpiler/TranspileOptions.cs
+++ b/src/Dn2Cpp.Transpiler/TranspileOptions.cs
@@ -112,12 +112,11 @@ public sealed record TranspileOptions
     /// PlatformNotSupportedException only in the shipped game).</summary>
     public IReadOnlyList<string>? ManifestResourceRoots { get; init; }
 
-    /// <summary>[DllImport] module names (<c>--pinvoke-module</c>, repeatable) whose
-    /// P/Invokes lower to direct native calls from any loaded assembly — the opt-in
-    /// for an external binding library pulled in with <c>-r</c>, whose imports
-    /// otherwise stay on the intrinsic/throw boundary
-    /// (<see cref="Compilation.IsOptedInPInvokeModule"/>).</summary>
-    public IReadOnlyList<string>? PInvokeModules { get; init; }
+    /// <summary>Ordinal <c>module</c> or <c>module!entrypoint</c> selectors from the
+    /// repeatable <c>--direct-pinvoke</c> option. A single <c>*</c> selects every
+    /// import. Imports not selected here use the runtime loader lazily; framework
+    /// PAL imports implemented by the dn2cpp runtime remain direct independently.</summary>
+    public IReadOnlyList<string>? DirectPInvokes { get; init; }
 
     /// <summary>Method-body chunk size cap per emitted C++ translation unit
     /// (overflow spills into generated_N.cpp); a non-positive value keeps


### PR DESCRIPTION
## 概要

- ユーザー assembly の DllImport を resolver-first の遅延解決へ切り替え、platform loader と MethodDef／address-taken stub ごとの thread-safe cache を実装
- 旧 pinvoke module 指定を、完全一致で反復可能な direct-pinvoke selector に置換し、runtime PAL と static-only target の direct link を維持
- NativeLibrary の path/name overload、AssemblyDirectory、Windows loader search flags、typed loader failure、resolver lifetime／multicast／concurrent publication を実装
- framework import の intrinsic/refusal 境界を維持し、Godot Web/iOS exporter との連携と回帰検査を追加

## 検証

- dotnet build src/Dn2Cpp.Cli -c Release --no-restore: warning 0 / error 0
- P/Invoke native gate: Release / Debug とも .NET exact diff を含め成功
- P/Invoke wasm gate: Debug、Node / .NET exact diff を含め成功
- self-host emit: 160 TUs を managed/native で byte-for-byte 再現
- Godot Web export: 通常ブラウザ実行と hermetic Release/Debug が成功し、direct-pinvoke wildcard を exporter log で確認
- Godot iOS export: XCFramework、Xcode build、simulator 実行、unsupported architecture refusal が成功
- CRI: wasm smoke、Android 実機、Web Chrome 実行が成功
- Thrive Windows export: extra link libs なしで生成・link し、resolver 経由で native initialization を完了

Godot exporter companion: https://github.com/takuma-komatsu/godot-dn2cpp/pull/11
