### PR TITLE
文字列型引数の変性呼び出しで実装を到達対象に含める

### DIFF
--- a/gates/build-and-run-array-dispatch.sh
+++ b/gates/build-and-run-array-dispatch.sh
@@ -46,7 +46,12 @@ source "$(dirname "$0")/_common.sh"
 # not theorized: that is exactly how this refactor first ran.) The guard also covers
 # the warm-hit path, where the hook never runs and there is nothing to remove.
 shimless=""
-_cleanup_shimless() { [ -n "$shimless" ] && rm -rf "$shimless"; return 0; }
+variance_only=""
+_cleanup_shimless() {
+    [ -n "$shimless" ] && rm -rf "$shimless"
+    [ -n "$variance_only" ] && rm -rf "$variance_only"
+    return 0
+}
 trap _cleanup_shimless EXIT
 
 gate_extra_asserts() {
@@ -89,6 +94,22 @@ gate_extra_asserts() {
         exit 1
     fi
     echo "OK (missing support shim rejected)"
+
+    # The full bucket invokes reflection, which roots every app method. Exclude
+    # those entry calls so only variant dispatch can reach the StringPair slots.
+    echo "-- string variance without reflection rooting --"
+    variance_only=$(mktemp -d artifacts/string-variance.XXXXXX)
+    dotnet build samples/dotnet/ArrayDispatch/ArrayDispatch.csproj -c "$CONFIG" \
+        --nologo -v q -p:DefineConstants=STRING_VARIANCE_ONLY -o "$variance_only/app"
+    invoke_cli "$variance_only/app/ArrayDispatch.dll" -r "$corelib" -r "$linq" \
+        -o "$variance_only/gen"
+    compile_console "$variance_only/gen" ArrayDispatch
+    local variance_native variance_expected
+    variance_native=$(run_bounded "$variance_only/gen/ArrayDispatch")
+    variance_expected=$(run_bounded dotnet "$variance_only/app/ArrayDispatch.dll")
+    assert_output "$variance_native" "$variance_expected"
+    grep -qx 'string pair: 0/0' <<<"$variance_native"
+    grep -qx 'string contravariant: compare:0' <<<"$variance_native"
 }
 
 # What the section asserts is the TRANSPILER's conduct with a member of its own bundle
@@ -97,7 +118,7 @@ gate_extra_asserts() {
 # reword the refusal, or lose it, and OUT stays byte-identical and the cached green is
 # replayed. The CLI hash closes it, the same stand-in a behavior gate uses; it also
 # covers the copied tree, which IS the CLI output directory.
-export DN2CPP_GATE_EXTRA_CONTEXT="noshim-refusal|cli:$(_gate_cli_hash)"
+export DN2CPP_GATE_EXTRA_CONTEXT="noshim-refusal|string-variance:STRING_VARIANCE_ONLY|cli:$(_gate_cli_hash)"
 
 # System.Linq rides in for one section: IGrouping<out TKey, out TElement> is the only
 # two-parameter variant interface the BCL exposes, and a two-parameter variant definition

--- a/samples/dotnet/ArrayDispatch/GenericVarianceDispatchSubset.cs
+++ b/samples/dotnet/ArrayDispatch/GenericVarianceDispatchSubset.cs
@@ -115,8 +115,59 @@ namespace GenericVarianceDispatchSubset
         }
     }
 
