### PR TITLE
Integrate planning and reachability improvements

### DIFF
--- a/gates/build-and-run-array-dispatch.sh
+++ b/gates/build-and-run-array-dispatch.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# Consolidated array-dispatch gate. Merges the former array covariance / interface
+# Array and generic interface dispatch, including inherited diamond closures and
+# multiple slots reached through nested covariance and contravariance.
+# Merges the former array covariance / interface
 # dispatch / multidimensional subset gates into one multi-section program,
 # transpiled once against the tree-shaken real CoreLib and diffed exactly against
 # real .NET. Covers array covariance + covariant virtual dispatch, SZArray
@@ -50,6 +52,26 @@ _cleanup_shimless() { [ -n "$shimless" ] && rm -rf "$shimless"; return 0; }
 trap _cleanup_shimless EXIT
 
 gate_extra_asserts() {
+    local closure_tail
+    closure_tail='-- interface closure dispatch --
+diamond exact: cat/cat
+diamond variant: cat/cat
+diamond parents: cat/cat
+diamond nested first: cat/cat
+diamond nested second: cat/cat
+diamond nested reverse: False
+diamond value invariant: False
+diamond nested consumer: first:cat/second:cat
+diamond array: 1/cat/cat
+diamond array enumeration: cat/cat
+derived comparer: True/False/5
+base comparer: True/False/5
+derived comparer again: True/False/5'
+    case "$(strip_cr_win "$native")" in
+        *"$closure_tail") ;;
+        *) echo "FAIL: interface closure dispatch section did not run completely" >&2; exit 1 ;;
+    esac
+
     echo "-- negative: transpiling without the support shim must be rejected --"
     local corelib app linq noshim_rc=0 noshim_err
     corelib=$(locate_corelib)

--- a/gates/build-and-run-array-dispatch.sh
+++ b/gates/build-and-run-array-dispatch.sh
@@ -46,7 +46,12 @@ source "$(dirname "$0")/_common.sh"
 # not theorized: that is exactly how this refactor first ran.) The guard also covers
 # the warm-hit path, where the hook never runs and there is nothing to remove.
 shimless=""
