### PR TITLE
Reuse ordered interface closures for dispatch

### DIFF
--- a/gates/build-and-run-array-dispatch.sh
+++ b/gates/build-and-run-array-dispatch.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# Consolidated array-dispatch gate. Merges the former array covariance / interface
+# Array and generic interface dispatch, including inherited diamond closures and
+# multiple slots reached through nested covariance and contravariance.
+# Merges the former array covariance / interface
 # dispatch / multidimensional subset gates into one multi-section program,
 # transpiled once against the tree-shaken real CoreLib and diffed exactly against
 # real .NET. Covers array covariance + covariant virtual dispatch, SZArray
@@ -50,6 +52,26 @@ _cleanup_shimless() { [ -n "$shimless" ] && rm -rf "$shimless"; return 0; }
 trap _cleanup_shimless EXIT
 
 gate_extra_asserts() {
+    local closure_tail
+    closure_tail='-- interface closure dispatch --
+diamond exact: cat/cat
+diamond variant: cat/cat
+diamond parents: cat/cat
+diamond nested first: cat/cat
+diamond nested second: cat/cat
+diamond nested reverse: False
+diamond value invariant: False
+diamond nested consumer: first:cat/second:cat
+diamond array: 1/cat/cat
+diamond array enumeration: cat/cat
+derived comparer: True/False/5
+base comparer: True/False/5
+derived comparer again: True/False/5'
+    case "$(strip_cr_win "$native")" in
+        *"$closure_tail") ;;
+        *) echo "FAIL: interface closure dispatch section did not run completely" >&2; exit 1 ;;
+    esac
+
     echo "-- negative: transpiling without the support shim must be rejected --"
     local corelib app linq noshim_rc=0 noshim_err
     corelib=$(locate_corelib)

--- a/gates/build-and-run-emit-order-stability.sh
+++ b/gates/build-and-run-emit-order-stability.sh
@@ -62,6 +62,7 @@ SAMPLES=(
     "ReflectTypes|System.Linq.Expressions System.Linq System.Collections System.Reflection.Emit System.Reflection.Emit.Lightweight System.Reflection.Emit.ILGeneration System.ComponentModel.Primitives"
     "StringCore|System.Linq"
     "ArrayCore|"
+    "ArrayDispatch|System.Linq"
 )
 
 echo "== 2/5 Building app assemblies =="
@@ -83,6 +84,7 @@ if gate_cache_check "$OUT" "emit-order-stability|jobs:1,2|measure-jobs:1,2|cli:$
         "samples/dotnet/ReflectTypes/bin/$CONFIG/$TFM/ReflectTypes.dll" \
         "samples/dotnet/StringCore/bin/$CONFIG/$TFM/StringCore.dll" \
         "samples/dotnet/ArrayCore/bin/$CONFIG/$TFM/ArrayCore.dll" \
+        "samples/dotnet/ArrayDispatch/bin/$CONFIG/$TFM/ArrayDispatch.dll" \
         "samples/dotnet/SharedGenerics/bin/$CONFIG/$TFM/SharedGenerics.dll" \
         "samples/dotnet/PInvokeByValTStrBad/bin/$CONFIG/$TFM/PInvokeByValTStrBad.dll"; then
     gate_cache_hit_msg

