### PR TITLE
Skip final C++ body rendering during planning

### DIFF
--- a/gates/build-and-run-emit-order-stability.sh
+++ b/gates/build-and-run-emit-order-stability.sh
@@ -58,6 +58,7 @@ mkdir -p "$OUT"
 
 # project | extra BCL references (the same reference set each project's own gate uses)
 SAMPLES=(
+    "SharedGenerics|System.Collections"
     "ReflectTypes|System.Linq.Expressions System.Linq System.Collections System.Reflection.Emit System.Reflection.Emit.Lightweight System.Reflection.Emit.ILGeneration System.ComponentModel.Primitives"
     "StringCore|System.Linq"
     "ArrayCore|"
@@ -82,6 +83,7 @@ if gate_cache_check "$OUT" "emit-order-stability|jobs:1,2|measure-jobs:1,2|cli:$
         "samples/dotnet/ReflectTypes/bin/$CONFIG/$TFM/ReflectTypes.dll" \
         "samples/dotnet/StringCore/bin/$CONFIG/$TFM/StringCore.dll" \
         "samples/dotnet/ArrayCore/bin/$CONFIG/$TFM/ArrayCore.dll" \
+        "samples/dotnet/SharedGenerics/bin/$CONFIG/$TFM/SharedGenerics.dll" \
         "samples/dotnet/PInvokeByValTStrBad/bin/$CONFIG/$TFM/PInvokeByValTStrBad.dll"; then
     gate_cache_hit_msg
     exit 0

--- a/gates/build-and-run-shared-generics.sh
+++ b/gates/build-and-run-shared-generics.sh
@@ -38,6 +38,8 @@
 # created, and a generic that calls itself at an ever-deeper type argument creates
 # them without end. That bound, and the transpiler's other resource limits, are
 # asserted by gates/build-and-run-transpiler-limits.sh.
+# Static synchronized prologues must taint even when the IL never mentions T;
+# instance synchronized bodies remain shared and lock the real receiver.
 #
 # The last section (GenericMethodSubset, folded from the retired
 # build-and-run-generic-method-subset.sh) is NOT about sharing: it is the
@@ -271,6 +273,17 @@ for sym in ti_GvmCanonicalSubset_Chain_GvmCanonicalSubset_Row_String \
 done
 echo "gvm dispatcher over a canonical group: shape present, all cases declared: OK"
 
+for inst in String Object; do
+    grep -Eq "^DN2CPP_NOINLINE int32_t m_GenericStaticsSubset_SynchronizedOwner_${inst}_StaticProbe_[0-9]+\\(" "$out"/generated*.cpp \
+        || { echo "FAIL: static synchronized body lost its real type: $inst" >&2; exit 1; }
+done
+grep -Eq '^DN2CPP_NOINLINE int32_t m_GenericStaticsSubset_SynchronizedOwner__CnRef_InstanceProbe_[0-9]+\(' "$out"/generated*.cpp \
+    || { echo "FAIL: instance synchronized body no longer shares" >&2; exit 1; }
+if grep -Eq 'm_GenericStaticsSubset_SynchronizedOwner__CnRef_StaticProbe_[0-9]+\(' "$out/generated.h" "$out"/generated*.cpp; then
+    echo "FAIL: static synchronized prologue escaped the planning taint" >&2
+    exit 1
+fi
+
 echo "== 5/7 Transpiling with --no-shared-generics (size regression check) =="
 invoke_cli "$app" "${refs[@]}" --no-shared-generics -o "$out-off"
 on_bytes=$(cat "$out"/generated*.cpp | wc -c | tr -d ' ')
@@ -300,4 +313,10 @@ expected=$(dotnet "$app"); expected_code=$?
 set -e
 assert_output "$native" "$expected"
 assert_exit_code "$native_code" "$expected_code"
+for line in \
+    'sync static string own=False' 'sync static object own=False' 'sync static other=True' \
+    'sync instance string own=False' 'sync instance object own=False' 'sync instance other=True'; do
+    grep -Fxq "$line" <<<"$native" \
+        || { echo "FAIL: synchronized prologue witness missing: $line" >&2; exit 1; }
+done
 gate_cache_commit

--- a/gates/build-and-run-transpiler-limits.sh
+++ b/gates/build-and-run-transpiler-limits.sh
@@ -478,7 +478,7 @@ echo "== 3f/8 Wrapper lowering must distinguish unsupported shapes from fatal bo
 wrapper_transpiler="$(dirname "${DN2CPP_CLI_DLL:-src/Dn2Cpp.Cli/bin/$CONFIG/$TFM/dn2cpp.dll}")/Dn2Cpp.Transpiler.dll"
 wrapper_rc=0
 wrapper_result=$(dotnet "$wrapper_app" "$wrapper_transpiler") || wrapper_rc=$?
-assert_output "$wrapper_result" 'wrapper NotSupportedException: OK
+assert_output "$(strip_cr_win "$wrapper_result")" 'wrapper NotSupportedException: OK
 wrapper InstantiationBoundException: OK
 wrapper StrictCompletionException: OK'
 assert_exit_code "$wrapper_rc" 0

--- a/gates/build-and-run-transpiler-limits.sh
+++ b/gates/build-and-run-transpiler-limits.sh
@@ -82,6 +82,8 @@
 #
 # A sibling measurement aid, gates/measure-transpile-mem.sh, reports peak RSS and
 # the per-phase heap curve. This gate asserts; that one measures.
+# Canonical linking and synthesized-wrapper lowering must preserve fatal bounds
+# while ordinary unsupported wrapper shapes still fall back.
 source "$(dirname "$0")/_common.sh"
 
 out="artifacts/transpiler-limits"
@@ -100,6 +102,9 @@ build_proj samples/dotnet/StringCore/StringCore.csproj
 build_proj samples/dotnet/ArrayCore/ArrayCore.csproj
 build_proj samples/dotnet/SharedTrialMint/SharedTrialMint.csproj
 build_proj samples/dotnet/TypeofMissingAsmBad/TypeofMissingAsmBad.csproj
+# These compiler probes live outside the suite's samples-only prebuild.
+build_gate_proj gates/fixtures/transpiler-limits/CanonicalLink/CanonicalLinkBound.csproj
+build_gate_proj gates/fixtures/transpiler-limits/WrapperExceptions/WrapperExceptions.csproj
 rec_app="samples/dotnet/GenericRecursionBad/bin/$CONFIG/$TFM/GenericRecursionBad.dll"
 sig_app="samples/dotnet/GenericSignatureRecursionBad/bin/$CONFIG/$TFM/GenericSignatureRecursionBad.dll"
 fld_app="samples/dotnet/GenericFieldRecursionBad/bin/$CONFIG/$TFM/GenericFieldRecursionBad.dll"
@@ -108,6 +113,8 @@ big_app="samples/dotnet/StringCore/bin/$CONFIG/$TFM/StringCore.dll"
 arr_app="samples/dotnet/ArrayCore/bin/$CONFIG/$TFM/ArrayCore.dll"
 mint_app="samples/dotnet/SharedTrialMint/bin/$CONFIG/$TFM/SharedTrialMint.dll"
 tma_app="samples/dotnet/TypeofMissingAsmBad/bin/$CONFIG/$TFM/TypeofMissingAsmBad.dll"
+link_app="gates/fixtures/transpiler-limits/CanonicalLink/bin/$CONFIG/$TFM/CanonicalLinkBound.dll"
+wrapper_app="gates/fixtures/transpiler-limits/WrapperExceptions/bin/$CONFIG/$TFM/WrapperExceptions.dll"
 # The assembly section 8 withholds and then supplies. It sits beside the CoreLib in
 # the shared framework; a requested reference that is absent is a hard failure, not
 # a quietly dropped one — withholding it is the whole point of the section,
@@ -133,8 +140,15 @@ numerics_dll="$(dirname "$corelib")/System.Runtime.Numerics.dll"
 # to catch that.
 tenv="tenv:${DN2CPP_MAX_GENERIC_DEPTH:-}/${DN2CPP_MAX_INSTANTIATIONS:-}/${DN2CPP_MAX_HEAP_MB:-}/${DN2CPP_SHARED_ASSERT:-}/${DN2CPP_STRICT_COMPLETION:-}/${DN2CPP_SPEC_DRAIN:-}"
 rm -rf "$out" "$sig_out" "$cut_out" "$mint_out"; mkdir -p "$out"
-if gate_cache_check "$out" "transpiler-limits|cli:$(_gate_cli_hash)|$corelib|$tenv" \
+if gate_cache_check "$out" "transpiler-limits|canonical-cap:1,2|canonical-refs:none|wrapper-exceptions|cli:$(_gate_cli_hash)|$corelib|$tenv" \
         "$rec_app" "$sig_app" "$fld_app" "$afld_app" "$big_app" "$arr_app" "$mint_app" "$tma_app" \
+        gates/fixtures/transpiler-limits/CanonicalLink/Program.cs \
+        gates/fixtures/transpiler-limits/CanonicalLink/CanonicalLinkBound.csproj \
+        gates/fixtures/transpiler-limits/WrapperExceptions/Program.cs \
+        gates/fixtures/transpiler-limits/WrapperExceptions/WrapperExceptions.csproj \
+        "$link_app" "$wrapper_app" \
+        "${link_app%.dll}.runtimeconfig.json" "${link_app%.dll}.deps.json" \
+        "${wrapper_app%.dll}.runtimeconfig.json" "${wrapper_app%.dll}.deps.json" \
         "${sig_app%.dll}.runtimeconfig.json" "${sig_app%.dll}.deps.json"; then
     gate_cache_hit_msg
     exit 0
@@ -423,6 +437,52 @@ set -e
 assert_output "$mint_native" "$mint_expected"
 assert_exit_code "$mint_native_rc" "$mint_expected_rc"
 echo "OK (and the shared body's array-to-collection boundary runs — output matches real .NET)"
+
+echo "== 3e/8 Canonical linking must preserve the instantiation bound =="
+# No BCL reference: the only instantiations are Id<string> and its canonical
+# Id<CnRef>. The second mint occurs inside canonical linking's fallback arm.
+for mode in "" "--measure"; do
+    label=${mode:-emit}
+    link_dir="$out/canonical-${label#--}"
+    link_so="$out/canonical-${label#--}.stdout"
+    link_se="$out/canonical-${label#--}.stderr"
+    link_rc=0
+    (export DN2CPP_MAX_INSTANTIATIONS=1
+     invoke_cli "$link_app" $mode -o "$link_dir") >"$link_so" 2>"$link_se" || link_rc=$?
+    if [ "$link_rc" -ne 2 ] \
+            || ! grep -q 'instantiation count passed the 1 limit while instantiating CanonicalLinkBound.Program::Id<CnRef>' "$link_se" \
+            || ! grep -q 'DN2CPP_MAX_INSTANTIATIONS' "$link_se" \
+            || grep -q 'instantiation count passed' "$link_so"; then
+        echo "FAIL: canonical linking ($label) must fail with exit 2 and the count-bound diagnostic; got $link_rc" >&2
+        cat "$link_so" "$link_se" >&2
+        exit 1
+    fi
+
+    (export DN2CPP_MAX_INSTANTIATIONS=2
+     invoke_cli "$link_app" $mode -o "$link_dir") >"$link_so" 2>"$link_se"
+    if [ -z "$mode" ]; then
+        if ! grep -Eq '^inline .* m_CanonicalLinkBound_Program_Id_[0-9]+___CnRef\([^;]*\)$' "$link_dir/generated.h"; then
+            echo "FAIL: raising the bound did not produce the canonical Id<CnRef> body" >&2
+            exit 1
+        fi
+    elif ! grep -q '0 gaps total' "$link_so" \
+            || [ ! -f "$link_dir/s0-gaps.tsv" ] || [ -s "$link_dir/s0-gaps.tsv" ]; then
+        echo "FAIL: raising the canonical-link bound did not produce a clean measure report" >&2
+        cat "$link_so" "$link_se" >&2
+        exit 1
+    fi
+    echo "OK ($label: canonical-link bound escaped; raising it permits canonical sharing)"
+done
+
+echo "== 3f/8 Wrapper lowering must distinguish unsupported shapes from fatal bounds =="
+wrapper_transpiler="$(dirname "${DN2CPP_CLI_DLL:-src/Dn2Cpp.Cli/bin/$CONFIG/$TFM/dn2cpp.dll}")/Dn2Cpp.Transpiler.dll"
+wrapper_rc=0
+wrapper_result=$(dotnet "$wrapper_app" "$wrapper_transpiler") || wrapper_rc=$?
+assert_output "$wrapper_result" 'wrapper NotSupportedException: OK
+wrapper InstantiationBoundException: OK
+wrapper StrictCompletionException: OK'
+assert_exit_code "$wrapper_rc" 0
+echo "OK (ordinary wrapper failure falls back; fatal exceptions escape unchanged)"
 
 echo "== 4/8 The heap ceiling fires — in emit AND in --measure =="
 # A program big enough that the model alone passes a small budget: the real

--- a/gates/fixtures/transpiler-limits/CanonicalLink/CanonicalLinkBound.csproj
+++ b/gates/fixtures/transpiler-limits/CanonicalLink/CanonicalLinkBound.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Optimize>true</Optimize>
+    <DebugType>none</DebugType>
+  </PropertyGroup>
+</Project>

--- a/gates/fixtures/transpiler-limits/CanonicalLink/Program.cs
+++ b/gates/fixtures/transpiler-limits/CanonicalLink/Program.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Globalization;
+
+namespace CanonicalLinkBound;
+
+internal static class Program
+{
+    private static T Id<T>(T value) => value;
+
+    private static void Main()
+    {
+        CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+        CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+        Console.WriteLine(Id("canonical-link-bound"));
+    }
+}

--- a/gates/fixtures/transpiler-limits/WrapperExceptions/Program.cs
+++ b/gates/fixtures/transpiler-limits/WrapperExceptions/Program.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.IO;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Runtime.Loader;
+
+namespace WrapperExceptions;
+
+internal static class Program
+{
+    private static int Main(string[] args)
+    {
+        CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+        CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+        if (args.Length != 1)
+            throw new ArgumentException("Pass the Dn2Cpp.Transpiler.dll used by this gate.");
+
+        var assembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(Path.GetFullPath(args[0]));
+        var compilerType = assembly.GetType("Dn2Cpp.MethodCompiler", throwOnError: true)!;
+        var methodType = assembly.GetType("Dn2Cpp.MethodInfo", throwOnError: true)!;
+        var moduleType = assembly.GetType("Dn2Cpp.Module", throwOnError: true)!;
+        var typeDescType = assembly.GetType("Dn2Cpp.TypeDesc", throwOnError: true)!;
+        var boundType = assembly.GetType("Dn2Cpp.InstantiationBoundException", throwOnError: true)!;
+        var strictType = assembly.GetType("Dn2Cpp.StrictCompletionException", throwOnError: true)!;
+        var wrapper = compilerType.GetMethod("SynthesizeWrapperBody", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        // Load the gate's exact compiler and inject at its lowering boundary; a
+        // real wrapper's instantiation count depends on the loaded BCL version.
+        var method = Activator.CreateInstance(methodType)!;
+        methodType.GetField("Attributes")!.SetValue(method, MethodAttributes.Static);
+        methodType.GetField("Module")!.SetValue(method, Activator.CreateInstance(moduleType));
+        var returnType = typeDescType.GetMethod("MakePrimitive")!.Invoke(null, new object[] { PrimitiveTypeCode.Void })!;
+        typeof(Program).GetMethod(nameof(SetSignature), BindingFlags.NonPublic | BindingFlags.Static)!
+            .MakeGenericMethod(typeDescType).Invoke(null, new[] { method, returnType });
+        var compiler = Activator.CreateInstance(compilerType, new object?[] { null, method, null, null })!;
+        var errors = new[]
+        {
+            new NotSupportedException("unsupported wrapper shape"),
+            (Exception)Activator.CreateInstance(boundType, new object[] { "instantiation bound" })!,
+            (Exception)Activator.CreateInstance(strictType, new object[] { "strict completion" })!,
+        };
+
+        bool passed = true;
+        foreach (var error in errors)
+        {
+            bool lowerRan = false;
+            Func<bool> lower = () => { lowerRan = true; throw error; };
+            bool fallback = false;
+            bool escaped = false;
+            try
+            {
+                fallback = wrapper.Invoke(compiler, new object[] { "Unused*", lower, "exception probe" }) is null;
+            }
+            catch (TargetInvocationException ex) when (ex.InnerException is { } inner)
+            {
+                escaped = ReferenceEquals(inner, error);
+            }
+            bool expectedFallback = error.GetType() == typeof(NotSupportedException);
+            bool correct = lowerRan && (expectedFallback ? fallback && !escaped : escaped && !fallback);
+            passed &= correct;
+            Console.WriteLine($"wrapper {error.GetType().Name}: {(correct ? "OK" : "FAIL")}");
+        }
+        return passed ? 0 : 1;
+    }
+
+    private static void SetSignature<T>(object method, object returnType)
+    {
+        var signature = new MethodSignature<T>(default, (T)returnType, 0, 0, ImmutableArray<T>.Empty);
+        method.GetType().GetProperty("Signature")!.SetValue(method, signature);
+    }
+}

--- a/gates/fixtures/transpiler-limits/WrapperExceptions/WrapperExceptions.csproj
+++ b/gates/fixtures/transpiler-limits/WrapperExceptions/WrapperExceptions.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Optimize>true</Optimize>
+    <DebugType>none</DebugType>
+  </PropertyGroup>
+</Project>

--- a/samples/dotnet/SharedGenerics/GenericStaticsSubset.cs
+++ b/samples/dotnet/SharedGenerics/GenericStaticsSubset.cs
@@ -4,6 +4,8 @@
 // static-touching bodies fall back per instantiation by the statics taint rule.
 // Real System.Private.CoreLib (-r), run vs .NET.
 using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
 namespace GenericStaticsSubset;
 
 enum Mode { Off = 0, On = 1 }
@@ -24,8 +26,48 @@ class Counter<T>
     public static string Describe() => Tag + "#" + Created;
 }
 
+class SynchronizedOwner<T>
+{
+    // The IL has no type-dependent operation; only the static monitor prologue
+    // makes this body ineligible for canonical sharing.
+    [MethodImpl(MethodImplOptions.Synchronized | MethodImplOptions.NoInlining)]
+    public static bool StaticProbe(object monitor) => MonitorProbe.CanEnter(monitor);
+
+    [MethodImpl(MethodImplOptions.Synchronized | MethodImplOptions.NoInlining)]
+    public bool InstanceProbe(object monitor) => MonitorProbe.CanEnter(monitor);
+}
+
+static class MonitorProbe
+{
+    public static bool CanEnter(object monitor)
+    {
+        bool entered = false;
+        var thread = new Thread(() =>
+        {
+            entered = Monitor.TryEnter(monitor, 0);
+            if (entered)
+                Monitor.Exit(monitor);
+        });
+        thread.Start();
+        thread.Join();
+        return entered;
+    }
+}
+
 class Program
 {
+    internal static void SynchronizedPrologues()
+    {
+        Console.WriteLine("sync static string own=" + SynchronizedOwner<string>.StaticProbe(typeof(SynchronizedOwner<string>)));
+        Console.WriteLine("sync static object own=" + SynchronizedOwner<object>.StaticProbe(typeof(SynchronizedOwner<object>)));
+        Console.WriteLine("sync static other=" + SynchronizedOwner<string>.StaticProbe(typeof(SynchronizedOwner<object>)));
+        var first = new SynchronizedOwner<string>();
+        var second = new SynchronizedOwner<object>();
+        Console.WriteLine("sync instance string own=" + first.InstanceProbe(first));
+        Console.WriteLine("sync instance object own=" + second.InstanceProbe(second));
+        Console.WriteLine("sync instance other=" + first.InstanceProbe(second));
+    }
+
     internal static void __GateEntry()
     {
         var a = new Counter<Mode>(Mode.On);

--- a/samples/dotnet/SharedGenerics/Program.cs
+++ b/samples/dotnet/SharedGenerics/Program.cs
@@ -38,6 +38,7 @@ namespace SharedGenerics
             MangleKindShadowSubset.Program.__GateEntry();
             GenericMethodSubset.Program.__GateEntry();
             GvmCanonicalSubset.Program.__GateEntry();
+            GenericStaticsSubset.Program.SynchronizedPrologues();
         }
     }
 }

