### PR TITLE
Preserve runtime state through hosted exit

### DIFF
--- a/gates/build-and-run-uco-shared.sh
+++ b/gates/build-and-run-uco-shared.sh
@@ -12,7 +12,12 @@
 #     non-exported callback's address handed out through an exported one,
 #   - starts the Task.Run worker pool, quiesces it (dn2cpp_runtime_quiesce
 #     must join every worker), and dlcloses the library — the one lane that
-#     exercises a real unload after background threads ran.
+#     exercises a real unload after background threads ran,
+#   - separately returns from a hosted process while a managed WaitAny worker
+#     remains live, exercising process static teardown without a runtime quiesce.
+#     The destroyed-mutex abort this guards against needs a non-trivial ~mutex
+#     (Apple libc++); where ~mutex is a no-op the run only proves the exit stays
+#     clean and bounded with the worker live.
 source "$(dirname "$0")/_common.sh"
 
 OUT=artifacts/ucoshared
@@ -73,4 +78,14 @@ driver_out=$("$OUT/driver" "$DYLIB"); driver_code=$?
 set -e
 assert_output "$driver_out" "$EXPECTED"
 assert_exit_code "$driver_code" 0
+
+EXIT_EXPECTED='init=0
+waitany_worker=1
+exit_worker_live OK'
+set +e
+# Bounded: a teardown that deadlocks instead of aborting must fail, not hang.
+exit_out=$(run_bounded "$OUT/driver" "$DYLIB" --exit-with-waitany); exit_code=$?
+set -e
+assert_output "$exit_out" "$EXIT_EXPECTED"
+assert_exit_code "$exit_code" 0
 gate_cache_commit

--- a/runtime/core/dn2cpp_casts.cpp
+++ b/runtime/core/dn2cpp_casts.cpp
@@ -527,7 +527,7 @@ struct Dn2CppBbiTable
     const void** slots;
     Dn2CppBbiTable* next;
 };
-std::mutex g_bbi_mutex;
+std::mutex& g_bbi_mutex = dn2cpp_never_destroyed<std::mutex>();
 Dn2CppBbiTable* g_bbi_tables;
 
 // `selfKind` (1 = IComparable<T>, 2 = IEquatable<T>, 0 = neither) and `self` come from

--- a/runtime/core/dn2cpp_core.h
+++ b/runtime/core/dn2cpp_core.h
@@ -2333,13 +2333,13 @@ extern Dn2CppTypeInfo dn2cpp_safehandle_zero_or_minus_one_type;
 // Called once from the generated init prologue before any managed code runs.
 void dn2cpp_enum_set_interfaces(const Dn2CppInterfaceEntry* entries, int32_t count);
 
-/// Heap-allocates a T that is never destroyed, for a namespace-scope object the
-/// detached finalizer thread or a Task.Run pool worker can touch. Those threads keep
-/// running while the process tears its statics down, and locking a std::mutex whose
-/// destructor already ran returns EINVAL, which libc++ throws as an uncaught
-/// std::system_error. NOT a complete answer for a shared library: unloading one unmaps
-/// the code those threads execute, which no data lifetime can save — only stopping
-/// them can (dn2cpp_runtime_quiesce).
+/// Heap-allocates a T that is never destroyed, for static-duration state any managed
+/// thread can touch. Program-owned workers, the finalizer thread, and Task.Run pool
+/// workers may keep running while a hosted process tears its statics down; locking a
+/// std::mutex whose destructor already ran returns EINVAL, which libc++ throws as an
+/// uncaught std::system_error. NOT a complete answer for a shared library: unloading
+/// one unmaps the code those threads execute, which no data lifetime can save — only
+/// stopping them can (dn2cpp_runtime_quiesce).
 template <class T>
 T& dn2cpp_never_destroyed()
 {
@@ -2367,9 +2367,10 @@ extern "C" DN2CPP_RT_EXPORT int32_t dn2cpp_runtime_quiesce(int32_t timeout_ms);
 // The exit path of a generated executable's `main`, and the lowering of
 // Environment.Exit(code). Flushes stdio and terminates without running static
 // destructors or the atexit chain: the detached finalizer thread and pool
-// workers keep running through teardown, and destroying the mutexes they lock
-// makes them abort. Build with DN2CPP_EXIT_VIA_STDEXIT to fall back to
-// std::exit for sanitizer runs (which report from an atexit handler).
+// workers keep running through teardown, and any static they still touch outside
+// the runtime's never-destroyed state would already be gone. Build with
+// DN2CPP_EXIT_VIA_STDEXIT to fall back to std::exit for sanitizer runs (which
+// report from an atexit handler).
 [[noreturn]] void dn2cpp_environment_exit(int32_t code);
 
 /// How the generated `main` leaves. An executable terminates the process there and

--- a/runtime/core/dn2cpp_exceptions.cpp
+++ b/runtime/core/dn2cpp_exceptions.cpp
@@ -800,12 +800,16 @@ struct Dn2CppExcFrameEntry
     bool collapsed; // several distinct rows share this fnPtr (shared generics / ICF)
 };
 