--- a/samples/dotnet/ArrayDispatch/InterfaceClosureDispatchSubset.cs
+++ b/samples/dotnet/ArrayDispatch/InterfaceClosureDispatchSubset.cs
@@ -1,0 +1,129 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using GenericVarianceDispatchSubset;
+
+namespace InterfaceClosureDispatchSubset;
+
+internal interface IPair<out T>
+{
+    T First();
+    T Second();
+}
+
+internal interface ILeft<out T> : IPair<T> { }
+internal interface IRight<out T> : IPair<T> { }
+internal interface IDiamond<out T> : ILeft<T>, IRight<T> { }
+
+internal class PairBase<T> : IDiamond<T>
+{
+    private readonly T _value;
+
+    internal PairBase(T value) { _value = value; }
+    public T First()
+    {
+        return _value;
+    }
+
+    public T Second()
+    {
+        return _value;
+    }
+}
+
+internal sealed class Diamond<T> : PairBase<T>
+{
+    internal Diamond(T value) : base(value) { }
+}
+
+internal interface IConsumer<in T>
+{
+    string First(T value);
+    string Second(T value);
+}
+
+internal sealed class AnimalConsumer : IConsumer<Animal>
+{
+    public string First(Animal value)
+    {
+        return "first:" + value.Name;
+    }
+
+    public string Second(Animal value)
+    {
+        return "second:" + value.Name;
+    }
+}
+
+internal class LengthComparer : EqualityComparer<string>
+{
+    public override bool Equals(string? x, string? y)
+    {
+        return x?.Length == y?.Length;
+    }
+
+    public override int GetHashCode(string value)
+    {
+        return value.Length;
+    }
+}
+
+internal sealed class DerivedLengthComparer : LengthComparer { }
+
+internal static class Program
+{
+    internal static void Run()
+    {
+        Console.WriteLine("-- interface closure dispatch --");
+        var diamond = new Diamond<Cat>(new Cat());
+        IPair<Cat> exact = diamond;
+        Console.WriteLine("diamond exact: " + exact.First().Name + "/" + exact.Second().Name);
+
+        // Both slots must survive an exact miss through the same inherited diamond.
+        IPair<Animal> wide = diamond;
+        Console.WriteLine("diamond variant: " + wide.First().Name + "/" + wide.Second().Name);
+        ILeft<Animal> left = diamond;
+        IRight<Animal> right = diamond;
+        Console.WriteLine("diamond parents: " + left.First().Name + "/" + right.Second().Name);
+
+        // The outer argument is a class whose interface closure supplies the inner match.
+        object nested = new Diamond<Diamond<Cat>>(diamond);
+        var nestedWide = (IPair<IPair<Animal>>)nested;
+        Console.WriteLine("diamond nested first: " + nestedWide.First().First().Name
+            + "/" + nestedWide.First().Second().Name);
+        Console.WriteLine("diamond nested second: " + nestedWide.Second().First().Name
+            + "/" + nestedWide.Second().Second().Name);
+        Console.WriteLine("diamond nested reverse: "
+            + ((object)new Diamond<IPair<Animal>>(wide) is IPair<IPair<Cat>>));
+        Console.WriteLine("diamond value invariant: " + ((object)new Diamond<int>(7) is IPair<object>));
+
+        var consumer = new AnimalConsumer();
+        IPair<IConsumer<Cat>> consumers = new Diamond<AnimalConsumer>(consumer);
+        Console.WriteLine("diamond nested consumer: " + consumers.First().First(new Cat())
+            + "/" + consumers.Second().Second(new Cat()));
+
+        // IList<T> is invariant; only the reference-element array fallback serves this.
+        object array = new Diamond<Cat>[] { diamond };
+        var list = (IList<IPair<Animal>>)array;
+        Console.WriteLine("diamond array: " + list.Count + "/" + list[0].First().Name
+            + "/" + list[0].Second().Name);
+        var sequence = (IEnumerable<IPair<Animal>>)array;
+        foreach (var pair in sequence)
+            Console.WriteLine("diamond array enumeration: " + pair.First().Name + "/" + pair.Second().Name);
+
+        // EqualityComparer's intrinsic base acquires its interface at allocation reach.
+        // Exercise the derived closure before and after allocating the concrete base.
+        var derived = new DerivedLengthComparer();
+        IPair<IEqualityComparer<string>> derivedPair = new Diamond<DerivedLengthComparer>(derived);
+        PrintComparer("derived comparer", derivedPair);
+        IPair<IEqualityComparer<string>> basePair = new Diamond<LengthComparer>(new LengthComparer());
+        PrintComparer("base comparer", basePair);
+        PrintComparer("derived comparer again", derivedPair);
+    }
+
+    private static void PrintComparer(string label, IPair<IEqualityComparer<string>> pair)
+    {
+        Console.WriteLine(label + ": " + pair.First().Equals("cat", "dog")
+            + "/" + pair.Second().Equals("cat", "lion") + "/" + pair.Second().GetHashCode("horse"));
+    }
+}