--- a/src/Dn2Cpp.Transpiler/Compilation.Rgctx.cs
+++ b/src/Dn2Cpp.Transpiler/Compilation.Rgctx.cs
@@ -131,7 +131,7 @@ internal sealed partial class Compilation
             // over wrong-sharing.
             counterpart.EnsureSignature();
         }
-        catch (NotSupportedException)
+        catch (NotSupportedException ex) when (!IsMustEscape(ex))
         {
             return;
         }

--- a/src/Dn2Cpp.Transpiler/MethodCompiler.cs
+++ b/src/Dn2Cpp.Transpiler/MethodCompiler.cs
@@ -850,12 +850,49 @@ internal sealed partial class MethodCompiler : IEvalStack
             TranslateWithPendingReferenceBarriers(insn);
         }
 
+        return FinishBody();
+    }
+
+    private string FinishBody()
+    {
+        // Signature rendering can resolve lazy model state and reject unsupported types.
+        // Keep it, prologue taint and rgctx validation in both compile passes.
+        string signature = Signature(_method);
+        string? synchronizedTypeInfo = null;
+        if (_method.IsSynchronized && _method.IsStatic)
+        {
+            // A canonical owner has no type-info: each real instantiation must lock
+            // its own interned Type object, even when the IL never mentions T.
+            TaintIfCanonical(_method.DeclaringClass, "synchronized");
+            synchronizedTypeInfo = _method.DeclaringClass.CppTypeInfoName;
+        }
+        string? rgctxAnchor = null;
+        if (_usedRgctx && !_method.RgctxParam && SharedDirectCallees is null)
+        {
+            if (!_method.RgctxUses)
+                throw new InvalidOperationException(
+                    $"{_method.DeclaringClass.FullName}.{_method.Name}: body uses rgctx but the "
+                    + "planning pass did not record it");
+            rgctxAnchor = _c.RgctxAnchorSym(_method.DeclaringClass)
+                ?? throw new InvalidOperationException(
+                    $"{_method.DeclaringClass.FullName}.{_method.Name}: rgctx use with no anchor "
+                    + "and no hidden parameter");
+        }
+
+        // Planning keeps lowering's effects, but has no consumer for a finished function.
+        if (_c.Phase == EmitPhase.Planning)
+            return "";
+        return RenderBody(signature, synchronizedTypeInfo, rgctxAnchor);
+    }
+
+    private string RenderBody(string signature, string? synchronizedTypeInfo, string? rgctxAnchor)
+    {
         var sb = new StringBuilder();
         sb.AppendLine($"// {_method.DeclaringClass.FullName}::{_method.Name}");
         // External linkage (no `static`): the body may live in a different translation unit
         // than its callers once the output is split across files; the header carries the
         // forward declaration. Unused external functions don't warn, so no [[maybe_unused]].
-        sb.AppendLine($"{Signature(_method)}");
+        sb.AppendLine(signature);
         sb.AppendLine("{");
         // An [UnmanagedCallersOnly] method can be invoked from a thread the
         // collector has never seen (a native host's own thread pool); the prologue
@@ -868,7 +905,7 @@ internal sealed partial class MethodCompiler : IEvalStack
         // it — the frame brackets the whole body on every return path and on unwind.
         // The name is a raw C string literal, NOT a LiteralPool str_N entry: the pool
         // is numbered during the planning pass, and pooling the name would perturb
-        // that numbering. Emitted identically in both passes (no pass branch).
+        // that numbering.
         if (_c.ShadowStackEnabled)
             sb.AppendLine($"    Dn2CppShadowFrame __shadowFrame(\"{ShadowFrameName()}\");");
         // [MethodImpl(MethodImplOptions.Synchronized)]: the whole body runs under
@@ -883,11 +920,8 @@ internal sealed partial class MethodCompiler : IEvalStack
         {
             if (_method.IsStatic)
             {
-                // A canonical shared body has no ti_ of its own; taint so each
-                // real instantiation compiles its own body locking its own type.
-                TaintIfCanonical(_method.DeclaringClass, "synchronized");
                 sb.AppendLine("    Dn2CppMonitorGuard __syncGuard((Dn2CppObject*)"
-                    + $"dn2cpp_get_type_from_handle(&{_method.DeclaringClass.CppTypeInfoName}));");
+                    + $"dn2cpp_get_type_from_handle(&{synchronizedTypeInfo}));");
             }
             else
             {
@@ -899,18 +933,10 @@ internal sealed partial class MethodCompiler : IEvalStack
         // type at this class's declaring level. Emitted only when a slot was
         // actually used (the lazy prologue), and only in the emission pass
         // (planning text is discarded, and its flags are not final yet).
-        if (_usedRgctx && !_method.RgctxParam && SharedDirectCallees is null)
+        if (rgctxAnchor is not null)
         {
-            if (!_method.RgctxUses)
-                throw new InvalidOperationException(
-                    $"{_method.DeclaringClass.FullName}.{_method.Name}: body uses rgctx but the "
-                    + "planning pass did not record it");
-            string anchor = _c.RgctxAnchorSym(_method.DeclaringClass)
-                ?? throw new InvalidOperationException(
-                    $"{_method.DeclaringClass.FullName}.{_method.Name}: rgctx use with no anchor "
-                    + "and no hidden parameter");
             sb.AppendLine("    const void* const* __rgctx = "
-                + $"dn2cpp_rgctx(((const Dn2CppObject*)a0)->type, &{anchor});");
+                + $"dn2cpp_rgctx(((const Dn2CppObject*)a0)->type, &{rgctxAnchor});");
         }
         // [HotPath(NoAlias)] span parameters: the element pointer hoisted once,
         // qualified. Only the entries an indexer route actually addressed are

--- a/src/Dn2Cpp.Transpiler/MethodCompiler.cs
+++ b/src/Dn2Cpp.Transpiler/MethodCompiler.cs
@@ -1053,7 +1053,7 @@ internal sealed partial class MethodCompiler : IEvalStack
             if (!lower())
                 return null;
         }