+struct Dn2CppExcFrameIndex
+{
+    std::vector<Dn2CppExcFrameEntry> entries;
+    std::once_flag once;
+};
+
 static std::vector<Dn2CppExcFrameEntry>& dn2cpp_exc_fn_index()
 {
-    static std::vector<Dn2CppExcFrameEntry>& index =
-        dn2cpp_never_destroyed<std::vector<Dn2CppExcFrameEntry>>();
-    static std::once_flag once;
-    std::call_once(once, []
+    static Dn2CppExcFrameIndex& state = dn2cpp_never_destroyed<Dn2CppExcFrameIndex>();
+    std::call_once(state.once, []
     {
         std::vector<Dn2CppExcFrameEntry> rows;
         auto add = [&rows](const Dn2CppMethodInfo* table, int32_t count)
@@ -845,19 +849,19 @@ static std::vector<Dn2CppExcFrameEntry>& dn2cpp_exc_fn_index()
             });
         for (size_t i = 0; i < rows.size(); i++)
         {
-            if (!index.empty() && index.back().fn == rows[i].fn)
+            if (!state.entries.empty() && state.entries.back().fn == rows[i].fn)
             {
                 // A second row naming the same body: keep the representative,
                 // note the collapse when it is a genuinely different identity.
-                if (std::strcmp(nameOf(index.back().mi, true), nameOf(rows[i].mi, true)) != 0
-                    || std::strcmp(nameOf(index.back().mi, false), nameOf(rows[i].mi, false)) != 0)
-                    index.back().collapsed = true;
+                if (std::strcmp(nameOf(state.entries.back().mi, true), nameOf(rows[i].mi, true)) != 0
+                    || std::strcmp(nameOf(state.entries.back().mi, false), nameOf(rows[i].mi, false)) != 0)
+                    state.entries.back().collapsed = true;
                 continue;
             }
-            index.push_back(rows[i]);
+            state.entries.push_back(rows[i]);
         }
     });
-    return index;
+    return state.entries;
 }
 
 // The captured entry either IS a table row's fnPtr — the row's body is the

--- a/runtime/core/dn2cpp_gc.cpp
+++ b/runtime/core/dn2cpp_gc.cpp
@@ -131,7 +131,7 @@ void dn2cpp_gc_stats_dump()
 // The summary must print exactly once whether the process leaves through the
 // exit funnel (which skips atexit) or through a host that returns and runs the
 // atexit chain — both call this.
-std::once_flag g_gc_stats_once;
+std::once_flag& g_gc_stats_once = dn2cpp_never_destroyed<std::once_flag>();
 void dn2cpp_gc_stats_dump_once()
 {
     std::call_once(g_gc_stats_once, dn2cpp_gc_stats_dump);
@@ -176,7 +176,7 @@ void dn2cpp_gc_suppress_stats_dump()
     std::fprintf(stderr, "================================\n");
 }
 