--- a/samples/dotnet/ArrayDispatch/Program.cs
+++ b/samples/dotnet/ArrayDispatch/Program.cs
@@ -28,6 +28,7 @@ namespace ArrayDispatch
             MultiDimArraySubset.Program.Run();
             ObjectReachedValueDispatchSubset.Program.Run();
             MdInterfaceDispatchSubset.Program.Run();
+            InterfaceClosureDispatchSubset.Program.Run();
         }
     }
 }

--- a/src/Dn2Cpp.Transpiler/Compilation.Reachability.cs
+++ b/src/Dn2Cpp.Transpiler/Compilation.Reachability.cs
@@ -238,12 +238,12 @@ internal sealed partial class Compilation
             && IEqualityComparerInterfaceFor(eqElem) is { } eqItf)
         {
             if (!c.Interfaces.Contains(eqItf))
+            {
                 c.Interfaces.Add(eqItf);
-            // ImplementsInterface caches c's interface closure, and the used×allocated
-            // cross above already computed and froze it WITHOUT this interface. Drop the
-            // stale cache so ReachVirtualImpl's ImplementsInterface check — and every
-            // later dispatch reacher — sees the interface just added.
-            c.InterfaceClosureCache = null;
+                // A cached closure may inherit c through another type's base chain.
+                // Invalidate both membership and DFS order for every dependent root.
+                _interfaceClosureVersion++;
+            }
             // Record that this element type's IEqualityComparer<T> type-info is now emitted
             // (RenderItfTables lays it down as c's interface). The concrete form AND its
             // canonical alias, so the emit-time dispatch gate resolves for both a concrete
@@ -2476,15 +2476,8 @@ internal sealed partial class Compilation
         // Collect first, reach after: a Reach can complete classes and grow the model,
         // and the closure walk below is over the interface graph, not over Classes.
         List<MethodInfo>? impls = null;
-        var stack = new Stack<ClassInfo>();
-        PushDirectInterfaces(stack, c);
-        var visited = new HashSet<ClassInfo>();
-        while (stack.Count > 0)
+        foreach (var have in GetInterfaceClosure(c).Ordered)
         {
-            var have = stack.Pop();
-            if (!visited.Add(have))
-                continue;
-            PushDirectInterfaces(stack, have);
             if (have == want || !VariantMatches(have, want, mask))
                 continue;
             have.EnsureMembers();   // the interface's declarations ARE its rows
@@ -2569,15 +2562,8 @@ internal sealed partial class Compilation
             return;
         // Collect first, reach after — same discipline as ReachVariantItfImpl.
         List<MethodInfo>? impls = null;
-        var stack = new Stack<ClassInfo>();
-        PushDirectInterfaces(stack, c);
-        var visited = new HashSet<ClassInfo>();
-        while (stack.Count > 0)
+        foreach (var have in GetInterfaceClosure(c).Ordered)
         {
-            var have = stack.Pop();
-            if (!visited.Add(have))
-                continue;
-            PushDirectInterfaces(stack, have);
             if (have == want
                 || have.Module != want.Module || have.Handle != want.Handle
                 || have.Context.TypeArgs.Length != wa.Length)
@@ -2660,15 +2646,8 @@ internal sealed partial class Compilation
             return false;
         if (VariantMatches(fc, tc, vmask))
             return true;
-        var stack = new Stack<ClassInfo>();
-        PushDirectInterfaces(stack, fc);
-        var visited = new HashSet<ClassInfo>();
-        while (stack.Count > 0)
+        foreach (var itf in GetInterfaceClosure(fc).Ordered)
         {
-            var itf = stack.Pop();
-            if (!visited.Add(itf))
-                continue;
-            PushDirectInterfaces(stack, itf);
             if (VariantMatches(itf, tc, vmask))
                 return true;
         }
@@ -2750,37 +2729,34 @@ internal sealed partial class Compilation
         return false;
     }
 
-    private static bool ImplementsInterface(ClassInfo c, ClassInfo itf)
+    private bool ImplementsInterface(ClassInfo c, ClassInfo itf) =>
+        GetInterfaceClosure(c).Members.Contains(itf);
+
+    // Comparer interfaces can be added after shape completion. A compilation-wide
+    // version also invalidates closures that read the changed type as an ancestor.
+    private int _interfaceClosureVersion;
+
+    private InterfaceClosure GetInterfaceClosure(ClassInfo c)
     {
-        // Iterative closure walk with a visited set: the interface graph is a DAG
-        // (IList<T> -> ICollection<T> -> IEnumerable<T> <- IReadOnlyCollection<T>, …),
-        // so a naive recursion re-walks shared parents once per inbound path —
-        // exponential for diamond-rich BCL hierarchies. Each interface node is
-        // expanded at most once here, making the check linear in the closure size.
-        //
-        // The closure is cached per entry class: this is asked per
-        // (allocated type × used interface) pair by the GVM/dispatch reachers, and
-        // an uncached ask re-walks the DAG and allocates a Stack+HashSet. The walk is
-        // pure shape reads (Interfaces/BaseClass — never a member pull), so the
-        // full closure costs what one miss cost; membership probes are O(1) after.
-        // Cached ONLY when every node the walk read was ShapeReady: a
-        // specialization minted mid-scan has empty Interfaces (and no BaseClass)
-        // until its CompleteShape turn, and freezing that immature answer would
-        // change a later ask that the uncached walk answered from the live lists.
-        if (c.InterfaceClosureCache is { } cached)
-            return cached.Contains(itf);
+        // Shape reads only: an unfinished node makes this a temporary snapshot.
+        // First-visit DFS order preserves candidate and reach order independently
+        // of HashSet enumeration, including diamonds and inherited interfaces.
+        if (c.InterfaceClosureCache is { } cached && cached.Version == _interfaceClosureVersion)
+            return cached;
         var stack = new Stack<ClassInfo>();
         bool ready = PushDirectInterfaces(stack, c);
-        var closure = new HashSet<ClassInfo>();
+        var closure = new InterfaceClosure(_interfaceClosureVersion);
         while (stack.Count > 0)
         {
             var i = stack.Pop();
-            if (closure.Add(i))
-                ready &= PushDirectInterfaces(stack, i);
+            if (!closure.Members.Add(i))
+                continue;
+            closure.Ordered.Add(i);
+            ready &= PushDirectInterfaces(stack, i);
         }
         if (ready)
             c.InterfaceClosureCache = closure;
-        return closure.Contains(itf);
+        return closure;
     }
 
     /// <summary>Pushes every interface directly implemented by <paramref name="x"/>

--- a/src/Dn2Cpp.Transpiler/Model.cs
+++ b/src/Dn2Cpp.Transpiler/Model.cs
@@ -849,6 +849,18 @@ internal sealed record PInvokeInfo(
     }
 }
 
+internal sealed class InterfaceClosure
+{
+    public readonly HashSet<ClassInfo> Members = new();
+    public readonly List<ClassInfo> Ordered = new();
+    public readonly int Version;
+
+    public InterfaceClosure(int version)
+    {
+        Version = version;
+    }
+}
+
 internal sealed class ClassInfo
 {
     public required string Namespace;
@@ -1007,16 +1019,11 @@ internal sealed class ClassInfo
     public GenericContext Context = GenericContext.Empty; // for closed specializations
     public List<ClassInfo> Interfaces = new(); // directly implemented interfaces
 
-    /// <summary>Cached transitive interface closure — every interface this class (or a
-    /// class/interface on any base chain the walk crosses) implements, directly or
-    /// through interface inheritance. Interfaces are shape: populated at load
-    /// (non-generic) or <c>CompleteShape</c> (specializations) and immutable after, so
-    /// the closure is final once every node the walk visited was
-    /// <see cref="ShapeReady"/> — Compilation.ImplementsInterface only stores it then,
-    /// and a walk that crossed a not-yet-completed specialization stays uncached so a
-    /// later ask re-reads the live lists exactly as the uncached walk always did.
-    /// Membership-only (never enumerated), so set order cannot reach the output.</summary>
-    internal HashSet<ClassInfo>? InterfaceClosureCache;
+    /// <summary>Membership and first-visit DFS order, cached only when every interface
+    /// and base-chain node read was <see cref="ShapeReady"/>. Later interface additions
+    /// invalidate the compilation's closure version, including dependent roots.
+    /// Published closures are never mutated; an active enumeration keeps its snapshot.</summary>
+    internal InterfaceClosure? InterfaceClosureCache;
     // Interfaces implemented by CLR FullName but not modeled as a loaded
     // ClassInfo — the assembly declaring them was not referenced at transpile
     // (e.g. a hot-update patch that implements a base-image interface without


### PR DESCRIPTION
変性インターフェースへの呼び出しでは、同じ受信型に対してインターフェース DAG の Stack/HashSet を繰り返し作っていました。完全一致判定と変性・配列フォールバックが、型ごとの同じ閉包を使うようにします。

PR #113 の `perf/skip-planning-body-render` にスタックしています。この PR の差分はインターフェース閉包の変更だけです。

### 実装

`GetInterfaceClosure` は完全一致用の membership 集合と、従来の DFS の初回訪問順を保持するリストを同時に構築します。`ReachVariantItfImpl`、`ReachArrayWrapperItfImpl`、`RefAssignable` はこのリストを列挙します。HashSet の列挙順は使わず、候補一致後の `EnsureMembers`／実装解決と、候補列挙後にまとめて Reach する順序を維持しています。

基底型を含め、読んだ全ノードが `ShapeReady` のときだけ保存します。未完成の閉包は一時スナップショットです。comparer の interface を後から追加する経路では compilation 全体の version を進め、継承側のキャッシュも次の照会で再構築します。稀な追加では無関係なキャッシュも無効になりますが、逆向きの依存グラフを保持する必要がありません。公開済みの閉包自体は変更せず、列挙中のスナップショットを保ちます。

ArrayDispatch に、複数 slot を持つ継承 diamond、完全一致が外れた後の変性 dispatch、クラスの閉包を介した入れ子の変性、変性の逆方向・値型の負例、配列 fallback、基底／派生 comparer の節を追加しました。既存 stdout が不変の prefix であることを確認し、ゲートは新しい末尾の全行も検証します。ArrayDispatch を emit-order-stability の比較対象と cache key にも追加しています。

### 計測

基準は PR #113 の先端 `c0ce390f5a0ff8991b6b13b167c9ee9d4582543e`。Windows x64、Core i9-13900HX、SDK 10.0.301 / runtime 10.0.11。入力 DLL と参照 DLL は基準ビルドに固定しました。共有 on、`--jobs 1`、`DN2CPP_TIME=1`、新しい出力ディレクトリと CLI process を使い、各条件の warmup を1回除外して、前後を交互に直列3回測定しています。他の検証ジョブ、C++ build、gate cache、強制 GC は含みません。

中央値、括弧内は最小–最大です。Windows の peak working set を外部の `Process` から取得しています。

| 入力 | wall ms 前 → 後 | peak working set MiB 前 → 後 |
|---|---|---|
| HelloWorld（既定参照） | 300.226 (298.846–308.642) → 302.686 (295.926–303.867) | 47.492 (46.121–47.727) → 46.996 (45.777–48.074) |
| JsonProbe（CoreLib/STJ、auto-ref） | 1144.291 (1134.024–1160.189) → 1146.114 (1140.500–1148.318) | 176.652 (176.641–176.871) → 181.777 (170.895–182.074) |
| full CLI 自己入力（selfhost-emit の参照集合） | 9504.566 (9484.842–9550.748) → 8653.593 (8634.167–8800.306) | 559.922 (537.152–560.102) → 565.875 (560.801–569.277) |

自己入力の phase 中央値は、discover 2203→1703 ms、shared-sync 703→687 ms、plan-bodies 3657→3172 ms、compile-bodies 1109→1328 ms、emit-typeinfos 1234→1219 ms。phase は JIT/GC を含む区間時間で、閉包処理単体の CPU 時間ではありません。小さい入力での明確な高速化や、ピークメモリ削減は主張しません。

別の managed 専用計測ビルドで、従来の各 walk の入口／初回ノード訪問と新しい共通 builder を計数しました。実行 CLI の Transpiler DLL だけを差し替え、自己入力・参照 DLL は未計測の基準ビルドのままです。自己入力の結果は次のとおりです。

| 計数対象 | 前 | 後 |
|---|---:|---:|
| 完全一致照会 | 8,866,961 | 8,866,961 |
| 変性 fallback 照会 | 6,703,351 | 6,703,351 |
| 配列 fallback 照会 | 469 | 469 |
| RefAssignable の閉包照会 | 6,217 | 6,217 |
| 閉包構築（完全一致も含む） | 6,716,557 | 6,520 |
| 構築時の初回ノード訪問 | 24,099,473 | 23,392 |

この自己入力では全構築が完成 shape で、後追加による無効化はありませんでした。追加した ArrayDispatch 入力では comparer の追加が前後とも実際に2回発生し、構築回数は23,277→250でした。候補の走査と変性照合は引き続き行います。

`GC.GetTotalAllocatedBytes(true)` の phase 境界差分を取った計測版の自己入力の中央値です。これは保持量ではなく累計割当量です。計測コードは製品コードにも self-host 入力にも含めていません。

| 割当 bytes | 前 | 後 |
|---|---:|---:|
| discover | 1,179,402,024 | 491,726,640 |
| shared-sync | 544,086,280 | 105,362,592 |
| plan-bodies | 3,678,780,304 | 2,038,057,752 |
| compile-bodies | 1,817,847,168 | 1,818,564,216 |
| 最後の write-files 境界までの累計 | 8,975,033,616 | 6,211,240,840 |

`DN2CPP_TIME_LIVE=1` は別実行に分け、時間比較には使っていません。自己入力の live heap は planning 後189→190 MiB、compile 後201→202 MiB、typeinfo 後261→261 MiB、write-files 後328→329 MiB。キャッシュに順序リストを保持する分の増加も含みます。

### 検証

- Release／Debug CLI build、ArrayDispatch／SharedGenerics／emit-order-stability の Release／Debug ゲート、Release parallel-bodies ゲートが成功。
- 同じ入力 DLL／参照で、ArrayDispatch・SharedGenerics・full CLI 自己入力の変更前後を比較。共有 on/off × jobs=1/FIFO、jobs=2/FIFO、jobs=2/strict、jobs=2/LIFO の全条件で `generated*` のファイル集合と SHA-256 が一致。
- 通常・計数・live heap の実行間も生成物が一致。到達集合は生成シンボルと、元モジュール・型／メソッドの metadata token・未加工のジェネリック識別子の両方で照合し、自己入力の 50,492 メソッドは一致。
- 隔離した managed 検証で、未完成の基底型／interface を保存しないこと、diamond の初回訪問順、完成後の再利用、祖先追加後の再構築、古いスナップショットの不変性を確認。
- `gates/selfhost-emit.sh artifacts/interface-closure-study/selfhost-native` が成功。変更後 CLI の managed/native 固定点が成立。
- `JOBS=4 CMAKE_BUILD_PARALLEL_LEVEL=4 ./gates/run-all-gates.sh` が exit 0。最終実行は 142 pass（12 実行・130 cached）、4 skip、0 fail。skip は Xcode 不在の `ios-sim-console`、`godot-ios-export`、`godot-ios-sim`、`godot-editor-export-ios`。`cri-android` は APK の生成・内容確認まで成功しましたが、adb 実機未接続のため実機実行は partial です。`platform-isa-native` の Arm supported/masked 実行、`wasm-console` の finalizer のキュー投入後の抑止タイミング、`godot-dotnet-wasm` の単体ホストでの初期化は既存の expected partial です。Godot の desktop／Android／Web export、同梱ツールだけの Web export、CRI Web のブラウザ実行も成功しました。

`gates/pre-merge.sh` は AGENTS.md に従い未実行です。マージ前にはメンテナによる実行が必要です。

Closes #111