-        catch (NotSupportedException)
+        catch (NotSupportedException ex) when (!Compilation.IsMustEscape(ex))
         {
             return null; // a shape the lowering does not model stays bodyless
         }


### PR DESCRIPTION
共有ジェネリックのplanningは各bodyのloweringを実行した後、使用しない完成関数のC++文字列も構築していました。`MethodCompiler`の終了処理を意味処理と文字列の組み立てに分け、planningでは完成関数の`StringBuilder`、`_body`のコピー、最後の`ToString()`を省きます。

`Signature`の評価、static synchronizedメソッドのcanonical taint、rgctxの不変条件チェックは分岐前に残しています。通常emission・限定並列・`--measure`は同じ終了処理を通ります。ILのlowering、`_body`の保存、合成本体の処理は従来どおりです。bodyやILを次のpassまで保持するキャッシュは追加していません。今回の範囲はIssueの最初の実装単位（計測と最終整形の分離）です。

回帰ケースを既存のSharedGenericsバケットに追加しました。型引数に依存しないILを持つstatic synchronizedメソッドが、各閉じた型のmonitorを使うことを別スレッドの`Monitor.TryEnter`で確認します。同じILを持つinstanceメソッドは共有されたまま実receiverをlockすることも確認し、両方向の生成symbolをassertします。既存stdoutが変更なしのprefixとして残り、新しい末尾の各行が実行されることを確認しました。このバケットを出力順序・strict completionの比較対象にも追加しています。