-_cleanup_shimless() { [ -n "$shimless" ] && rm -rf "$shimless"; return 0; }
+variance_only=""
+_cleanup_shimless() {
+    [ -n "$shimless" ] && rm -rf "$shimless"
+    [ -n "$variance_only" ] && rm -rf "$variance_only"
+    return 0
+}
 trap _cleanup_shimless EXIT
 
 gate_extra_asserts() {
@@ -89,6 +94,22 @@ gate_extra_asserts() {
         exit 1
     fi
     echo "OK (missing support shim rejected)"
+
+    # The full bucket invokes reflection, which roots every app method. Exclude
+    # those entry calls so only variant dispatch can reach the StringPair slots.
+    echo "-- string variance without reflection rooting --"
+    variance_only=$(mktemp -d artifacts/string-variance.XXXXXX)
+    dotnet build samples/dotnet/ArrayDispatch/ArrayDispatch.csproj -c "$CONFIG" \
+        --nologo -v q -p:DefineConstants=STRING_VARIANCE_ONLY -o "$variance_only/app"
+    invoke_cli "$variance_only/app/ArrayDispatch.dll" -r "$corelib" -r "$linq" \
+        -o "$variance_only/gen"
+    compile_console "$variance_only/gen" ArrayDispatch
+    local variance_native variance_expected
+    variance_native=$(run_bounded "$variance_only/gen/ArrayDispatch")
+    variance_expected=$(run_bounded dotnet "$variance_only/app/ArrayDispatch.dll")
+    assert_output "$variance_native" "$variance_expected"
+    grep -qx 'string pair: 0/0' <<<"$variance_native"
+    grep -qx 'string contravariant: compare:0' <<<"$variance_native"
 }
 
 # What the section asserts is the TRANSPILER's conduct with a member of its own bundle
@@ -97,7 +118,7 @@ gate_extra_asserts() {
 # reword the refusal, or lose it, and OUT stays byte-identical and the cached green is
 # replayed. The CLI hash closes it, the same stand-in a behavior gate uses; it also
 # covers the copied tree, which IS the CLI output directory.
-export DN2CPP_GATE_EXTRA_CONTEXT="noshim-refusal|cli:$(_gate_cli_hash)"
+export DN2CPP_GATE_EXTRA_CONTEXT="noshim-refusal|string-variance:STRING_VARIANCE_ONLY|cli:$(_gate_cli_hash)"
 
 # System.Linq rides in for one section: IGrouping<out TKey, out TElement> is the only
 # two-parameter variant interface the BCL exposes, and a two-parameter variant definition

--- a/gates/build-and-run-emit-order-stability.sh
+++ b/gates/build-and-run-emit-order-stability.sh
@@ -62,6 +62,7 @@ SAMPLES=(
     "ReflectTypes|System.Linq.Expressions System.Linq System.Collections System.Reflection.Emit System.Reflection.Emit.Lightweight System.Reflection.Emit.ILGeneration System.ComponentModel.Primitives"
     "StringCore|System.Linq"
     "ArrayCore|"
+    "ArrayDispatch|System.Linq"
 )
 
 echo "== 2/5 Building app assemblies =="
@@ -83,6 +84,7 @@ if gate_cache_check "$OUT" "emit-order-stability|jobs:1,2|measure-jobs:1,2|cli:$
         "samples/dotnet/ReflectTypes/bin/$CONFIG/$TFM/ReflectTypes.dll" \
         "samples/dotnet/StringCore/bin/$CONFIG/$TFM/StringCore.dll" \
         "samples/dotnet/ArrayCore/bin/$CONFIG/$TFM/ArrayCore.dll" \
+        "samples/dotnet/ArrayDispatch/bin/$CONFIG/$TFM/ArrayDispatch.dll" \
         "samples/dotnet/SharedGenerics/bin/$CONFIG/$TFM/SharedGenerics.dll" \
         "samples/dotnet/PInvokeByValTStrBad/bin/$CONFIG/$TFM/PInvokeByValTStrBad.dll"; then
     gate_cache_hit_msg

--- a/gates/build-and-run-emit-order-stability.sh
+++ b/gates/build-and-run-emit-order-stability.sh
@@ -58,6 +58,7 @@ mkdir -p "$OUT"
 
 # project | extra BCL references (the same reference set each project's own gate uses)
 SAMPLES=(
+    "SharedGenerics|System.Collections"
     "ReflectTypes|System.Linq.Expressions System.Linq System.Collections System.Reflection.Emit System.Reflection.Emit.Lightweight System.Reflection.Emit.ILGeneration System.ComponentModel.Primitives"
     "StringCore|System.Linq"
     "ArrayCore|"
@@ -82,6 +83,7 @@ if gate_cache_check "$OUT" "emit-order-stability|jobs:1,2|measure-jobs:1,2|cli:$
         "samples/dotnet/ReflectTypes/bin/$CONFIG/$TFM/ReflectTypes.dll" \
         "samples/dotnet/StringCore/bin/$CONFIG/$TFM/StringCore.dll" \
         "samples/dotnet/ArrayCore/bin/$CONFIG/$TFM/ArrayCore.dll" \
+        "samples/dotnet/SharedGenerics/bin/$CONFIG/$TFM/SharedGenerics.dll" \
         "samples/dotnet/PInvokeByValTStrBad/bin/$CONFIG/$TFM/PInvokeByValTStrBad.dll"; then
     gate_cache_hit_msg
     exit 0

--- a/gates/build-and-run-shared-generics.sh
+++ b/gates/build-and-run-shared-generics.sh
@@ -38,6 +38,8 @@
 # created, and a generic that calls itself at an ever-deeper type argument creates
 # them without end. That bound, and the transpiler's other resource limits, are
 # asserted by gates/build-and-run-transpiler-limits.sh.
+# Static synchronized prologues must taint even when the IL never mentions T;
+# instance synchronized bodies remain shared and lock the real receiver.
 #
 # The last section (GenericMethodSubset, folded from the retired
 # build-and-run-generic-method-subset.sh) is NOT about sharing: it is the
@@ -271,6 +273,17 @@ for sym in ti_GvmCanonicalSubset_Chain_GvmCanonicalSubset_Row_String \
 done
 echo "gvm dispatcher over a canonical group: shape present, all cases declared: OK"
 
+for inst in String Object; do
+    grep -Eq "^DN2CPP_NOINLINE int32_t m_GenericStaticsSubset_SynchronizedOwner_${inst}_StaticProbe_[0-9]+\\(" "$out"/generated*.cpp \
+        || { echo "FAIL: static synchronized body lost its real type: $inst" >&2; exit 1; }
+done
+grep -Eq '^DN2CPP_NOINLINE int32_t m_GenericStaticsSubset_SynchronizedOwner__CnRef_InstanceProbe_[0-9]+\(' "$out"/generated*.cpp \
+    || { echo "FAIL: instance synchronized body no longer shares" >&2; exit 1; }
+if grep -Eq 'm_GenericStaticsSubset_SynchronizedOwner__CnRef_StaticProbe_[0-9]+\(' "$out/generated.h" "$out"/generated*.cpp; then
+    echo "FAIL: static synchronized prologue escaped the planning taint" >&2
+    exit 1
+fi
+
 echo "== 5/7 Transpiling with --no-shared-generics (size regression check) =="
 invoke_cli "$app" "${refs[@]}" --no-shared-generics -o "$out-off"
 on_bytes=$(cat "$out"/generated*.cpp | wc -c | tr -d ' ')
@@ -300,4 +313,10 @@ expected=$(dotnet "$app"); expected_code=$?
 set -e
 assert_output "$native" "$expected"
 assert_exit_code "$native_code" "$expected_code"
+for line in \
+    'sync static string own=False' 'sync static object own=False' 'sync static other=True' \
+    'sync instance string own=False' 'sync instance object own=False' 'sync instance other=True'; do
+    grep -Fxq "$line" <<<"$native" \
+        || { echo "FAIL: synchronized prologue witness missing: $line" >&2; exit 1; }
+done
 gate_cache_commit

--- a/gates/build-and-run-transpiler-limits.sh
+++ b/gates/build-and-run-transpiler-limits.sh
@@ -478,7 +478,7 @@ echo "== 3f/8 Wrapper lowering must distinguish unsupported shapes from fatal bo
 wrapper_transpiler="$(dirname "${DN2CPP_CLI_DLL:-src/Dn2Cpp.Cli/bin/$CONFIG/$TFM/dn2cpp.dll}")/Dn2Cpp.Transpiler.dll"
 wrapper_rc=0
 wrapper_result=$(dotnet "$wrapper_app" "$wrapper_transpiler") || wrapper_rc=$?
-assert_output "$wrapper_result" 'wrapper NotSupportedException: OK
+assert_output "$(strip_cr_win "$wrapper_result")" 'wrapper NotSupportedException: OK
 wrapper InstantiationBoundException: OK
 wrapper StrictCompletionException: OK'
 assert_exit_code "$wrapper_rc" 0

--- a/gates/build-and-run-transpiler-limits.sh
+++ b/gates/build-and-run-transpiler-limits.sh
@@ -82,6 +82,8 @@
 #
 # A sibling measurement aid, gates/measure-transpile-mem.sh, reports peak RSS and
 # the per-phase heap curve. This gate asserts; that one measures.
+# Canonical linking and synthesized-wrapper lowering must preserve fatal bounds
+# while ordinary unsupported wrapper shapes still fall back.
 source "$(dirname "$0")/_common.sh"
 
 out="artifacts/transpiler-limits"
@@ -100,6 +102,9 @@ build_proj samples/dotnet/StringCore/StringCore.csproj
 build_proj samples/dotnet/ArrayCore/ArrayCore.csproj
 build_proj samples/dotnet/SharedTrialMint/SharedTrialMint.csproj
 build_proj samples/dotnet/TypeofMissingAsmBad/TypeofMissingAsmBad.csproj
+# These compiler probes live outside the suite's samples-only prebuild.
+build_gate_proj gates/fixtures/transpiler-limits/CanonicalLink/CanonicalLinkBound.csproj
+build_gate_proj gates/fixtures/transpiler-limits/WrapperExceptions/WrapperExceptions.csproj
 rec_app="samples/dotnet/GenericRecursionBad/bin/$CONFIG/$TFM/GenericRecursionBad.dll"
 sig_app="samples/dotnet/GenericSignatureRecursionBad/bin/$CONFIG/$TFM/GenericSignatureRecursionBad.dll"
 fld_app="samples/dotnet/GenericFieldRecursionBad/bin/$CONFIG/$TFM/GenericFieldRecursionBad.dll"
@@ -108,6 +113,8 @@ big_app="samples/dotnet/StringCore/bin/$CONFIG/$TFM/StringCore.dll"
 arr_app="samples/dotnet/ArrayCore/bin/$CONFIG/$TFM/ArrayCore.dll"
 mint_app="samples/dotnet/SharedTrialMint/bin/$CONFIG/$TFM/SharedTrialMint.dll"
 tma_app="samples/dotnet/TypeofMissingAsmBad/bin/$CONFIG/$TFM/TypeofMissingAsmBad.dll"
+link_app="gates/fixtures/transpiler-limits/CanonicalLink/bin/$CONFIG/$TFM/CanonicalLinkBound.dll"
+wrapper_app="gates/fixtures/transpiler-limits/WrapperExceptions/bin/$CONFIG/$TFM/WrapperExceptions.dll"
 # The assembly section 8 withholds and then supplies. It sits beside the CoreLib in
 # the shared framework; a requested reference that is absent is a hard failure, not
 # a quietly dropped one — withholding it is the whole point of the section,
@@ -133,8 +140,15 @@ numerics_dll="$(dirname "$corelib")/System.Runtime.Numerics.dll"
 # to catch that.
 tenv="tenv:${DN2CPP_MAX_GENERIC_DEPTH:-}/${DN2CPP_MAX_INSTANTIATIONS:-}/${DN2CPP_MAX_HEAP_MB:-}/${DN2CPP_SHARED_ASSERT:-}/${DN2CPP_STRICT_COMPLETION:-}/${DN2CPP_SPEC_DRAIN:-}"
 rm -rf "$out" "$sig_out" "$cut_out" "$mint_out"; mkdir -p "$out"
-if gate_cache_check "$out" "transpiler-limits|cli:$(_gate_cli_hash)|$corelib|$tenv" \
+if gate_cache_check "$out" "transpiler-limits|canonical-cap:1,2|canonical-refs:none|wrapper-exceptions|cli:$(_gate_cli_hash)|$corelib|$tenv" \
         "$rec_app" "$sig_app" "$fld_app" "$afld_app" "$big_app" "$arr_app" "$mint_app" "$tma_app" \
+        gates/fixtures/transpiler-limits/CanonicalLink/Program.cs \
+        gates/fixtures/transpiler-limits/CanonicalLink/CanonicalLinkBound.csproj \
+        gates/fixtures/transpiler-limits/WrapperExceptions/Program.cs \
+        gates/fixtures/transpiler-limits/WrapperExceptions/WrapperExceptions.csproj \
+        "$link_app" "$wrapper_app" \
+        "${link_app%.dll}.runtimeconfig.json" "${link_app%.dll}.deps.json" \
+        "${wrapper_app%.dll}.runtimeconfig.json" "${wrapper_app%.dll}.deps.json" \
         "${sig_app%.dll}.runtimeconfig.json" "${sig_app%.dll}.deps.json"; then
     gate_cache_hit_msg
     exit 0
@@ -423,6 +437,52 @@ set -e
 assert_output "$mint_native" "$mint_expected"
 assert_exit_code "$mint_native_rc" "$mint_expected_rc"
 echo "OK (and the shared body's array-to-collection boundary runs — output matches real .NET)"
+
+echo "== 3e/8 Canonical linking must preserve the instantiation bound =="
+# No BCL reference: the only instantiations are Id<string> and its canonical
+# Id<CnRef>. The second mint occurs inside canonical linking's fallback arm.
+for mode in "" "--measure"; do
+    label=${mode:-emit}
+    link_dir="$out/canonical-${label#--}"
+    link_so="$out/canonical-${label#--}.stdout"
+    link_se="$out/canonical-${label#--}.stderr"
+    link_rc=0
+    (export DN2CPP_MAX_INSTANTIATIONS=1
+     invoke_cli "$link_app" $mode -o "$link_dir") >"$link_so" 2>"$link_se" || link_rc=$?
+    if [ "$link_rc" -ne 2 ] \
+            || ! grep -q 'instantiation count passed the 1 limit while instantiating CanonicalLinkBound.Program::Id<CnRef>' "$link_se" \
+            || ! grep -q 'DN2CPP_MAX_INSTANTIATIONS' "$link_se" \
+            || grep -q 'instantiation count passed' "$link_so"; then
+        echo "FAIL: canonical linking ($label) must fail with exit 2 and the count-bound diagnostic; got $link_rc" >&2
+        cat "$link_so" "$link_se" >&2
+        exit 1
+    fi
+
+    (export DN2CPP_MAX_INSTANTIATIONS=2
+     invoke_cli "$link_app" $mode -o "$link_dir") >"$link_so" 2>"$link_se"
+    if [ -z "$mode" ]; then
+        if ! grep -Eq '^inline .* m_CanonicalLinkBound_Program_Id_[0-9]+___CnRef\([^;]*\)$' "$link_dir/generated.h"; then
+            echo "FAIL: raising the bound did not produce the canonical Id<CnRef> body" >&2
+            exit 1
+        fi
+    elif ! grep -q '0 gaps total' "$link_so" \
+            || [ ! -f "$link_dir/s0-gaps.tsv" ] || [ -s "$link_dir/s0-gaps.tsv" ]; then
+        echo "FAIL: raising the canonical-link bound did not produce a clean measure report" >&2
+        cat "$link_so" "$link_se" >&2
+        exit 1
+    fi
+    echo "OK ($label: canonical-link bound escaped; raising it permits canonical sharing)"
+done
+
+echo "== 3f/8 Wrapper lowering must distinguish unsupported shapes from fatal bounds =="
+wrapper_transpiler="$(dirname "${DN2CPP_CLI_DLL:-src/Dn2Cpp.Cli/bin/$CONFIG/$TFM/dn2cpp.dll}")/Dn2Cpp.Transpiler.dll"
+wrapper_rc=0
+wrapper_result=$(dotnet "$wrapper_app" "$wrapper_transpiler") || wrapper_rc=$?
+assert_output "$wrapper_result" 'wrapper NotSupportedException: OK
+wrapper InstantiationBoundException: OK
+wrapper StrictCompletionException: OK'
+assert_exit_code "$wrapper_rc" 0
+echo "OK (ordinary wrapper failure falls back; fatal exceptions escape unchanged)"
 
 echo "== 4/8 The heap ceiling fires — in emit AND in --measure =="
 # A program big enough that the model alone passes a small budget: the real

--- a/gates/fixtures/transpiler-limits/CanonicalLink/CanonicalLinkBound.csproj
+++ b/gates/fixtures/transpiler-limits/CanonicalLink/CanonicalLinkBound.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Optimize>true</Optimize>
+    <DebugType>none</DebugType>
+  </PropertyGroup>
+</Project>

--- a/gates/fixtures/transpiler-limits/CanonicalLink/Program.cs
+++ b/gates/fixtures/transpiler-limits/CanonicalLink/Program.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Globalization;
+
+namespace CanonicalLinkBound;
+
+internal static class Program
+{
+    private static T Id<T>(T value) => value;
+
+    private static void Main()
+    {
+        CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+        CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+        Console.WriteLine(Id("canonical-link-bound"));
+    }
+}

--- a/gates/fixtures/transpiler-limits/WrapperExceptions/Program.cs
+++ b/gates/fixtures/transpiler-limits/WrapperExceptions/Program.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.IO;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Runtime.Loader;
+
+namespace WrapperExceptions;
+
+internal static class Program
+{
+    private static int Main(string[] args)
+    {
+        CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
+        CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
+        if (args.Length != 1)
+            throw new ArgumentException("Pass the Dn2Cpp.Transpiler.dll used by this gate.");
+
+        var assembly = AssemblyLoadContext.Default.LoadFromAssemblyPath(Path.GetFullPath(args[0]));
+        var compilerType = assembly.GetType("Dn2Cpp.MethodCompiler", throwOnError: true)!;
+        var methodType = assembly.GetType("Dn2Cpp.MethodInfo", throwOnError: true)!;
+        var moduleType = assembly.GetType("Dn2Cpp.Module", throwOnError: true)!;
+        var typeDescType = assembly.GetType("Dn2Cpp.TypeDesc", throwOnError: true)!;
+        var boundType = assembly.GetType("Dn2Cpp.InstantiationBoundException", throwOnError: true)!;
+        var strictType = assembly.GetType("Dn2Cpp.StrictCompletionException", throwOnError: true)!;
+        var wrapper = compilerType.GetMethod("SynthesizeWrapperBody", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        // Load the gate's exact compiler and inject at its lowering boundary; a
+        // real wrapper's instantiation count depends on the loaded BCL version.
+        var method = Activator.CreateInstance(methodType)!;
+        methodType.GetField("Attributes")!.SetValue(method, MethodAttributes.Static);
+        methodType.GetField("Module")!.SetValue(method, Activator.CreateInstance(moduleType));
+        var returnType = typeDescType.GetMethod("MakePrimitive")!.Invoke(null, new object[] { PrimitiveTypeCode.Void })!;
+        typeof(Program).GetMethod(nameof(SetSignature), BindingFlags.NonPublic | BindingFlags.Static)!
+            .MakeGenericMethod(typeDescType).Invoke(null, new[] { method, returnType });
+        var compiler = Activator.CreateInstance(compilerType, new object?[] { null, method, null, null })!;
+        var errors = new[]
+        {
+            new NotSupportedException("unsupported wrapper shape"),
+            (Exception)Activator.CreateInstance(boundType, new object[] { "instantiation bound" })!,
+            (Exception)Activator.CreateInstance(strictType, new object[] { "strict completion" })!,
+        };
+
+        bool passed = true;
+        foreach (var error in errors)
+        {
+            bool lowerRan = false;
+            Func<bool> lower = () => { lowerRan = true; throw error; };
+            bool fallback = false;
+            bool escaped = false;
+            try
+            {
+                fallback = wrapper.Invoke(compiler, new object[] { "Unused*", lower, "exception probe" }) is null;
+            }
+            catch (TargetInvocationException ex) when (ex.InnerException is { } inner)
+            {
+                escaped = ReferenceEquals(inner, error);
+            }
+            bool expectedFallback = error.GetType() == typeof(NotSupportedException);
+            bool correct = lowerRan && (expectedFallback ? fallback && !escaped : escaped && !fallback);
+            passed &= correct;
+            Console.WriteLine($"wrapper {error.GetType().Name}: {(correct ? "OK" : "FAIL")}");
+        }
+        return passed ? 0 : 1;
+    }
+
+    private static void SetSignature<T>(object method, object returnType)
+    {
+        var signature = new MethodSignature<T>(default, (T)returnType, 0, 0, ImmutableArray<T>.Empty);
+        method.GetType().GetProperty("Signature")!.SetValue(method, signature);
+    }
+}

--- a/gates/fixtures/transpiler-limits/WrapperExceptions/WrapperExceptions.csproj
+++ b/gates/fixtures/transpiler-limits/WrapperExceptions/WrapperExceptions.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Optimize>true</Optimize>
+    <DebugType>none</DebugType>
+  </PropertyGroup>
+</Project>

--- a/samples/dotnet/ArrayDispatch/GenericVarianceDispatchSubset.cs
+++ b/samples/dotnet/ArrayDispatch/GenericVarianceDispatchSubset.cs
@@ -115,8 +115,59 @@ namespace GenericVarianceDispatchSubset
         }
     }
 
+    internal interface IPair<out T>
+    {
+        T First();
+        T Second();
+    }
+
+    internal sealed class StringPair : IPair<string>
+    {
+        public string First()
+        {
+            return "cat";
+        }
+
+        public string Second()
+        {
+            return "dog";
+        }
+    }
+
+    internal sealed class ComparableDescriber : IContravariant<IComparable<string>>
+    {
+        public string Describe(IComparable<string> value)
+        {
+            return "compare:" + value.CompareTo("cat");
+        }
+    }
+
     internal static class Program
     {
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+        private static object GetStringObject()
+        {
+            return "cat";
+        }
+
+        internal static void RunStringVariance()
+        {
+            Console.WriteLine("-- string argument variance --");
+            // Install String's interface map independently of the variant call.
+            foreach (char ch in (IEnumerable<char>)GetStringObject())
+                Console.Write(ch);
+            Console.WriteLine();
+            IComparable<string> registered = (IComparable<string>)GetStringObject();
+            Console.WriteLine("string direct: " + registered.CompareTo("cat"));
+
+            // Neither implementation is called through IPair<string> or StringPair.
+            IPair<IComparable<string>> pair = new StringPair();
+            Console.WriteLine("string pair: " + pair.First().CompareTo("cat")
+                + "/" + pair.Second().CompareTo("dog"));
+            IContravariant<string> describer = new ComparableDescriber();
+            Console.WriteLine("string contravariant: " + describer.Describe("cat"));
+        }
+
         internal static void Run()
         {
             Console.WriteLine("-- generic variance dispatch --");

--- a/samples/dotnet/ArrayDispatch/InterfaceClosureDispatchSubset.cs
+++ b/samples/dotnet/ArrayDispatch/InterfaceClosureDispatchSubset.cs
@@ -1,0 +1,129 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using GenericVarianceDispatchSubset;
+
+namespace InterfaceClosureDispatchSubset;
+
+internal interface IPair<out T>
+{
+    T First();
+    T Second();
+}
+
+internal interface ILeft<out T> : IPair<T> { }
+internal interface IRight<out T> : IPair<T> { }
+internal interface IDiamond<out T> : ILeft<T>, IRight<T> { }
+
+internal class PairBase<T> : IDiamond<T>
+{
+    private readonly T _value;
+
+    internal PairBase(T value) { _value = value; }
+    public T First()
+    {
+        return _value;
+    }
+
+    public T Second()
+    {
+        return _value;
+    }
+}
+
+internal sealed class Diamond<T> : PairBase<T>
+{
+    internal Diamond(T value) : base(value) { }
+}
+
+internal interface IConsumer<in T>
+{
+    string First(T value);
+    string Second(T value);
+}
+
+internal sealed class AnimalConsumer : IConsumer<Animal>
+{
+    public string First(Animal value)
+    {
+        return "first:" + value.Name;
+    }
+
+    public string Second(Animal value)
+    {
+        return "second:" + value.Name;
+    }
+}
+
+internal class LengthComparer : EqualityComparer<string>
+{
+    public override bool Equals(string? x, string? y)
+    {
+        return x?.Length == y?.Length;
+    }
+
+    public override int GetHashCode(string value)
+    {
+        return value.Length;
+    }
+}
+
+internal sealed class DerivedLengthComparer : LengthComparer { }
+
+internal static class Program
+{
+    internal static void Run()
+    {
+        Console.WriteLine("-- interface closure dispatch --");
+        var diamond = new Diamond<Cat>(new Cat());
+        IPair<Cat> exact = diamond;
+        Console.WriteLine("diamond exact: " + exact.First().Name + "/" + exact.Second().Name);
+
+        // Both slots must survive an exact miss through the same inherited diamond.
+        IPair<Animal> wide = diamond;
+        Console.WriteLine("diamond variant: " + wide.First().Name + "/" + wide.Second().Name);
+        ILeft<Animal> left = diamond;
+        IRight<Animal> right = diamond;
+        Console.WriteLine("diamond parents: " + left.First().Name + "/" + right.Second().Name);
+
+        // The outer argument is a class whose interface closure supplies the inner match.
+        object nested = new Diamond<Diamond<Cat>>(diamond);
+        var nestedWide = (IPair<IPair<Animal>>)nested;
+        Console.WriteLine("diamond nested first: " + nestedWide.First().First().Name
+            + "/" + nestedWide.First().Second().Name);
+        Console.WriteLine("diamond nested second: " + nestedWide.Second().First().Name
+            + "/" + nestedWide.Second().Second().Name);
+        Console.WriteLine("diamond nested reverse: "
+            + ((object)new Diamond<IPair<Animal>>(wide) is IPair<IPair<Cat>>));
+        Console.WriteLine("diamond value invariant: " + ((object)new Diamond<int>(7) is IPair<object>));
+
+        var consumer = new AnimalConsumer();
+        IPair<IConsumer<Cat>> consumers = new Diamond<AnimalConsumer>(consumer);
+        Console.WriteLine("diamond nested consumer: " + consumers.First().First(new Cat())
+            + "/" + consumers.Second().Second(new Cat()));
+
+        // IList<T> is invariant; only the reference-element array fallback serves this.
+        object array = new Diamond<Cat>[] { diamond };
+        var list = (IList<IPair<Animal>>)array;
+        Console.WriteLine("diamond array: " + list.Count + "/" + list[0].First().Name
+            + "/" + list[0].Second().Name);
+        var sequence = (IEnumerable<IPair<Animal>>)array;
+        foreach (var pair in sequence)
+            Console.WriteLine("diamond array enumeration: " + pair.First().Name + "/" + pair.Second().Name);
+
+        // EqualityComparer's intrinsic base acquires its interface at allocation reach.
+        // Exercise the derived closure before and after allocating the concrete base.
+        var derived = new DerivedLengthComparer();
+        IPair<IEqualityComparer<string>> derivedPair = new Diamond<DerivedLengthComparer>(derived);
+        PrintComparer("derived comparer", derivedPair);
+        IPair<IEqualityComparer<string>> basePair = new Diamond<LengthComparer>(new LengthComparer());
+        PrintComparer("base comparer", basePair);
+        PrintComparer("derived comparer again", derivedPair);
+    }
+
+    private static void PrintComparer(string label, IPair<IEqualityComparer<string>> pair)
+    {
+        Console.WriteLine(label + ": " + pair.First().Equals("cat", "dog")
+            + "/" + pair.Second().Equals("cat", "lion") + "/" + pair.Second().GetHashCode("horse"));
+    }
+}

--- a/samples/dotnet/ArrayDispatch/InterfaceClosureDispatchSubset.cs
+++ b/samples/dotnet/ArrayDispatch/InterfaceClosureDispatchSubset.cs
@@ -5,12 +5,6 @@ using GenericVarianceDispatchSubset;
 
 namespace InterfaceClosureDispatchSubset;
 
-internal interface IPair<out T>
-{
-    T First();
-    T Second();
-}
-
 internal interface ILeft<out T> : IPair<T> { }
 internal interface IRight<out T> : IPair<T> { }
 internal interface IDiamond<out T> : ILeft<T>, IRight<T> { }

--- a/samples/dotnet/ArrayDispatch/Program.cs
+++ b/samples/dotnet/ArrayDispatch/Program.cs
@@ -28,6 +28,7 @@ namespace ArrayDispatch
             MultiDimArraySubset.Program.Run();
             ObjectReachedValueDispatchSubset.Program.Run();
             MdInterfaceDispatchSubset.Program.Run();
+            InterfaceClosureDispatchSubset.Program.Run();
         }
     }
 }

--- a/samples/dotnet/ArrayDispatch/Program.cs
+++ b/samples/dotnet/ArrayDispatch/Program.cs
@@ -14,6 +14,7 @@ namespace ArrayDispatch
             CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
             CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
 
+#if !STRING_VARIANCE_ONLY
             ArrayCovarianceSubset.Program.Run();
             ArrayCovariantDispatchSubset.Program.Run();
             ArrayInterfaceDispatchSubset.Program.Run();
@@ -28,6 +29,8 @@ namespace ArrayDispatch
             MultiDimArraySubset.Program.Run();
             ObjectReachedValueDispatchSubset.Program.Run();
             MdInterfaceDispatchSubset.Program.Run();
+#endif
+            GenericVarianceDispatchSubset.Program.RunStringVariance();
         }
     }
 }

