### PR TITLE
保持ポリシーが空のときの全型走査を省く

### DIFF
--- a/src/Dn2Cpp.Transpiler/Compilation.Preservation.cs
+++ b/src/Dn2Cpp.Transpiler/Compilation.Preservation.cs
@@ -854,7 +854,8 @@ internal sealed partial class Compilation
 
     private bool ActivateConditionalPreservationPolicies()
     {
-        if (!_preservationSeedingActive) return false;
+        if (!_preservationSeedingActive || _preservePolicies.Count == 0)
+            return false;
         bool activated = false;
         foreach (var cls in Classes.ToList())
             if (!_activatedConditionalPolicies.Contains(cls)


### PR DESCRIPTION
保持ポリシーが空の入力でも、到達可能性解析の各 round で `Classes.ToList()` と全型走査を繰り返していました。`ActivateConditionalPreservationPolicies()` に `_preservePolicies.Count == 0` の早期 return を追加し、snapshot 作成前に終了します。ポリシーがある場合の activation、seed/apply、遅延 generic instance の保持、drain の fixpoint は既存の経路を維持します。

`main` をベースにした独立した変更です。PR #113（#110）と、その上で進行中の #111 には依存しません。

### 検証

- Release CLI build 成功。
- `./gates/build-and-run-preserve-control.sh` と `CONFIG=Debug ./gates/build-and-run-preserve-control.sh` を cache 無効で実行。属性・無条件保持、`required="0"` の used/unused、nested descriptor、後から具体化する generic instance の既存 assertion が成功。
- 固定した同一DLL・参照集合で変更前後を比較し、HelloWorld、PreserveControl の通常設定／共有無効／strict completion＋LIFO の生成 `.cpp` / `.h` の集合・サイズ・SHA-256 が一致。
- `SKIP_GODOT=1 JOBS=4 CMAKE_BUILD_PARALLEL_LEVEL=4 ./gates/run-all-gates.sh`：exit 0、128 実行・128 pass、cached/skip/fail はすべて 0。既存の expected partial は `platform-isa-native` の Arm ホストでは実行できない X86 supported/opt-in/masked 経路と、`wasm-console` の finalizer enqueue 後の抑止タイミング。Godot の18ゲートは対象外で、pass に含めていません。

`gates/pre-merge.sh` は AGENTS.md に従い未実行です。マージ前にメンテナによる実行が必要です。

### Thrive の比較計測

基準は `308e30e00cdda083d7166a1b397d0fa417bc1898`。macOS 26.6.2 / arm64、Apple M3 Max（16 logical CPUs、64 GiB）、SDK 10.0.400 / runtime 10.0.11 の managed Release CLI で計測しました。入力は Issue 記載の Thrive `706cd5fcdd63245b830cd4262622f029912cb52e` の DLL で、SHA-256 も Issue 記載値と一致します。

保存済み export log の argv（`--dotnet-module --auto-ref --project-root`）を使い、消失済み temporary reference は Issue と同じ ExportRelease の同名DLLへ置換しました。旧 reference との hash 同一性は未確認です。明示 CoreLib / `Dn2Cpp.Runtime.dll` を維持し、既定 shim の sibling DLL も前後同一に固定しました。

既定 jobs（requested 0 / effective 16）、`DN2CPP_TIME=1`、`DN2CPP_TIME_LIVE` 未設定。各条件の warmup を1回除外し、fresh process と新規出力先で、前→後・後→前・前→後の3組を直列実行しました。他のビルド・ゲート実行とは重ねていません。以下は中央値（min–max）です。

| 指標 | 変更前 | 変更後 |
|---|---:|---:|
| 全体 wall 秒 | 62.409 (62.174–64.030) | 52.870 (52.427–54.725) |
| plan-bodies 秒 | 35.941 (35.794–36.508) | 26.618 (26.575–28.030) |
| 最大 RSS MiB | 2565.641 (2488.609–2595.859) | 2590.375 (2579.500–2598.062) |

wall は外部の経過時間、最大RSSは macOS `/usr/bin/time -l`、phase は既存の `Timing.Mark` による値です。C# build・native build・packaging は含めていません。最大RSSの低減は確認されていません。

別の計装ビルドでは、transpile 全体の activation 呼出しは前後とも 8,677 回、policy/activation はともに 0 のまま、全型走査が 8,677 → 0 回、snapshot に入れる型参照の累計が 531,301,548 → 0 になりました。この累計は固有型数や live heap の測定値ではありません。計装の時間は性能比較に使用していません。

warmup を含む通常計測の全8実行は exit 0 で、生成716ファイルの集合・サイズ・SHA-256 がすべて一致しました。計装ビルドの生成物とも一致し、入力・参照・CLI payload・descriptor の計測前後の hash も不変でした。計測コードは製品コードに含めていません。

Closes #112