### 計測

基準は`308e30e00cdda083d7166a1b397d0fa417bc1898`。Windows x64、Core i9-13900HX（32 logical processors）、約64 GiB RAM、SDK 10.0.301 / runtime 10.0.11で計測しました。入力DLLと参照DLLは基準ビルドに固定し、共有on、`--jobs 1`、`DN2CPP_TIME=1`、新規出力ディレクトリ、新規CLI processで実行しています。各条件のwarmupを1回除外し、前後の実行順を交互にした3回の中央値です。C++のビルド、gate cache、他の検証ジョブとの並行実行は含みません。

| 入力 | 全体wall ms 前→後（min–max） | plan-bodies ms 前→後 | compile-bodies ms 前→後 | peak working set MiB 前→後 |
|---|---|---|---|---|
| HelloWorld（既定参照） | 311.939 (309.739–313.414) → 308.685 (307.682–310.967) | 94 → 94 | 16 → 16 | 48.070 → 47.117 |
| JsonProbe（CoreLib/STJ、auto-ref） | 1179.009 (1175.716–1189.245) → 1147.493 (1136.656–1149.968) | 359 → 359 | 156 → 141 | 180.652 → 169.598 |
| full CLI自己入力（selfhost-emitの参照集合） | 9750.792 (9547.361–9768.444) → 9516.752 (9380.701–9588.990) | 3672 → 3500 | 1234 → 1125 | 561.977 → 564.562 |