--- a/samples/dotnet/SharedGenerics/GenericStaticsSubset.cs
+++ b/samples/dotnet/SharedGenerics/GenericStaticsSubset.cs
@@ -4,6 +4,8 @@
 // static-touching bodies fall back per instantiation by the statics taint rule.
 // Real System.Private.CoreLib (-r), run vs .NET.
 using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
 namespace GenericStaticsSubset;
 
 enum Mode { Off = 0, On = 1 }
@@ -24,8 +26,48 @@ class Counter<T>
     public static string Describe() => Tag + "#" + Created;
 }
 
+class SynchronizedOwner<T>
+{
+    // The IL has no type-dependent operation; only the static monitor prologue
+    // makes this body ineligible for canonical sharing.
+    [MethodImpl(MethodImplOptions.Synchronized | MethodImplOptions.NoInlining)]
+    public static bool StaticProbe(object monitor) => MonitorProbe.CanEnter(monitor);
+
+    [MethodImpl(MethodImplOptions.Synchronized | MethodImplOptions.NoInlining)]
+    public bool InstanceProbe(object monitor) => MonitorProbe.CanEnter(monitor);
+}
+
+static class MonitorProbe
+{
+    public static bool CanEnter(object monitor)
+    {
+        bool entered = false;
+        var thread = new Thread(() =>
+        {
+            entered = Monitor.TryEnter(monitor, 0);
+            if (entered)
+                Monitor.Exit(monitor);
+        });
+        thread.Start();
+        thread.Join();
+        return entered;
+    }
+}
+
 class Program
 {
+    internal static void SynchronizedPrologues()
+    {
+        Console.WriteLine("sync static string own=" + SynchronizedOwner<string>.StaticProbe(typeof(SynchronizedOwner<string>)));
+        Console.WriteLine("sync static object own=" + SynchronizedOwner<object>.StaticProbe(typeof(SynchronizedOwner<object>)));
+        Console.WriteLine("sync static other=" + SynchronizedOwner<string>.StaticProbe(typeof(SynchronizedOwner<object>)));
+        var first = new SynchronizedOwner<string>();
+        var second = new SynchronizedOwner<object>();
+        Console.WriteLine("sync instance string own=" + first.InstanceProbe(first));
+        Console.WriteLine("sync instance object own=" + second.InstanceProbe(second));
+        Console.WriteLine("sync instance other=" + first.InstanceProbe(second));
+    }
+
     internal static void __GateEntry()
     {
         var a = new Counter<Mode>(Mode.On);

--- a/samples/dotnet/SharedGenerics/Program.cs
+++ b/samples/dotnet/SharedGenerics/Program.cs
@@ -38,6 +38,7 @@ namespace SharedGenerics
             MangleKindShadowSubset.Program.__GateEntry();
             GenericMethodSubset.Program.__GateEntry();
             GvmCanonicalSubset.Program.__GateEntry();
+            GenericStaticsSubset.Program.SynchronizedPrologues();
         }
     }
 }