-std::once_flag g_gc_suppress_stats_once;
+std::once_flag& g_gc_suppress_stats_once = dn2cpp_never_destroyed<std::once_flag>();
 void dn2cpp_gc_suppress_stats_dump_once()
 {
     std::call_once(g_gc_suppress_stats_once, dn2cpp_gc_suppress_stats_dump);
@@ -603,12 +603,13 @@ void dn2cpp_runtime_init(Dn2CppCpuFeaturesInit initCpuFeatures)
 // The background threads this runtime spawns — the finalizer thread and the
 // Task.Run pool workers — are detached and have no stop mechanism, by design
 // ("process-lifetime pool"). Returning from `main` would run `exit()`, which
-// destroys the namespace-scope mutexes those threads lock; a thread that locks
-// one after its destructor ran gets EINVAL from pthread_mutex_lock, which
-// libc++ turns into an uncaught std::system_error and the process aborts. So
-// terminate without unwinding any of it: nothing is destroyed, so nothing can
-// be locked after destruction. Real .NET exits the same way — background
-// threads are not joined and static state is not torn down.
+// destroys every static object those threads may still touch. The runtime's own
+// locks are never destroyed (dn2cpp_never_destroyed), but standard-library and
+// third-party statics are not under that control, and a mutex locked after its
+// destructor ran gets EINVAL from pthread_mutex_lock, which libc++ turns into
+// an uncaught std::system_error and the process aborts. So terminate without
+// unwinding any of it. Real .NET exits the same way — background threads are
+// not joined and static state is not torn down.
 //
 // Only the C stdio buffers must be committed by hand, since _Exit does not.
 [[noreturn]] void dn2cpp_environment_exit(int32_t code)
@@ -1956,7 +1957,7 @@ void dn2cpp_ensure_finalizer_thread()
     // g_finalizer_ring is fully allocated — with a happens-before edge — before
     // any other thread's dn2cpp_register_finalizer call returns and reaches a
     // GC_MALLOC that could invoke the callback that writes into it.
-    static std::once_flag once;
+    static std::once_flag& once = dn2cpp_never_destroyed<std::once_flag>();
     std::call_once(once, [] {
         g_finalizer_ring = static_cast<std::atomic<Dn2CppObject*>*>(
             GC_MALLOC_UNCOLLECTABLE(sizeof(std::atomic<Dn2CppObject*>) * kFinalizerRingCapacity));

--- a/runtime/core/dn2cpp_marshal.cpp
+++ b/runtime/core/dn2cpp_marshal.cpp
@@ -1165,7 +1165,7 @@ struct Dn2CppPInvokeResolverEntry
 };
 
 DN2CPP_GC_STATIC_ROOT Dn2CppPInvokeResolverEntry* g_pinvoke_resolvers = nullptr;
-std::mutex g_pinvoke_resolver_mutex;
+std::mutex& g_pinvoke_resolver_mutex = dn2cpp_never_destroyed<std::mutex>();
 
 static std::string dn2cpp_native_utf8(Dn2CppString* value)
 {

--- a/runtime/core/dn2cpp_threading.cpp
+++ b/runtime/core/dn2cpp_threading.cpp
@@ -765,8 +765,14 @@ struct Dn2CppSafeWaitHandle : Dn2CppObject
     uint32_t dangerousRefs;
 };
 
-static std::mutex g_wait_handle_mutex;
-static std::unordered_map<Dn2CppObject*, Dn2CppObject*> g_wait_safe_handles;
+struct Dn2CppWaitHandleRegistry
+{
+    std::mutex mutex;
+    std::unordered_map<Dn2CppObject*, Dn2CppObject*> safeHandles;
+};
+
+static Dn2CppWaitHandleRegistry& g_wait_handle_registry =
+    dn2cpp_never_destroyed<Dn2CppWaitHandleRegistry>();
 
 Dn2CppObject* dn2cpp_semaphore_new(int32_t initial, int32_t maxCount)
 {
@@ -899,12 +905,12 @@ Dn2CppObject* dn2cpp_waithandle_get_safe(Dn2CppObject* waitHandle)
 {
     if (waitHandle == nullptr)
         dn2cpp_throw_null_reference();
-    std::lock_guard<std::mutex> lk(g_wait_handle_mutex);
-    auto it = g_wait_safe_handles.find(waitHandle);
-    if (it == g_wait_safe_handles.end())
+    std::lock_guard<std::mutex> lk(g_wait_handle_registry.mutex);
+    auto it = g_wait_handle_registry.safeHandles.find(waitHandle);
+    if (it == g_wait_handle_registry.safeHandles.end())
     {
         auto* safe = dn2cpp_managed_event_safe(waitHandle);
-        it = g_wait_safe_handles.emplace(waitHandle, safe).first;
+        it = g_wait_handle_registry.safeHandles.emplace(waitHandle, safe).first;
     }
     return it->second;
 }
@@ -913,11 +919,11 @@ void dn2cpp_waithandle_set_safe(Dn2CppObject* waitHandle, Dn2CppObject* safeHand
 {
     if (waitHandle == nullptr)
         dn2cpp_throw_null_reference();
-    std::lock_guard<std::mutex> lk(g_wait_handle_mutex);
+    std::lock_guard<std::mutex> lk(g_wait_handle_registry.mutex);
     // SafeWaitHandle's nullable setter uses null to clear the OS handle. The next
     // getter returns a real invalid wrapper rather than null; retaining a null map
     // value would make every event operation dereference it.
-    g_wait_safe_handles[waitHandle] = safeHandle != nullptr
+    g_wait_handle_registry.safeHandles[waitHandle] = safeHandle != nullptr
         ? safeHandle : dn2cpp_safewaithandle_new(0, 0);
 }
 
@@ -1018,9 +1024,9 @@ void dn2cpp_waithandle_close(Dn2CppObject* waitHandle)
         || waitHandle->type == &dn2cpp_manualresetevent_type
         || waitHandle->type == &dn2cpp_autoresetevent_type;
     {
-        std::lock_guard<std::mutex> lk(g_wait_handle_mutex);
-        auto it = g_wait_safe_handles.find(waitHandle);
-        if (it != g_wait_safe_handles.end())
+        std::lock_guard<std::mutex> lk(g_wait_handle_registry.mutex);
+        auto it = g_wait_handle_registry.safeHandles.find(waitHandle);
+        if (it != g_wait_handle_registry.safeHandles.end())
         {
             safe = static_cast<Dn2CppSafeWaitHandle*>(it->second);
             // A managed WaitHandle subclass can borrow another runtime event's
@@ -1039,7 +1045,7 @@ void dn2cpp_waithandle_close(Dn2CppObject* waitHandle)
         else if (runtimeEvent)
         {
             safe = dn2cpp_managed_event_safe(waitHandle);
-            g_wait_safe_handles.emplace(waitHandle, safe);
+            g_wait_handle_registry.safeHandles.emplace(waitHandle, safe);
         }
     }
     if (safe != nullptr)
@@ -1067,9 +1073,9 @@ static Dn2CppEvent* dn2cpp_event_from_operand(Dn2CppObject* o,
         return nullptr;
     }
     {
-        std::lock_guard<std::mutex> lk(g_wait_handle_mutex);
-        auto it = g_wait_safe_handles.find(o);
-        if (it != g_wait_safe_handles.end())
+        std::lock_guard<std::mutex> lk(g_wait_handle_registry.mutex);
+        auto it = g_wait_handle_registry.safeHandles.find(o);
+        if (it != g_wait_handle_registry.safeHandles.end())
         {
             auto* safe = static_cast<Dn2CppSafeWaitHandle*>(it->second);
             std::lock_guard<std::mutex> slk(safe->m);

--- a/runtime/core/intrinsics/dn2cpp_http2_stream.cpp
+++ b/runtime/core/intrinsics/dn2cpp_http2_stream.cpp
@@ -353,9 +353,12 @@ const char* CaFileOverride()
 {
     // Function-local static: C++11 guarantees the initializer runs exactly once,
     // even if several workers reach here at the same instant.
-    static const std::string value = []() {
+    static const std::string& value = []() -> const std::string& {
         const char* v = std::getenv("DN2CPP_HTTP_CAINFO");
-        return v != nullptr ? std::string(v) : std::string();
+        auto& result = dn2cpp_never_destroyed<std::string>();
+        if (v != nullptr)
+            result = v;
+        return result;
     }();
     return value.empty() ? nullptr : value.c_str();
 }
@@ -382,12 +385,18 @@ const char* CaFileOverride()
 //     so a host process carrying its own curl cannot bind to ours.
 // What changes is WHEN a failing init is discovered: at the first request instead
 // of at startup. The return code is therefore kept and reported.
+struct CurlGlobalState
+{
+    CURLcode result = CURLE_FAILED_INIT;
+    std::once_flag once;
+};
+
 CURLcode EnsureGlobalInit()
 {
-    static CURLcode rc = CURLE_FAILED_INIT;
-    static std::once_flag once;
-    std::call_once(once, [] { rc = curl_global_init(CURL_GLOBAL_DEFAULT); });
-    return rc;
+    static CurlGlobalState& state = dn2cpp_never_destroyed<CurlGlobalState>();
+    std::call_once(state.once,
+        [] { state.result = curl_global_init(CURL_GLOBAL_DEFAULT); });
+    return state.result;
 }
 
 void TransportLoop();

--- a/runtime/core/intrinsics/dn2cpp_system_globalization.cpp
+++ b/runtime/core/intrinsics/dn2cpp_system_globalization.cpp
@@ -183,7 +183,7 @@ struct Dn2CppCultureCacheNode
     Dn2CppCultureCacheNode* next;
 };
 static DN2CPP_GC_STATIC_ROOT Dn2CppCultureCacheNode* g_cultureCache = nullptr;
-static std::mutex g_cultureCacheMutex;
+static std::mutex& g_cultureCacheMutex = dn2cpp_never_destroyed<std::mutex>();
 
 // Build (or find) the culture for `row`, or — when `row` is null — the
 // invariant-symbol stand-in carrying `name`. Caller must NOT hold the lock.
@@ -297,7 +297,7 @@ int32_t dn2cpp_culture_is_neutral(const Dn2CppNumberFormatInfo* c)
 // the first read together.
 static DN2CPP_GC_STATIC_ROOT const Dn2CppNumberFormatInfo* g_currentCulture = nullptr;
 static DN2CPP_GC_STATIC_ROOT const Dn2CppNumberFormatInfo* g_hostCulture = nullptr;
-static std::once_flag g_hostCultureOnce;
+static std::once_flag& g_hostCultureOnce = dn2cpp_never_destroyed<std::once_flag>();
 
 static const Dn2CppNumberFormatInfo* dn2cpp_culture_host_default()
 {
@@ -478,7 +478,7 @@ Dn2CppObject* dn2cpp_nfi_wrap(const Dn2CppNumberFormatInfo* n, int32_t kind)
         Dn2CppNfiBoxNode* next;
     };
     static DN2CPP_GC_STATIC_ROOT Dn2CppNfiBoxNode* g_nfiBoxes = nullptr;
-    static std::mutex g_nfiBoxMutex;
+    static std::mutex& g_nfiBoxMutex = dn2cpp_never_destroyed<std::mutex>();
     std::lock_guard<std::mutex> lock(g_nfiBoxMutex);
     for (Dn2CppNfiBoxNode* p = g_nfiBoxes; p != nullptr; p = p->next)
         if (p->box.nfi == n && p->box.type == ti)

--- a/runtime/core/intrinsics/dn2cpp_system_reflection.cpp
+++ b/runtime/core/intrinsics/dn2cpp_system_reflection.cpp
@@ -98,7 +98,7 @@ struct Dn2CppSynthInst
     Dn2CppSynthInst* next;
 };
 static Dn2CppSynthInst* g_synth_insts = nullptr;
-static std::mutex g_synth_mtx;
+static std::mutex& g_synth_mtx = dn2cpp_never_destroyed<std::mutex>();
 
 // The rgctx anchor tables of the synthesized instantiations, one node per
 // placeholder chain level, keyed (clone type-info, level definition). A clone's
@@ -1883,7 +1883,7 @@ struct Dn2CppMetaRow
 };
 
 static Dn2CppMetaRow* g_meta_rows = nullptr;
-static std::mutex g_meta_rows_mtx;
+static std::mutex& g_meta_rows_mtx = dn2cpp_never_destroyed<std::mutex>();
 
 // The descriptor a synthesized row answers from, or null when `mi` is an ordinary
 // emitted row. Identity is the row ADDRESS: every synthesized row lives inside a
@@ -3333,7 +3333,7 @@ struct Dn2CppAsmBoxNode
     Dn2CppAsmBoxNode* next;
 };
 static DN2CPP_GC_STATIC_ROOT Dn2CppAsmBoxNode* g_asmBoxes = nullptr;
-static std::mutex g_asmBoxMutex;
+static std::mutex& g_asmBoxMutex = dn2cpp_never_destroyed<std::mutex>();
 
 static Dn2CppAsmBox* dn2cpp_asm_box_of(const void* p)
 {

--- a/runtime/core/intrinsics/dn2cpp_system_string.cpp
+++ b/runtime/core/intrinsics/dn2cpp_system_string.cpp
@@ -1886,25 +1886,29 @@ Dn2CppArrayN* dn2cpp_newarr_n_atomic_t(int32_t length, int32_t elemSize, const D
 // for the process lifetime — the same shape as the string intern pool below.
 namespace
 {
-std::mutex g_empty_array_mtx;
-
-std::unordered_map<const Dn2CppTypeInfo*, Dn2CppArray**>& dn2cpp_empty_array_pool()
+struct Dn2CppEmptyArrayPool
 {
-    static auto* pool = new std::unordered_map<const Dn2CppTypeInfo*, Dn2CppArray**>();
-    return *pool;
+    std::mutex mutex;
+    std::unordered_map<const Dn2CppTypeInfo*, Dn2CppArray**> entries;
+};
+
+Dn2CppEmptyArrayPool& dn2cpp_empty_array_pool()
+{
+    static Dn2CppEmptyArrayPool& pool = dn2cpp_never_destroyed<Dn2CppEmptyArrayPool>();
+    return pool;
 }
 
 template <typename Alloc>
 Dn2CppArray* dn2cpp_array_empty_cached(const Dn2CppTypeInfo* ti, Alloc alloc)
 {
-    std::lock_guard<std::mutex> lk(g_empty_array_mtx);
     auto& pool = dn2cpp_empty_array_pool();
-    auto it = pool.find(ti);
-    if (it != pool.end())
+    std::lock_guard<std::mutex> lk(pool.mutex);
+    auto it = pool.entries.find(ti);
+    if (it != pool.entries.end())
         return *it->second;
     auto** cell = static_cast<Dn2CppArray**>(dn2cpp_alloc_pinned(sizeof(Dn2CppArray*)));
     dn2cpp_gc_store_ref(cell, alloc());
-    pool.emplace(ti, cell);
+    pool.entries.emplace(ti, cell);
     return *cell;
 }
 } // namespace
@@ -2318,12 +2322,16 @@ struct Dn2CppStringInternCell
     Dn2CppString* str;
 };
 
-std::mutex g_string_intern_mtx;
-
-std::unordered_map<std::u16string_view, Dn2CppStringInternCell*>& dn2cpp_string_intern_pool()
+struct Dn2CppStringInternPool
 {
-    static auto* pool = new std::unordered_map<std::u16string_view, Dn2CppStringInternCell*>();
-    return *pool;
+    std::mutex mutex;
+    std::unordered_map<std::u16string_view, Dn2CppStringInternCell*> entries;
+};
+
+Dn2CppStringInternPool& dn2cpp_string_intern_pool()
+{
+    static Dn2CppStringInternPool& pool = dn2cpp_never_destroyed<Dn2CppStringInternPool>();
+    return pool;
 }
 
 std::u16string_view dn2cpp_string_intern_key(Dn2CppString* s)
@@ -2336,14 +2344,14 @@ Dn2CppString* dn2cpp_string_intern(Dn2CppString* s)
 {
     if (s == nullptr)
         dn2cpp_throw_argument_null();
-    std::lock_guard<std::mutex> lk(g_string_intern_mtx);
     auto& pool = dn2cpp_string_intern_pool();
-    auto it = pool.find(dn2cpp_string_intern_key(s));
-    if (it != pool.end())
+    std::lock_guard<std::mutex> lk(pool.mutex);
+    auto it = pool.entries.find(dn2cpp_string_intern_key(s));
+    if (it != pool.entries.end())
         return it->second->str;
     auto* cell = static_cast<Dn2CppStringInternCell*>(dn2cpp_alloc_pinned(sizeof(Dn2CppStringInternCell)));
     dn2cpp_gc_store_ref(&cell->str, s);
-    pool.emplace(dn2cpp_string_intern_key(s), cell);
+    pool.entries.emplace(dn2cpp_string_intern_key(s), cell);
     return s;
 }
 
@@ -2351,8 +2359,8 @@ Dn2CppString* dn2cpp_string_is_interned(Dn2CppString* s)
 {
     if (s == nullptr)
         dn2cpp_throw_argument_null();
-    std::lock_guard<std::mutex> lk(g_string_intern_mtx);
     auto& pool = dn2cpp_string_intern_pool();
-    auto it = pool.find(dn2cpp_string_intern_key(s));
-    return it != pool.end() ? it->second->str : nullptr;
+    std::lock_guard<std::mutex> lk(pool.mutex);
+    auto it = pool.entries.find(dn2cpp_string_intern_key(s));
+    return it != pool.entries.end() ? it->second->str : nullptr;
 }

--- a/runtime/core/platform/posix/dn2cpp_pal_posix.cpp
+++ b/runtime/core/platform/posix/dn2cpp_pal_posix.cpp
@@ -286,8 +286,8 @@ void dn2cpp_pal_membarrier_processwide(void)
     // i.e. every other thread observes a full barrier, which is exactly the
     // FlushProcessWriteBuffers contract. The page is process-lifetime (never
     // unmapped); a static mutex serializes concurrent barrier requests.
-    static std::mutex mtx;
-    std::lock_guard<std::mutex> lk(mtx);
+    static std::mutex* mtx = new std::mutex();
+    std::lock_guard<std::mutex> lk(*mtx);
     static const size_t pageSize = static_cast<size_t>(::sysconf(_SC_PAGESIZE));
     static void* page = []() -> void* {
         void* p = ::mmap(nullptr, pageSize, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
@@ -358,11 +358,16 @@ namespace
         uintptr_t textHi = 0;          // here can belong to a listed function
     };
 
+    struct Dn2CppMachOFnStartsState
+    {
+        Dn2CppMachOFnStarts table;
+        std::once_flag once;
+    };
+
     const Dn2CppMachOFnStarts& dn2cpp_macho_fn_starts()
     {
-        static Dn2CppMachOFnStarts table;
-        static std::once_flag once;
-        std::call_once(once, []
+        static Dn2CppMachOFnStartsState* state = new Dn2CppMachOFnStartsState();
+        std::call_once(state->once, []
         {
             // The image that holds the runtime is the image that holds the
             // generated bodies — they are always linked together — and dladdr's
@@ -433,14 +438,14 @@ namespace
                 if (val == 0)
                     break;
                 addr += static_cast<uintptr_t>(val);
-                table.starts.push_back(addr + slide);
+                state->table.starts.push_back(addr + slide);
                 val = 0;
                 shift = 0;
             }
-            table.textLo = textSecLo + slide;
-            table.textHi = textSecHi + slide;
+            state->table.textLo = textSecLo + slide;
+            state->table.textHi = textSecHi + slide;
         });
-        return table;
+        return state->table;
     }
 
     // Entry address of the function containing `pc`, or 0 for a PC outside

--- a/samples/dotnet/UcoShared/Program.cs
+++ b/samples/dotnet/UcoShared/Program.cs
@@ -4,6 +4,7 @@
 // below from the main thread and from a foreign thread.
 using System;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 namespace UcoShared;
 
@@ -28,7 +29,11 @@ internal static unsafe class Exports
 {
     private delegate int Unary(int value);
 
+    private const int WaitAnyRegistryReadinessPasses = 256;
     private static readonly Unary s_identity = Identity;
+    private static readonly ManualResetEvent s_waitAnySignaled = new(true);
+    private static readonly ManualResetEvent s_waitAnyBlocked = new(false);
+    private static int s_waitAnyRegistryPasses;
 
     private static int Identity(int value) => value;
 
@@ -76,5 +81,31 @@ internal static unsafe class Exports
     private static int TaskRunSum(int a, int b)
     {
         return System.Threading.Tasks.Task.Run(() => a + b).Result;
+    }
+
+    // The host deliberately returns without stopping this program-owned worker.
+    // Hosted processes may run static teardown while such background work is
+    // still inside the runtime.
+    [UnmanagedCallersOnly(EntryPoint = "uco_start_waitany_worker")]
+    private static int StartWaitAnyWorker()
+    {
+        var worker = new Thread(() =>
+        {
+            WaitHandle[] handles = { s_waitAnySignaled, s_waitAnyBlocked };
+            for (;;)
+            {
+                WaitHandle.WaitAny(handles);
+                Interlocked.Increment(ref s_waitAnyRegistryPasses);
+            }
+        })
+        {
+            IsBackground = true,
+        };
+        worker.Start();
+        // Readiness means completed registry traffic, and the same loop remains
+        // hot after the host observes it and returns.
+        while (Volatile.Read(ref s_waitAnyRegistryPasses) < WaitAnyRegistryReadinessPasses)
+            Thread.Yield();
+        return 1;
     }
 }

--- a/samples/dotnet/UcoShared/driver.cpp
+++ b/samples/dotnet/UcoShared/driver.cpp
@@ -5,6 +5,8 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
+#include <chrono>
+#include <cstring>
 #include <thread>
 
 #ifdef _WIN32
@@ -44,6 +46,25 @@ struct Pair
 };
 
 void* g_lib = nullptr;
+
+// POSIX hosts register this destructor before dlopen registers the library's
+// destructors, so the delay widens their live-worker teardown race. Windows has
+// no equivalent cross-module ordering guarantee; there this only checks that
+// process exit is clean while the worker is live.
+struct ExitRaceWindow
+{
+    bool armed = false;
+
+    ~ExitRaceWindow()
+    {
+#ifndef _WIN32
+        if (armed)
+            std::this_thread::sleep_for(std::chrono::milliseconds(250));
+#endif
+    }
+};
+
+ExitRaceWindow g_exit_race_window;
 
 void* sym(const char* name)
 {
@@ -85,9 +106,11 @@ int main(int argc, char** argv)
     _setmode(_fileno(stdout), _O_BINARY);
     _setmode(_fileno(stderr), _O_BINARY);
 #endif
-    if (argc < 2)
+    const bool exitWithWaitAny =
+        argc == 3 && std::strcmp(argv[2], "--exit-with-waitany") == 0;
+    if (argc < 2 || (argc > 2 && !exitWithWaitAny))
     {
-        std::fprintf(stderr, "usage: driver <shared-library>\n");
+        std::fprintf(stderr, "usage: driver <shared-library> [--exit-with-waitany]\n");
         return 2;
     }
     g_lib = dlopen(argv[1], RTLD_NOW | RTLD_LOCAL);
@@ -105,6 +128,16 @@ int main(int argc, char** argv)
     // Enable foreign-thread GC registration before any off-main-thread call.
     auto set_reg = (void (*)(int))sym("dn2cpp_set_native_callback_gc_registration");
     set_reg(1);
+
+    if (exitWithWaitAny)
+    {
+        auto start_waitany_worker =
+            (int32_t (*)())sym("uco_start_waitany_worker");
+        check("waitany_worker", start_waitany_worker(), 1);
+        g_exit_race_window.armed = true;
+        std::puts("exit_worker_live OK");
+        return 0;
+    }
 
     auto uco_add = (int32_t (*)(int32_t, int32_t))sym("uco_add");
     auto uco_pair_swap = (Pair (*)(Pair))sym("uco_pair_swap");


### PR DESCRIPTION
## Summary

- Runtime synchronization state that a managed worker can still reach during a
  normal process exit now lives for the whole process lifetime.
- The wait-handle registry's mutex and map are one never-destroyed object, and
  the same-shaped static state found in the audit was converted alongside it.
- The UcoShared gate gains a scenario where a hosted process returns while a
  managed WaitAny worker is still live. The existing quiesce-then-dlclose
  coverage is unchanged.

## Reproduction

Before the fix the new exit scenario aborted in libc++ with
`mutex lock failed: Invalid argument` (exit code 134). After the fix the same
scenario exits with code 0.

## Verification

- DN2CPP_GATE_CACHE=0 ./gates/build-and-run-uco-shared.sh (Release and CONFIG=Debug)
- ./gates/build-and-run-threading-primitives.sh
- ./gates/build-and-run-reflect-types.sh
- ./gates/build-and-run-culture-info-api.sh
- ./gates/build-and-run-pinvoke-native.sh
- dotnet build src/Dn2Cpp.Cli -c Release --no-restore -v:minimal
- git diff --check

Closes #104