phaseは既存の`Timing.Mark`による区間で、`compile-bodies`にはsymbol/NoAlloc auditも含みます。wallとpeak working setは外部の`Process`から取得しました。selfhostのwallの範囲は重なるため、安定した速度向上率やピークメモリ削減は主張しません。

別のmanaged専用計測ビルドで、lowering完了後の最終整形を`Stopwatch.GetTimestamp` / `GC.GetAllocatedBytesForCurrentThread`で計測しました。実行側のTranspiler DLLだけを差し替え、自己入力や参照DLLは未計測の基準ビルドのままです。完了点に到達した通常bodyのみを数え、途中taintのtrialと合成本体は含めません。次はselfhostの中央値です。

| 計測対象 | planning 前→後 | emission 前→後 |
|---|---|---|
| 完了body数 | 52,478 → 52,478 | 23,817 → 23,817 |
| `_body` UTF-16文字数（累計） | 72,416,662 → 72,416,662 | 42,744,444 → 42,744,444 |
| 完成関数 UTF-16文字数（累計） | 143,216,486 → 0 | 81,315,247 → 81,315,247 |
| 最終整形の割り当てbytes（累計） | 785,027,776 → 75,950,480 | 415,491,656 → 415,207,232 |
| 最終整形の合計ms | 255.026 → 67.183 | 107.875 → 104.074 |
| phase全体の割り当てbytes | 4,396,604,784 → 3,687,711,456 | 1,816,746,664 → 1,810,698,984 |