--- a/src/Dn2Cpp.Transpiler/Compilation.Preservation.cs
+++ b/src/Dn2Cpp.Transpiler/Compilation.Preservation.cs
@@ -854,7 +854,8 @@ internal sealed partial class Compilation
 
     private bool ActivateConditionalPreservationPolicies()
     {
-        if (!_preservationSeedingActive) return false;
+        if (!_preservationSeedingActive || _preservePolicies.Count == 0)
+            return false;
         bool activated = false;
         foreach (var cls in Classes.ToList())
             if (!_activatedConditionalPolicies.Contains(cls)

--- a/src/Dn2Cpp.Transpiler/Compilation.Reachability.cs
+++ b/src/Dn2Cpp.Transpiler/Compilation.Reachability.cs
@@ -238,12 +238,12 @@ internal sealed partial class Compilation
             && IEqualityComparerInterfaceFor(eqElem) is { } eqItf)
         {
             if (!c.Interfaces.Contains(eqItf))
+            {
                 c.Interfaces.Add(eqItf);
-            // ImplementsInterface caches c's interface closure, and the used×allocated
-            // cross above already computed and froze it WITHOUT this interface. Drop the
-            // stale cache so ReachVirtualImpl's ImplementsInterface check — and every
-            // later dispatch reacher — sees the interface just added.
-            c.InterfaceClosureCache = null;
+                // A cached closure may inherit c through another type's base chain.
+                // Invalidate both membership and DFS order for every dependent root.
+                _interfaceClosureVersion++;
+            }
             // Record that this element type's IEqualityComparer<T> type-info is now emitted
             // (RenderItfTables lays it down as c's interface). The concrete form AND its
             // canonical alias, so the emit-time dispatch gate resolves for both a concrete
@@ -2476,15 +2476,8 @@ internal sealed partial class Compilation
         // Collect first, reach after: a Reach can complete classes and grow the model,
         // and the closure walk below is over the interface graph, not over Classes.
         List<MethodInfo>? impls = null;
-        var stack = new Stack<ClassInfo>();
-        PushDirectInterfaces(stack, c);
-        var visited = new HashSet<ClassInfo>();
-        while (stack.Count > 0)
+        foreach (var have in GetInterfaceClosure(c).Ordered)
         {
-            var have = stack.Pop();
-            if (!visited.Add(have))
-                continue;
-            PushDirectInterfaces(stack, have);
             if (have == want || !VariantMatches(have, want, mask))
                 continue;
             have.EnsureMembers();   // the interface's declarations ARE its rows
@@ -2569,15 +2562,8 @@ internal sealed partial class Compilation
             return;
         // Collect first, reach after — same discipline as ReachVariantItfImpl.
         List<MethodInfo>? impls = null;
-        var stack = new Stack<ClassInfo>();
-        PushDirectInterfaces(stack, c);
-        var visited = new HashSet<ClassInfo>();
-        while (stack.Count > 0)
+        foreach (var have in GetInterfaceClosure(c).Ordered)
         {
-            var have = stack.Pop();
-            if (!visited.Add(have))
-                continue;
-            PushDirectInterfaces(stack, have);
             if (have == want
                 || have.Module != want.Module || have.Handle != want.Handle
                 || have.Context.TypeArgs.Length != wa.Length)
@@ -2660,15 +2646,8 @@ internal sealed partial class Compilation
             return false;
         if (VariantMatches(fc, tc, vmask))
             return true;
-        var stack = new Stack<ClassInfo>();
-        PushDirectInterfaces(stack, fc);
-        var visited = new HashSet<ClassInfo>();
-        while (stack.Count > 0)
+        foreach (var itf in GetInterfaceClosure(fc).Ordered)
         {
-            var itf = stack.Pop();
-            if (!visited.Add(itf))
-                continue;
-            PushDirectInterfaces(stack, itf);
             if (VariantMatches(itf, tc, vmask))
                 return true;
         }
@@ -2750,37 +2729,34 @@ internal sealed partial class Compilation
         return false;
     }
 
-    private static bool ImplementsInterface(ClassInfo c, ClassInfo itf)
+    private bool ImplementsInterface(ClassInfo c, ClassInfo itf) =>
+        GetInterfaceClosure(c).Members.Contains(itf);
+
+    // Comparer interfaces can be added after shape completion. A compilation-wide
+    // version also invalidates closures that read the changed type as an ancestor.
+    private int _interfaceClosureVersion;
+
+    private InterfaceClosure GetInterfaceClosure(ClassInfo c)
     {
-        // Iterative closure walk with a visited set: the interface graph is a DAG
-        // (IList<T> -> ICollection<T> -> IEnumerable<T> <- IReadOnlyCollection<T>, …),
-        // so a naive recursion re-walks shared parents once per inbound path —
-        // exponential for diamond-rich BCL hierarchies. Each interface node is
-        // expanded at most once here, making the check linear in the closure size.
-        //
-        // The closure is cached per entry class: this is asked per
-        // (allocated type × used interface) pair by the GVM/dispatch reachers, and
-        // an uncached ask re-walks the DAG and allocates a Stack+HashSet. The walk is
-        // pure shape reads (Interfaces/BaseClass — never a member pull), so the
-        // full closure costs what one miss cost; membership probes are O(1) after.
-        // Cached ONLY when every node the walk read was ShapeReady: a
-        // specialization minted mid-scan has empty Interfaces (and no BaseClass)
-        // until its CompleteShape turn, and freezing that immature answer would
-        // change a later ask that the uncached walk answered from the live lists.
-        if (c.InterfaceClosureCache is { } cached)
-            return cached.Contains(itf);
+        // Shape reads only: an unfinished node makes this a temporary snapshot.
+        // First-visit DFS order preserves candidate and reach order independently
+        // of HashSet enumeration, including diamonds and inherited interfaces.
+        if (c.InterfaceClosureCache is { } cached && cached.Version == _interfaceClosureVersion)
+            return cached;
         var stack = new Stack<ClassInfo>();
         bool ready = PushDirectInterfaces(stack, c);
-        var closure = new HashSet<ClassInfo>();
+        var closure = new InterfaceClosure(_interfaceClosureVersion);
         while (stack.Count > 0)
         {
             var i = stack.Pop();
-            if (closure.Add(i))
-                ready &= PushDirectInterfaces(stack, i);
+            if (!closure.Members.Add(i))
+                continue;
+            closure.Ordered.Add(i);
+            ready &= PushDirectInterfaces(stack, i);
         }
         if (ready)
             c.InterfaceClosureCache = closure;
-        return closure.Contains(itf);
+        return closure;
     }
 
     /// <summary>Pushes every interface directly implemented by <paramref name="x"/>

--- a/src/Dn2Cpp.Transpiler/Compilation.Reachability.cs
+++ b/src/Dn2Cpp.Transpiler/Compilation.Reachability.cs
@@ -2645,8 +2645,11 @@ internal sealed partial class Compilation
             return false;
         if (to.IsObject)
             return true;
-        if (from is not { Kind: TypeKind.Class, Class: { } fc }
-            || to is not { Kind: TypeKind.Class, Class: { } tc })
+        // String signatures use a primitive descriptor; its interfaces live on the
+        // CoreLib class just like those of other reference types.
+        var fc = from.IsString ? FindClassByFullName("System.String") : from.Class;
+        var tc = to.IsString ? FindClassByFullName("System.String") : to.Class;
+        if (fc is null || tc is null)
             return false;
         if (DerivesFromOrIs(fc, tc) || ImplementsInterface(fc, tc))
             return true;

--- a/src/Dn2Cpp.Transpiler/Compilation.Rgctx.cs
+++ b/src/Dn2Cpp.Transpiler/Compilation.Rgctx.cs
@@ -131,7 +131,7 @@ internal sealed partial class Compilation
             // over wrong-sharing.
             counterpart.EnsureSignature();
         }
-        catch (NotSupportedException)
+        catch (NotSupportedException ex) when (!IsMustEscape(ex))
         {
             return;
         }

--- a/src/Dn2Cpp.Transpiler/MethodCompiler.cs
+++ b/src/Dn2Cpp.Transpiler/MethodCompiler.cs
@@ -850,12 +850,49 @@ internal sealed partial class MethodCompiler : IEvalStack
             TranslateWithPendingReferenceBarriers(insn);
         }
 
+        return FinishBody();
+    }
+
+    private string FinishBody()
+    {
+        // Signature rendering can resolve lazy model state and reject unsupported types.
+        // Keep it, prologue taint and rgctx validation in both compile passes.
+        string signature = Signature(_method);
+        string? synchronizedTypeInfo = null;
+        if (_method.IsSynchronized && _method.IsStatic)
+        {
+            // A canonical owner has no type-info: each real instantiation must lock
+            // its own interned Type object, even when the IL never mentions T.
+            TaintIfCanonical(_method.DeclaringClass, "synchronized");
+            synchronizedTypeInfo = _method.DeclaringClass.CppTypeInfoName;
+        }
+        string? rgctxAnchor = null;
+        if (_usedRgctx && !_method.RgctxParam && SharedDirectCallees is null)
+        {
+            if (!_method.RgctxUses)
+                throw new InvalidOperationException(
+                    $"{_method.DeclaringClass.FullName}.{_method.Name}: body uses rgctx but the "
+                    + "planning pass did not record it");
+            rgctxAnchor = _c.RgctxAnchorSym(_method.DeclaringClass)
+                ?? throw new InvalidOperationException(
+                    $"{_method.DeclaringClass.FullName}.{_method.Name}: rgctx use with no anchor "
+                    + "and no hidden parameter");
+        }
+
+        // Planning keeps lowering's effects, but has no consumer for a finished function.
+        if (_c.Phase == EmitPhase.Planning)
+            return "";
+        return RenderBody(signature, synchronizedTypeInfo, rgctxAnchor);
+    }
+
+    private string RenderBody(string signature, string? synchronizedTypeInfo, string? rgctxAnchor)
+    {
         var sb = new StringBuilder();
         sb.AppendLine($"// {_method.DeclaringClass.FullName}::{_method.Name}");
         // External linkage (no `static`): the body may live in a different translation unit
         // than its callers once the output is split across files; the header carries the
         // forward declaration. Unused external functions don't warn, so no [[maybe_unused]].
-        sb.AppendLine($"{Signature(_method)}");
+        sb.AppendLine(signature);
         sb.AppendLine("{");
         // An [UnmanagedCallersOnly] method can be invoked from a thread the
         // collector has never seen (a native host's own thread pool); the prologue
@@ -868,7 +905,7 @@ internal sealed partial class MethodCompiler : IEvalStack
         // it — the frame brackets the whole body on every return path and on unwind.
         // The name is a raw C string literal, NOT a LiteralPool str_N entry: the pool
         // is numbered during the planning pass, and pooling the name would perturb
-        // that numbering. Emitted identically in both passes (no pass branch).
+        // that numbering.
         if (_c.ShadowStackEnabled)
             sb.AppendLine($"    Dn2CppShadowFrame __shadowFrame(\"{ShadowFrameName()}\");");
         // [MethodImpl(MethodImplOptions.Synchronized)]: the whole body runs under
@@ -883,11 +920,8 @@ internal sealed partial class MethodCompiler : IEvalStack
         {
             if (_method.IsStatic)
             {
-                // A canonical shared body has no ti_ of its own; taint so each
-                // real instantiation compiles its own body locking its own type.
-                TaintIfCanonical(_method.DeclaringClass, "synchronized");
                 sb.AppendLine("    Dn2CppMonitorGuard __syncGuard((Dn2CppObject*)"
-                    + $"dn2cpp_get_type_from_handle(&{_method.DeclaringClass.CppTypeInfoName}));");
+                    + $"dn2cpp_get_type_from_handle(&{synchronizedTypeInfo}));");
             }
             else
             {
@@ -899,18 +933,10 @@ internal sealed partial class MethodCompiler : IEvalStack
         // type at this class's declaring level. Emitted only when a slot was
         // actually used (the lazy prologue), and only in the emission pass
         // (planning text is discarded, and its flags are not final yet).
-        if (_usedRgctx && !_method.RgctxParam && SharedDirectCallees is null)
+        if (rgctxAnchor is not null)
         {
-            if (!_method.RgctxUses)
-                throw new InvalidOperationException(
-                    $"{_method.DeclaringClass.FullName}.{_method.Name}: body uses rgctx but the "
-                    + "planning pass did not record it");
-            string anchor = _c.RgctxAnchorSym(_method.DeclaringClass)
-                ?? throw new InvalidOperationException(
-                    $"{_method.DeclaringClass.FullName}.{_method.Name}: rgctx use with no anchor "
-                    + "and no hidden parameter");
             sb.AppendLine("    const void* const* __rgctx = "
-                + $"dn2cpp_rgctx(((const Dn2CppObject*)a0)->type, &{anchor});");
+                + $"dn2cpp_rgctx(((const Dn2CppObject*)a0)->type, &{rgctxAnchor});");
         }
         // [HotPath(NoAlias)] span parameters: the element pointer hoisted once,
         // qualified. Only the entries an indexer route actually addressed are

--- a/src/Dn2Cpp.Transpiler/MethodCompiler.cs
+++ b/src/Dn2Cpp.Transpiler/MethodCompiler.cs
@@ -1053,7 +1053,7 @@ internal sealed partial class MethodCompiler : IEvalStack
             if (!lower())
                 return null;
         }
