### PR TITLE
Store wait handles on managed owners

### DIFF
--- a/docs/BPI-FORMAT.md
+++ b/docs/BPI-FORMAT.md
@@ -823,7 +823,7 @@ D <SigKey>
   are enabled (the default), `0` for a `--no-shared-generics` build. Sharing
   changes which concrete function a bound symbol resolves to without moving any
   symbolic line. `layout=` is the field-layout policy —
-  `AbiContract.LayoutPolicyVersion` (currently 5) — bumped by any change that
+  `AbiContract.LayoutPolicyVersion` (currently 6) — bumped by any change that
   moves real field offsets/sizes while changing no symbolic `F`/`L`/`V` line
   (field-width narrowing, growth of the runtime `Dn2CppExceptionObject` prefix,
   a repack of a runtime-owned struct). It applies to both sharing modes, so

--- a/gates/build-and-run-doc-claims.sh
+++ b/gates/build-and-run-doc-claims.sh
@@ -752,7 +752,13 @@ doc_vendored=$(awk '/^## /{s = ($0 == "## License")} s' README.md \
 set_eq "README.md's vendored license list vs third_party/" \
        "licensed by README.md" "$doc_vendored" "present under third_party/" "$tree_vendored"
 
-echo "== 12/14 dangling path references in every doc =="
+echo "== 12/14 BPI policy version and dangling path references in every doc =="
+bpi_layout_doc=$(sed -n 's/.*LayoutPolicyVersion` (currently \([0-9][0-9]*\)).*/\1/p' \
+    docs/BPI-FORMAT.md)
+bpi_layout_tree=$(sed -n 's/^[[:space:]]*public const int LayoutPolicyVersion = \([0-9][0-9]*\);/\1/p' \
+    src/Dn2Cpp.Transpiler/HotUpdate/AbiContract.cs)
+eq "docs/BPI-FORMAT.md current layout-policy version" "$bpi_layout_doc" "$bpi_layout_tree"
+
 for f in docs/*.md README.md CLAUDE.md AGENTS.md CONTRIBUTING.md; do
     check_paths "$f"
 done

--- a/gates/build-and-run-threading-primitives.sh
+++ b/gates/build-and-run-threading-primitives.sh
@@ -2,7 +2,8 @@
 # Real synchronization primitives — Interlocked (i4/i8/ref atomics + return-value
 # contract), Volatile.Read/Write (int/long/double/bool), legacy
 # Thread.VolatileRead/Write (integer/reference/float/double), Interlocked.MemoryBarrier, and
-# [ThreadStatic] (main-thread behavior). All single-threaded, so the output is identical
+# [ThreadStatic] (main-thread behavior), and managed WaitHandle subclass key lifetime
+# across collection and address reuse. All single-threaded, so the output is identical
 # to real .NET and is diffed exact (corelib_diff_gate). The genuine cross-thread test
 # (N threads racing a shared counter, Join, exact total) is the Thread gate.
 # Also covers the two lowerings of the `lock` STATEMENT, single-threaded and so

--- a/runtime/core/dn2cpp_core.h
+++ b/runtime/core/dn2cpp_core.h
@@ -662,6 +662,16 @@ struct Dn2CppObject
     const Dn2CppTypeInfo* type;
 };
 
+// A managed WaitHandle owns its SafeWaitHandle association in the object itself.
+// Every emitted subclass inherits this prefix, so collecting the owner also removes
+// the only lookup path to the association; no native pointer-keyed registry can alias
+// a later object that reuses the same address. Growing this prefix is an ABI change —
+// bump AbiContract.LayoutPolicyVersion when its layout changes.
+struct Dn2CppWaitHandle : Dn2CppObject
+{
+    Dn2CppObject* safeHandle;
+};
+
 // A boxed value type's payload sits immediately after the object header. Used by
 // the tostring/gethashcode/equals/formatspec slot wrappers a value type wires on
 // its own type-info.

--- a/runtime/core/dn2cpp_threading.cpp
+++ b/runtime/core/dn2cpp_threading.cpp
@@ -38,7 +38,6 @@
 #include <atomic>             // g_inflight_async_tasks, real Interlocked
 #include <deque>             // Task.Run worker-pool work queue
 #include <new>               // placement new (in-place ctor of a GC-allocated Timer)
-#include <unordered_map>     // Dn2CppType intern table (one Type per type-info handle)
 
 // Allocation-size query for NativeMemory.AlignedRealloc routes through the PAL
 // (malloc_size on macOS, malloc_usable_size on glibc/musl/BSD).
@@ -712,11 +711,11 @@ static const Dn2CppFieldInfo dn2cpp_ownflds_waithandle[] = {
 };
 extern const Dn2CppType dn2cpp_waithandle_type_obj;
 const Dn2CppTypeInfo dn2cpp_waithandle_type =
-    dn2cpp_ti_with_typeobject({ "System.Threading.WaitHandle", nullptr, 0, nullptr, nullptr, 0, nullptr, nullptr, nullptr, DN2CPP_TF_NO_SHALLOW_CLONE, dn2cpp_ownflds_waithandle, 1 }, &dn2cpp_waithandle_type_obj);
+    dn2cpp_ti_with_typeobject({ "System.Threading.WaitHandle", nullptr, sizeof(Dn2CppWaitHandle), nullptr, nullptr, 0, nullptr, nullptr, nullptr, DN2CPP_TF_NO_SHALLOW_CLONE, dn2cpp_ownflds_waithandle, 1 }, &dn2cpp_waithandle_type_obj);
 const Dn2CppType dn2cpp_waithandle_type_obj = { { &dn2cpp_type_type }, &dn2cpp_waithandle_type };
 extern const Dn2CppType dn2cpp_event_type_obj;
 const Dn2CppTypeInfo dn2cpp_event_type =
-    dn2cpp_ti_with_typeobject({ "System.Threading.EventWaitHandle", &dn2cpp_waithandle_type, 0, nullptr, nullptr, 0, nullptr, nullptr, nullptr, DN2CPP_TF_NO_SHALLOW_CLONE }, &dn2cpp_event_type_obj);
+    dn2cpp_ti_with_typeobject({ "System.Threading.EventWaitHandle", &dn2cpp_waithandle_type, sizeof(Dn2CppWaitHandle), nullptr, nullptr, 0, nullptr, nullptr, nullptr, DN2CPP_TF_NO_SHALLOW_CLONE }, &dn2cpp_event_type_obj);
 const Dn2CppType dn2cpp_event_type_obj = { { &dn2cpp_type_type }, &dn2cpp_event_type };
 extern const Dn2CppType dn2cpp_manualresetevent_type_obj;
 const Dn2CppTypeInfo dn2cpp_manualresetevent_type =
@@ -746,7 +745,7 @@ struct Dn2CppSemaphore : Dn2CppObject
     int maxCount;
 };
 
-struct Dn2CppEvent : Dn2CppObject
+struct Dn2CppEvent : Dn2CppWaitHandle
 {
     std::mutex m;
     std::condition_variable cv;
@@ -765,14 +764,7 @@ struct Dn2CppSafeWaitHandle : Dn2CppObject
     uint32_t dangerousRefs;
 };
 
-struct Dn2CppWaitHandleRegistry
-{
-    std::mutex mutex;
-    std::unordered_map<Dn2CppObject*, Dn2CppObject*> safeHandles;
-};
-
-static Dn2CppWaitHandleRegistry& g_wait_handle_registry =
-    dn2cpp_never_destroyed<Dn2CppWaitHandleRegistry>();
+static std::mutex& g_wait_handle_mutex = dn2cpp_never_destroyed<std::mutex>();
 
 Dn2CppObject* dn2cpp_semaphore_new(int32_t initial, int32_t maxCount)
 {
@@ -868,6 +860,7 @@ Dn2CppObject* dn2cpp_event_new(int32_t initial, int32_t manualReset, const Dn2Cp
 {
     auto* e = new Dn2CppEvent();
     e->type = ti != nullptr ? ti : &dn2cpp_event_type;
+    e->safeHandle = nullptr;
     e->signaled = initial != 0;
     e->manualReset = manualReset != 0;
     e->closed = false;
@@ -901,30 +894,45 @@ static Dn2CppSafeWaitHandle* dn2cpp_managed_event_safe(Dn2CppObject* waitHandle)
     return safe;
 }
 
+static bool dn2cpp_is_runtime_event(Dn2CppObject* waitHandle)
+{
+    return waitHandle->type == &dn2cpp_event_type
+        || waitHandle->type == &dn2cpp_manualresetevent_type
+        || waitHandle->type == &dn2cpp_autoresetevent_type;
+}
+
+static void dn2cpp_waithandle_store_safe(Dn2CppWaitHandle* waitHandle,
+    Dn2CppObject* safeHandle)
+{
+    waitHandle->safeHandle = safeHandle;
+    // Emitted subclasses are GC objects; runtime events are native objects. The
+    // conditional barrier is correct for both storage locations.
+    dn2cpp_gc_write_barrier_if_heap(&waitHandle->safeHandle);
+}
+
 Dn2CppObject* dn2cpp_waithandle_get_safe(Dn2CppObject* waitHandle)
 {
     if (waitHandle == nullptr)
         dn2cpp_throw_null_reference();
-    std::lock_guard<std::mutex> lk(g_wait_handle_registry.mutex);
-    auto it = g_wait_handle_registry.safeHandles.find(waitHandle);
-    if (it == g_wait_handle_registry.safeHandles.end())
-    {
-        auto* safe = dn2cpp_managed_event_safe(waitHandle);
-        it = g_wait_handle_registry.safeHandles.emplace(waitHandle, safe).first;
-    }
-    return it->second;
+    auto* wh = static_cast<Dn2CppWaitHandle*>(waitHandle);
+    std::lock_guard<std::mutex> lk(g_wait_handle_mutex);
+    if (wh->safeHandle == nullptr)
+        dn2cpp_waithandle_store_safe(wh, dn2cpp_is_runtime_event(waitHandle)
+            ? dn2cpp_managed_event_safe(waitHandle)
+            : dn2cpp_safewaithandle_new(0, 0));
+    return wh->safeHandle;
 }
 
 void dn2cpp_waithandle_set_safe(Dn2CppObject* waitHandle, Dn2CppObject* safeHandle)
 {
     if (waitHandle == nullptr)
         dn2cpp_throw_null_reference();
-    std::lock_guard<std::mutex> lk(g_wait_handle_registry.mutex);
-    // SafeWaitHandle's nullable setter uses null to clear the OS handle. The next
-    // getter returns a real invalid wrapper rather than null; retaining a null map
-    // value would make every event operation dereference it.
-    g_wait_handle_registry.safeHandles[waitHandle] = safeHandle != nullptr
-        ? safeHandle : dn2cpp_safewaithandle_new(0, 0);
+    auto* wh = static_cast<Dn2CppWaitHandle*>(waitHandle);
+    std::lock_guard<std::mutex> lk(g_wait_handle_mutex);
+    // SafeWaitHandle's nullable setter clears the OS handle. The next getter returns
+    // a stable invalid wrapper rather than null.
+    dn2cpp_waithandle_store_safe(wh, safeHandle != nullptr
+        ? safeHandle : dn2cpp_safewaithandle_new(0, 0));
 }
 
 intptr_t dn2cpp_safewaithandle_get(Dn2CppObject* safeHandle)
@@ -1020,15 +1028,13 @@ void dn2cpp_waithandle_close(Dn2CppObject* waitHandle)
     if (waitHandle == nullptr)
         dn2cpp_throw_null_reference();
     Dn2CppSafeWaitHandle* safe = nullptr;
-    bool runtimeEvent = waitHandle->type == &dn2cpp_event_type
-        || waitHandle->type == &dn2cpp_manualresetevent_type
-        || waitHandle->type == &dn2cpp_autoresetevent_type;
+    bool runtimeEvent = dn2cpp_is_runtime_event(waitHandle);
     {
-        std::lock_guard<std::mutex> lk(g_wait_handle_registry.mutex);
-        auto it = g_wait_handle_registry.safeHandles.find(waitHandle);
-        if (it != g_wait_handle_registry.safeHandles.end())
+        std::lock_guard<std::mutex> lk(g_wait_handle_mutex);
+        auto* wh = static_cast<Dn2CppWaitHandle*>(waitHandle);
+        safe = static_cast<Dn2CppSafeWaitHandle*>(wh->safeHandle);
+        if (safe != nullptr)
         {
-            safe = static_cast<Dn2CppSafeWaitHandle*>(it->second);
             // A managed WaitHandle subclass can borrow another runtime event's
             // SafeWaitHandle. Disposing the borrower detaches that alias; it must not
             // close the donor event that still owns the condition variable.
@@ -1037,7 +1043,7 @@ void dn2cpp_waithandle_close(Dn2CppObject* waitHandle)
                 std::lock_guard<std::mutex> slk(safe->m);
                 if (safe->managedEvent)
                 {
-                    it->second = dn2cpp_safewaithandle_new(0, 0);
+                    dn2cpp_waithandle_store_safe(wh, dn2cpp_safewaithandle_new(0, 0));
                     safe = nullptr;
                 }
             }
@@ -1045,7 +1051,7 @@ void dn2cpp_waithandle_close(Dn2CppObject* waitHandle)
         else if (runtimeEvent)
         {
             safe = dn2cpp_managed_event_safe(waitHandle);
-            g_wait_handle_registry.safeHandles.emplace(waitHandle, safe);
+            dn2cpp_waithandle_store_safe(wh, safe);
         }
     }
     if (safe != nullptr)
@@ -1073,11 +1079,12 @@ static Dn2CppEvent* dn2cpp_event_from_operand(Dn2CppObject* o,
         return nullptr;
     }
     {
-        std::lock_guard<std::mutex> lk(g_wait_handle_registry.mutex);
-        auto it = g_wait_handle_registry.safeHandles.find(o);
-        if (it != g_wait_handle_registry.safeHandles.end())
+        std::lock_guard<std::mutex> lk(g_wait_handle_mutex);
+        auto* wh = static_cast<Dn2CppWaitHandle*>(o);
+        auto* slot = wh->safeHandle;
+        if (slot != nullptr)
         {
-            auto* safe = static_cast<Dn2CppSafeWaitHandle*>(it->second);
+            auto* safe = static_cast<Dn2CppSafeWaitHandle*>(slot);
             std::lock_guard<std::mutex> slk(safe->m);
             if (safe->closed)
                 dn2cpp_throw_object_disposed();
@@ -1091,10 +1098,9 @@ static Dn2CppEvent* dn2cpp_event_from_operand(Dn2CppObject* o,
             return nullptr;
         }
     }
-    if (o->type == &dn2cpp_waithandle_type)
-    {
+    if (!dn2cpp_is_runtime_event(o)
+        && dn2cpp_typeinfo_assignable(o->type, &dn2cpp_waithandle_type))
         dn2cpp_throw_invalid_operation();
-    }
     return static_cast<Dn2CppEvent*>(o);
 }
 

--- a/samples/dotnet/ThreadingPrimitives/Program.cs
+++ b/samples/dotnet/ThreadingPrimitives/Program.cs
@@ -23,6 +23,7 @@ namespace ThreadingPrimitives
             LockTypeSubset.Program.__GateEntry();
             EventTypeIdentity.Program.__GateEntry();
             LegacyThreadVolatile.Program.__GateEntry();
+            WaitHandleRegistryLifetime.Program.__GateEntry();
         }
     }
 }

--- a/samples/dotnet/ThreadingPrimitives/WaitHandleRegistryLifetime.cs
+++ b/samples/dotnet/ThreadingPrimitives/WaitHandleRegistryLifetime.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Microsoft.Win32.SafeHandles;
+
+namespace WaitHandleRegistryLifetime;
+
+internal static class Program
+{
+    private sealed class AttachedWaitHandle : WaitHandle
+    {
+        internal int Sentinel;
+
+        internal AttachedWaitHandle()
+        {
+        }
+
+        internal AttachedWaitHandle(SafeWaitHandle safeHandle)
+        {
+            SafeWaitHandle = safeHandle;
+        }
+    }
+
+    private sealed class DerivedEventWaitHandle : EventWaitHandle
+    {
+        internal int Sentinel;
+
+        private DerivedEventWaitHandle()
+            : base(false, EventResetMode.ManualReset)
+        {
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void DropAttached(SafeWaitHandle donorSafe)
+    {
+        var attached = new AttachedWaitHandle(donorSafe);
+        GC.SuppressFinalize(attached);
+        GC.KeepAlive(attached);
+    }
+
+    internal static void __GateEntry()
+    {
+        Console.WriteLine("== wait handle key lifetime ==");
+
+        var donor = new ManualResetEvent(false);
+        SafeWaitHandle donorSafe = donor.SafeWaitHandle;
+        DropAttached(donorSafe);
+        for (int i = 0; i < 8; i++)
+            GC.Collect();
+
+        bool isolated = true;
+        bool freshInvalid = true;
+        bool freshOpen = true;
+        bool directLayout = true;
+        for (int i = 0; i < 4096; i++)
+        {
+            var fresh = new AttachedWaitHandle();
+            fresh.Sentinel = 42;
+            SafeWaitHandle freshSafe = fresh.SafeWaitHandle;
+            isolated &= !ReferenceEquals(freshSafe, donorSafe);
+            freshInvalid &= freshSafe.IsInvalid;
+            freshOpen &= !freshSafe.IsClosed;
+            directLayout &= fresh.Sentinel == 42;
+        }
+
+        Console.WriteLine("fresh isolated=" + isolated
+            + " invalid=" + freshInvalid + " open=" + freshOpen);
+
+        var derived = (DerivedEventWaitHandle)RuntimeHelpers.GetUninitializedObject(
+            typeof(DerivedEventWaitHandle));
+        derived.Sentinel = 42;
+        SafeWaitHandle derivedSafe = derived.SafeWaitHandle;
+        Console.WriteLine("layout direct=" + directLayout
+            + " event-derived=" + (derived.Sentinel == 42)
+            + " invalid=" + derivedSafe.IsInvalid + " open=" + !derivedSafe.IsClosed);
+        GC.KeepAlive(donor);
+    }
+}

--- a/src/Dn2Cpp.Transpiler/CppEmitter.cs
+++ b/src/Dn2Cpp.Transpiler/CppEmitter.cs
@@ -6177,6 +6177,19 @@ internal sealed partial class CppEmitter
             ClassInfo.ShareStructLayout && c.SharedOwner is not null;
         // The class whose emitted struct definition carries c's layout.
         static ClassInfo StructCarrier(ClassInfo c) => IsStructAlias(c) ? c.SharedOwner! : c;
+        static bool InheritsFromWaitHandle(ClassInfo c)
+        {
+            for (var b = c; b is not null; b = b.BaseClass)
+            {
+                if (b.FullName == "System.Threading.WaitHandle")
+                    return true;
+                if (b.BaseClass is null
+                    && b.ExternalBaseName is "System.Threading.WaitHandle"
+                        or "System.Threading.EventWaitHandle")
+                    return true;
+            }
+            return false;
+        }
         // Interfaces are emitted as empty structs (below) and can be pointer-field
         // types (e.g. Dictionary._comparer : IEqualityComparer<TKey>), so they need
         // forward declarations too, ahead of any struct that references them.
@@ -6258,15 +6271,15 @@ internal sealed partial class CppEmitter
             }
             // A non-opaque class chains through its non-opaque base. When the base
             // is opaque (typically System.Exception or System.Object) the layout
-            // roots at Dn2CppObject — except for user-defined Exception derivatives,
-            // which root at Dn2CppExceptionObject so the runtime's message/inner
-            // slots sit before any derived instance field, matching what
-            // dn2cpp_exception_message / _inner reinterpret_cast onto.
+            // roots at Dn2CppObject — except for runtime-owned prefixes whose hidden
+            // fields must precede every user-defined instance field.
             string baseName;
             if (!IsOpaque(cls) && cls.BaseClass is { } bc && !IsOpaque(bc))
                 baseName = bc.CppStructName;
             else if (!IsOpaque(cls) && Compilation.InheritsFromException(cls))
                 baseName = "Dn2CppExceptionObject";
+            else if (!IsOpaque(cls) && InheritsFromWaitHandle(cls))
+                baseName = "Dn2CppWaitHandle";
             else
                 baseName = "Dn2CppObject";
             _renderedStructRefs.Add((cls, "<base>", baseName));

--- a/src/Dn2Cpp.Transpiler/HotUpdate/AbiContract.cs
+++ b/src/Dn2Cpp.Transpiler/HotUpdate/AbiContract.cs
@@ -39,9 +39,10 @@ internal static class AbiContract
     /// 1 = value types packed at real storage width; 2 = an int32 hresult slot added
     /// to the Dn2CppExceptionObject prefix; 3 = a trace slot added to that prefix;
     /// 4 = reference-type instance fields and all static fields narrowed to real
-    /// storage width; 5 = <c>System.DateTime</c> repacked from 16 bytes to .NET's 8.
+    /// storage width; 5 = <c>System.DateTime</c> repacked from 16 bytes to .NET's 8;
+    /// 6 = WaitHandle gained its hidden SafeWaitHandle prefix slot.
     /// Bump on any future layout-mapping change.</summary>
-    public const int LayoutPolicyVersion = 5;
+    public const int LayoutPolicyVersion = 6;
 
     /// <summary>Serializes canonical contract v1 over the emitted classes. The
     /// serialization is symbolic — type names and base chains, layout


### PR DESCRIPTION
## Summary

- replace the native pointer-keyed wait-handle registry with a GC-visible slot owned by each managed WaitHandle
- preserve the hidden prefix through AOT and hot-update subclass layouts, including opaque EventWaitHandle bases
- add deterministic address-reuse and inherited-layout regression coverage

## Reproduction

Before this fix, repeated collection and allocation reused the collected subclass address on every dn2cpp run and returned the donor SafeWaitHandle from the stale registry entry. .NET instead returned a distinct invalid, open SafeWaitHandle for each fresh owner.

After this fix, the association is reachable only through its owning WaitHandle, so collecting the owner removes the lookup path and address reuse cannot inherit an earlier handle.

## Verification

- `dotnet build src/Dn2Cpp.Cli -c Release --no-restore -v:minimal`
- `DN2CPP_GATE_CACHE=0 ./gates/build-and-run-threading-primitives.sh`
- `CONFIG=Debug DN2CPP_GATE_CACHE=0 ./gates/build-and-run-threading-primitives.sh`
- `./gates/build-and-run-doc-claims.sh`
- `DN2CPP_SKIP_BUILD=1 DN2CPP_CLI_DLL="$PWD/src/Dn2Cpp.Cli/bin/Release/net10.0/dn2cpp.dll" ./gates/build-and-run-hotupdate-subset.sh`
- `git diff --check`

All gates completed without skips or expected-partial results.

Closes #108