削除した完成関数のUTF-16 payloadは286,432,972 bytes、最終整形の割り当て削減は709,077,296 bytesです。これらは別の量であり、どちらも同時生存メモリではありません。phase全体は`GC.GetTotalAllocatedBytes(true)`の境界差分です。残った最終整形の割り当てにはシグネチャ評価を含みます。計測コードはself-host入力に対応しないBCLを使うため、このPRの製品コードには入れていません。

`DN2CPP_TIME_LIVE=1`は別実行に分け、その所要時間を性能比較に使っていません。selfhostのlive heapはplanning後189 MiB、compile後201 MiB、typeinfo出力後261 MiBで前後同じでした。未計測版・計測版・live heap計測間でも、同一入力の`generated*`のファイル集合とSHA-256が一致しました。

### 検証

- Release CLI build、Debug CLI build。
- `build-and-run-shared-generics.sh`と`build-and-run-emit-order-stability.sh`をRelease/Debugで実行。
- `sync-primitives`、`exception-message-subset`、`hotpath`、`shadow-stack`、`transpiler-limits`、`parallel-bodies`のReleaseゲート。
- 変更前後を同一DLL・参照集合で比較：SharedGenerics、fault/filterを含むExceptionMessageSubset、full CLI自己入力。共有on/offそれぞれでjobs=1/FIFO、jobs=2/FIFO、jobs=2/strict、jobs=2/LIFOの全条件の`generated*`集合とSHA-256が一致。
- `--measure`はSharedGenericsと既知のP/Invoke gap入力で、前後・jobs=1/2のsidecar、stdout、stderrが一致（出力ディレクトリと計測行のみ正規化）。
- `gates/selfhost-emit.sh artifacts/planning-study/selfhost-native`：変更後CLIのmanaged/native固定点が成立。
- `SKIP_GODOT=1 JOBS=4 CMAKE_BUILD_PARALLEL_LEVEL=4 ./gates/run-all-gates.sh`：exit 0、127 pass（123実行・4 cached）、1 skip、0 fail。skipはWindowsホストにXcodeがない`ios-sim-console`です。`wasm-console`のfinalizerキュー投入後の抑止タイミングと、`platform-isa-native`のArm CPU上のsupported/masked実行は既存のexpected partialです。Godotの18ゲートは`SKIP_GODOT=1`により未実行で、passには数えていません。

`gates/pre-merge.sh`はAGENTS.mdに従い未実行です。マージ前にメンテナの実行が必要です。

Closes #110