-        catch (NotSupportedException)
+        catch (NotSupportedException ex) when (!Compilation.IsMustEscape(ex))
         {
             return null; // a shape the lowering does not model stays bodyless
         }

--- a/src/Dn2Cpp.Transpiler/Model.cs
+++ b/src/Dn2Cpp.Transpiler/Model.cs
@@ -849,6 +849,18 @@ internal sealed record PInvokeInfo(
     }
 }
 
+internal sealed class InterfaceClosure
+{
+    public readonly HashSet<ClassInfo> Members = new();
+    public readonly List<ClassInfo> Ordered = new();
+    public readonly int Version;
+
+    public InterfaceClosure(int version)
+    {
+        Version = version;
+    }
+}
+
 internal sealed class ClassInfo
 {
     public required string Namespace;
@@ -1007,16 +1019,11 @@ internal sealed class ClassInfo
     public GenericContext Context = GenericContext.Empty; // for closed specializations
     public List<ClassInfo> Interfaces = new(); // directly implemented interfaces
 
-    /// <summary>Cached transitive interface closure — every interface this class (or a
-    /// class/interface on any base chain the walk crosses) implements, directly or
-    /// through interface inheritance. Interfaces are shape: populated at load
-    /// (non-generic) or <c>CompleteShape</c> (specializations) and immutable after, so
-    /// the closure is final once every node the walk visited was
-    /// <see cref="ShapeReady"/> — Compilation.ImplementsInterface only stores it then,
-    /// and a walk that crossed a not-yet-completed specialization stays uncached so a
-    /// later ask re-reads the live lists exactly as the uncached walk always did.
-    /// Membership-only (never enumerated), so set order cannot reach the output.</summary>
-    internal HashSet<ClassInfo>? InterfaceClosureCache;
+    /// <summary>Membership and first-visit DFS order, cached only when every interface
+    /// and base-chain node read was <see cref="ShapeReady"/>. Later interface additions
+    /// invalidate the compilation's closure version, including dependent roots.
+    /// Published closures are never mutated; an active enumeration keeps its snapshot.</summary>
+    internal InterfaceClosure? InterfaceClosureCache;
     // Interfaces implemented by CLR FullName but not modeled as a loaded
     // ClassInfo — the assembly declaring them was not referenced at transpile
     // (e.g. a hot-update patch that implements a base-image interface without


### PR DESCRIPTION
## 内容

- #113、#115、#114、#117 を `main` を基準に統合します。
- #117 の競合では、interface closure dispatch と string argument variance の両方の回帰テスト呼び出しを保持しました。
- 統合後の出力順を確認するため、ArrayDispatch ゲートは両セクションが連続して末尾に現れることを検証します。

## 検証

- `dotnet build src/Dn2Cpp.Cli -c Release --no-restore -v:minimal`
- `./gates/build-and-run-array-dispatch.sh`

## マージ方法

`Create a merge commit` を使用してください。元の4PRのHEADコミットを祖先として保持するため、統合後に各PRが間接的にマージ済みになります。