+    internal interface IPair<out T>
+    {
+        T First();
+        T Second();
+    }
+
+    internal sealed class StringPair : IPair<string>
+    {
+        public string First()
+        {
+            return "cat";
+        }
+
+        public string Second()
+        {
+            return "dog";
+        }
+    }
+
+    internal sealed class ComparableDescriber : IContravariant<IComparable<string>>
+    {
+        public string Describe(IComparable<string> value)
+        {
+            return "compare:" + value.CompareTo("cat");
+        }
+    }
+
     internal static class Program
     {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private static object GetStringObject()
+        {
+            return "cat";
+        }
+
+        internal static void RunStringVariance()
+        {
+            Console.WriteLine("-- string argument variance --");
+            // Install String's interface map independently of the variant call.
+            foreach (char ch in (IEnumerable<char>)GetStringObject())
+                Console.Write(ch);
+            Console.WriteLine();
+            IComparable<string> registered = (IComparable<string>)GetStringObject();
+            Console.WriteLine("string direct: " + registered.CompareTo("cat"));
+
+            // Neither implementation is called through IPair<string> or StringPair.
+            IPair<IComparable<string>> pair = new StringPair();
+            Console.WriteLine("string pair: " + pair.First().CompareTo("cat")
+                + "/" + pair.Second().CompareTo("dog"));
+            IContravariant<string> describer = new ComparableDescriber();
+            Console.WriteLine("string contravariant: " + describer.Describe("cat"));
+        }
+
         internal static void Run()
         {
             Console.WriteLine("-- generic variance dispatch --");

--- a/samples/dotnet/ArrayDispatch/Program.cs
+++ b/samples/dotnet/ArrayDispatch/Program.cs
@@ -14,6 +14,7 @@ namespace ArrayDispatch
             CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
             CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
 
+#if !STRING_VARIANCE_ONLY
             ArrayCovarianceSubset.Program.Run();
             ArrayCovariantDispatchSubset.Program.Run();
             ArrayInterfaceDispatchSubset.Program.Run();
@@ -28,6 +29,8 @@ namespace ArrayDispatch
             MultiDimArraySubset.Program.Run();
             ObjectReachedValueDispatchSubset.Program.Run();
             MdInterfaceDispatchSubset.Program.Run();
+#endif
+            GenericVarianceDispatchSubset.Program.RunStringVariance();
         }
     }
 }

--- a/src/Dn2Cpp.Transpiler/Compilation.Reachability.cs
+++ b/src/Dn2Cpp.Transpiler/Compilation.Reachability.cs
@@ -2645,8 +2645,11 @@ internal sealed partial class Compilation
             return false;
         if (to.IsObject)
             return true;
-        if (from is not { Kind: TypeKind.Class, Class: { } fc }
-            || to is not { Kind: TypeKind.Class, Class: { } tc })
+        // String signatures use a primitive descriptor; its interfaces live on the
+        // CoreLib class just like those of other reference types.
+        var fc = from.IsString ? FindClassByFullName("System.String") : from.Class;
+        var tc = to.IsString ? FindClassByFullName("System.String") : to.Class;
+        if (fc is null || tc is null)
             return false;
         if (DerivesFromOrIs(fc, tc) || ImplementsInterface(fc, tc))
             return true;


### PR DESCRIPTION
`IPair<string>` を `IPair<IComparable<string>>` として呼び出すと、到達解析が文字列からインターフェースへの代入互換性を認めず、実装メソッドを除去していました。文字列の型記述子から CoreLib の `System.String` クラスを解決し、通常の参照型と同じ継承・インターフェース判定を適用します。

ArrayDispatch に共変・反変の呼び出しを追加しました。既存バケットの reflection 呼び出しはアプリ内の全メソッドを到達対象にして不具合を隠すため、`STRING_VARIANCE_ONLY` で新しい節だけを実行する検証軸も追加しています。この軸では String の interface map を独立に登録し、実装メソッドを完全一致呼び出しで到達させずに .NET とネイティブの出力を比較します。追加軸の定義はゲートキャッシュのコンテキストにも含めています。

検証:

- main の修正前実装で追加軸が終了コード 134 となり、`StringPair` の未到達スロットへの dispatch trap を再現。
- 修正後の ArrayDispatch ゲートは Release / Debug とも成功。通常実行、文字列変性の専用軸、サポート shim 欠落時の拒否を確認。
- 追加前のバケット出力が、追加後もバイト一致の prefix として保持されることを確認。
- `git diff --check`、`bash -n gates/build-and-run-array-dispatch.sh` 成功。
- `SKIP_GODOT=1 JOBS=4 ./gates/run-all-gates.sh`: 128 / 128 成功、skip 0、失敗 0（キャッシュ利用と宣言済みの構造的部分検証を含む）。Godot 18ゲートは実行対象外。
- Godotを含む全体スイートは、別チェックアウトのGodot検証が保持する共有ロック待ちで終了。Godotゲートは未完了。
- `gates/pre-merge.sh` はリポジトリ規約に従い未実行。マージ前に人間による実行が必要。

PR 作成前に Astra（effort xhigh）のレビューを完了し、最終差分に修正必須の指摘はありません。

Closes #116
